### PR TITLE
fix: exclude examples from controller-gen paths to avoid sub-module go.mod check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,5 +33,4 @@ jobs:
         env:
           ENVTEST_K8S_VERSION: ${{ matrix.k8s-version }}
         run: |
-          go mod tidy
           make test

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ help: ## Display this help.
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.
-	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."
+	$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./pkg/..."
 
 .PHONY: fmt
 fmt: ## Run go fmt against code.


### PR DESCRIPTION
## Problem

When the root `go.mod` is modified (e.g., upgrading a dependency), running `make test` fails because the `generate` target uses `paths="./..."` which recursively scans `examples/trino-operator/`. Since that directory is an **independent Go module**, Go's toolchain detects the mismatch and errors with:

```
go: updates to go.mod needed; to update it:
        go mod tidy
```

## Fix

Change the `controller-gen` paths from `./...` to `./pkg/...` so code generation only scans the root module's packages and never touches the `examples/` sub-module.

```makefile
# Before
$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./..."

# After
$(CONTROLLER_GEN) object:headerFile="hack/boilerplate.go.txt" paths="./pkg/..."
```