### PR TITLE
fix(reconciler): use prototype instead of nil zero value in fetchCR

### DIFF
--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -256,8 +256,10 @@ func (r *GenericReconciler[CR]) Reconcile(ctx context.Context, req ctrl.Request)
 // fetchCR fetches the cluster resource by name.
 func (r *GenericReconciler[CR]) fetchCR(ctx context.Context, key types.NamespacedName) (CR, error) {
 	var zero CR
-	// Create a new instance of the CR type by deep copying the prototype
-	cr := zero.DeepCopyCluster().(CR)
+	// Create a new instance of the CR type by deep copying the prototype.
+	// Using r.prototype instead of a zero value prevents a nil pointer panic
+	// when CR is a pointer type (e.g. *TrinoCluster), where var zero CR yields nil.
+	cr := r.prototype.DeepCopyCluster().(CR)
 
 	// Get the client.Object for the fetch
 	obj := r.getAsClientObject(cr)


### PR DESCRIPTION
## Problem

When `CR` is a pointer type (e.g. `*TrinoCluster`), `var zero CR` yields `nil`. Calling `zero.DeepCopyCluster()` on a nil pointer panics at runtime. The panic is caught by the `recover()` in `Reconcile`, but this causes the entire reconcile loop to silently fail with no useful error.

## Fix

Use `r.prototype.DeepCopyCluster().(CR)` instead. `r.prototype` is always non-nil as it is validated at `GenericReconciler` construction time.

```go
// Before
cr := zero.DeepCopyCluster().(CR)

// After
cr := r.prototype.DeepCopyCluster().(CR)
```