### PR TITLE
fix(action): test workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   go-test:
     name: Go Test
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/zncdatadev/operator-go/security/code-scanning/1](https://github.com/zncdatadev/operator-go/security/code-scanning/1)

The best fix is to add a `permissions` block restricting access to the minimal required scopes for the job. Given the steps (checkout, setup, run tests), only read access to contents is necessary—no write access is needed. This can be done by adding a `permissions:` section with `contents: read` under either the workflow root (applies to all jobs unless overridden) or directly under the `go-test` job for local scoping; since only one job is defined, either is fine. Insert this block above the `jobs:` key or under the specific job. To match the CodeQL suggestion, we should set it at the job level for clarity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
