### PR TITLE
fix(action): lint workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Lint
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/zncdatadev/operator-go/security/code-scanning/5](https://github.com/zncdatadev/operator-go/security/code-scanning/5)

To fix this problem, add an explicit `permissions` setting to the workflow. Linting jobs almost always only need to read repository contents, so the minimal permissions recommended are:
```yaml
permissions:
  contents: read
```
This can be set at the root level of the workflow to apply to all jobs (preferred, unless you want to customize jobs). No files outside `.github/workflows/lint.yml` need to be changed. Simply insert the `permissions` block after the `name:` line and before the first key at the root (generally after `name:` but before `on:`).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
