### PR TITLE
fix(reconciler): remove GetContainerImage/Ports/ServicePorts from RoleGroupHandler interface

### DIFF
--- a/examples/trino-operator/internal/controller/trino_handler.go
+++ b/examples/trino-operator/internal/controller/trino_handler.go
@@ -21,11 +21,8 @@ import (
 	"fmt"
 
 	trinov1alpha1 "github.com/zncdatadev/operator-go/examples/trino-operator/api/v1alpha1"
-	"github.com/zncdatadev/operator-go/examples/trino-operator/internal/constants"
 	"github.com/zncdatadev/operator-go/examples/trino-operator/internal/handlers"
 	"github.com/zncdatadev/operator-go/pkg/reconciler"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -35,31 +32,19 @@ const (
 	RoleWorkers      = "workers"
 )
 
-// TrinoRoleGroupHandler implements the operator-go RoleGroupHandler interface
-// This is the key to using operator-go SDK: delegate product-specific resource building logic through this interface.
-//
-// Note: GetContainerImage, GetContainerPorts, and GetServicePorts are required by the RoleGroupHandler
-// interface because BaseRoleGroupHandler uses them internally when building StatefulSets and Services.
-// This handler builds resources directly in CoordinatorsHandler/WorkersHandler without delegating to
-// BaseRoleGroupHandler, so those methods are not invoked by the SDK reconciliation loop here.
-// They are retained for interface compliance and would be used if this handler were refactored to
-// extend BaseRoleGroupHandler.
+// TrinoRoleGroupHandler implements the operator-go RoleGroupHandler interface.
+// It routes BuildResources calls to role-specific handlers (CoordinatorsHandler / WorkersHandler)
+// which build all Kubernetes resources directly using the SDK builder utilities.
 type TrinoRoleGroupHandler struct {
 	coordinatorsHandler *handlers.CoordinatorsHandler
 	workersHandler      *handlers.WorkersHandler
-	defaultImage        string
 }
 
-// NewTrinoRoleGroupHandler creates a new Handler.
-// defaultImage is returned by GetContainerImage and should match the CRD default
-// (i.e. constants.DefaultImage). At runtime the actual image comes from cr.Spec.Image
-// which is applied directly inside BuildStatefulSet, so this value acts as a
-// consistent fallback for any caller that queries the handler before reconciling.
-func NewTrinoRoleGroupHandler(defaultImage string) *TrinoRoleGroupHandler {
+// NewTrinoRoleGroupHandler creates a new Handler
+func NewTrinoRoleGroupHandler() *TrinoRoleGroupHandler {
 	return &TrinoRoleGroupHandler{
 		coordinatorsHandler: handlers.NewCoordinatorsHandler(),
 		workersHandler:      handlers.NewWorkersHandler(),
-		defaultImage:        defaultImage,
 	}
 }
 
@@ -79,42 +64,6 @@ func (h *TrinoRoleGroupHandler) BuildResources(
 		return h.workersHandler.BuildResources(ctx, k8sClient, cr, buildCtx)
 	default:
 		return nil, fmt.Errorf("unknown role: %s", buildCtx.RoleName)
-	}
-}
-
-// GetContainerImage returns the default container image for the given role.
-// The actual image used at runtime is taken from cr.Spec.Image inside BuildResources;
-// this method provides a consistent fallback for callers such as BaseRoleGroupHandler.
-func (h *TrinoRoleGroupHandler) GetContainerImage(roleName string) string {
-	return h.defaultImage
-}
-
-// GetContainerPorts returns the container ports
-func (h *TrinoRoleGroupHandler) GetContainerPorts(roleName, roleGroupName string) []corev1.ContainerPort {
-	switch roleName {
-	case RoleCoordinators, RoleWorkers:
-		return []corev1.ContainerPort{
-			{Name: "http", ContainerPort: constants.DefaultHTTPPort, Protocol: corev1.ProtocolTCP},
-		}
-	default:
-		return nil
-	}
-}
-
-// GetServicePorts returns the Service ports
-func (h *TrinoRoleGroupHandler) GetServicePorts(roleName, roleGroupName string) []corev1.ServicePort {
-	switch roleName {
-	case RoleCoordinators, RoleWorkers:
-		return []corev1.ServicePort{
-			{
-				Name:       "http",
-				Port:       constants.DefaultHTTPPort,
-				TargetPort: intstr.FromInt(int(constants.DefaultHTTPPort)),
-				Protocol:   corev1.ProtocolTCP,
-			},
-		}
-	default:
-		return nil
 	}
 }
 

--- a/examples/trino-operator/internal/controller/trino_handler_test.go
+++ b/examples/trino-operator/internal/controller/trino_handler_test.go
@@ -23,9 +23,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-
 	trinov1alpha1 "github.com/zncdatadev/operator-go/examples/trino-operator/api/v1alpha1"
 	"github.com/zncdatadev/operator-go/examples/trino-operator/internal/constants"
 	commonsv1alpha1 "github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
@@ -39,22 +36,21 @@ var _ = Describe("TrinoRoleGroupHandler", func() {
 	)
 
 	BeforeEach(func() {
-		handler = NewTrinoRoleGroupHandler(constants.DefaultImage)
+		handler = NewTrinoRoleGroupHandler()
 		ctx = context.Background()
 	})
 
 	Describe("NewTrinoRoleGroupHandler", func() {
 		It("should create a new handler successfully", func() {
-			handler := NewTrinoRoleGroupHandler(constants.DefaultImage)
+			handler := NewTrinoRoleGroupHandler()
 			Expect(handler).NotTo(BeNil())
 			Expect(handler.coordinatorsHandler).NotTo(BeNil())
 			Expect(handler.workersHandler).NotTo(BeNil())
-			Expect(handler.defaultImage).To(Equal(constants.DefaultImage))
 		})
 
 		It("should return a new instance each time", func() {
-			handler1 := NewTrinoRoleGroupHandler(constants.DefaultImage)
-			handler2 := NewTrinoRoleGroupHandler(constants.DefaultImage)
+			handler1 := NewTrinoRoleGroupHandler()
+			handler2 := NewTrinoRoleGroupHandler()
 			Expect(handler1).NotTo(BeIdenticalTo(handler2))
 		})
 	})
@@ -168,123 +164,11 @@ var _ = Describe("TrinoRoleGroupHandler", func() {
 		)
 	})
 
-	Describe("GetContainerImage", func() {
-		DescribeTable("should return the injected default image for any role",
-			func(roleName string) {
-				image := handler.GetContainerImage(roleName)
-				Expect(image).To(Equal(constants.DefaultImage))
-			},
-			Entry("coordinators role", RoleCoordinators),
-			Entry("workers role", RoleWorkers),
-			Entry("empty role", ""),
-			Entry("unknown role", "unknown"),
-			Entry("random role", "random-role"),
-		)
-
-		It("should return the expected image constant", func() {
-			image := handler.GetContainerImage(RoleCoordinators)
-			Expect(image).To(Equal(constants.DefaultImage))
-		})
-	})
-
-	Describe("GetContainerPorts", func() {
-		DescribeTable("should return correct ports for known roles",
-			func(roleName string, expectedLen int, expectNil bool) {
-				ports := handler.GetContainerPorts(roleName, "default")
-
-				if expectNil {
-					Expect(ports).To(BeNil())
-				} else {
-					Expect(ports).NotTo(BeNil())
-					Expect(ports).To(HaveLen(expectedLen))
-					Expect(ports[0].Name).To(Equal("http"))
-					Expect(ports[0].ContainerPort).To(Equal(constants.DefaultHTTPPort))
-					Expect(ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
-				}
-			},
-			Entry("coordinators role", RoleCoordinators, 1, false),
-			Entry("workers role", RoleWorkers, 1, false),
-			Entry("unknown role returns nil", "unknown", 0, true),
-			Entry("empty role returns nil", "", 0, true),
-		)
-
-		It("should return port 8080 for coordinators", func() {
-			ports := handler.GetContainerPorts(RoleCoordinators, "default")
-			Expect(ports).To(HaveLen(1))
-			Expect(ports[0].ContainerPort).To(Equal(int32(8080)))
-		})
-
-		It("should return port 8080 for workers", func() {
-			ports := handler.GetContainerPorts(RoleWorkers, "default")
-			Expect(ports).To(HaveLen(1))
-			Expect(ports[0].ContainerPort).To(Equal(int32(8080)))
-		})
-
-		It("should return the same ports for coordinators and workers", func() {
-			coordinatorPorts := handler.GetContainerPorts(RoleCoordinators, "default")
-			workerPorts := handler.GetContainerPorts(RoleWorkers, "default")
-
-			Expect(coordinatorPorts).To(HaveLen(len(workerPorts)))
-			Expect(coordinatorPorts[0].ContainerPort).To(Equal(workerPorts[0].ContainerPort))
-			Expect(coordinatorPorts[0].Name).To(Equal(workerPorts[0].Name))
-		})
-	})
-
-	Describe("GetServicePorts", func() {
-		DescribeTable("should return correct service ports for known roles",
-			func(roleName string, expectedLen int, expectNil bool) {
-				ports := handler.GetServicePorts(roleName, "default")
-
-				if expectNil {
-					Expect(ports).To(BeNil())
-				} else {
-					Expect(ports).NotTo(BeNil())
-					Expect(ports).To(HaveLen(expectedLen))
-					Expect(ports[0].Name).To(Equal("http"))
-					Expect(ports[0].Port).To(Equal(constants.DefaultHTTPPort))
-					Expect(ports[0].Protocol).To(Equal(corev1.ProtocolTCP))
-					Expect(ports[0].TargetPort).To(Equal(intstr.FromInt(int(constants.DefaultHTTPPort))))
-				}
-			},
-			Entry("coordinators role", RoleCoordinators, 1, false),
-			Entry("workers role", RoleWorkers, 1, false),
-			Entry("unknown role returns nil", "unknown", 0, true),
-			Entry("empty role returns nil", "", 0, true),
-		)
-
-		It("should return port 8080 for coordinators", func() {
-			ports := handler.GetServicePorts(RoleCoordinators, "default")
-			Expect(ports).To(HaveLen(1))
-			Expect(ports[0].Port).To(Equal(int32(8080)))
-		})
-
-		It("should return port 8080 for workers", func() {
-			ports := handler.GetServicePorts(RoleWorkers, "default")
-			Expect(ports).To(HaveLen(1))
-			Expect(ports[0].Port).To(Equal(int32(8080)))
-		})
-
-		It("should have correct TargetPort using intstr", func() {
-			ports := handler.GetServicePorts(RoleCoordinators, "default")
-			Expect(ports).To(HaveLen(1))
-			Expect(ports[0].TargetPort).To(Equal(intstr.FromInt(8080)))
-		})
-
-		It("should return the same service ports for coordinators and workers", func() {
-			coordinatorPorts := handler.GetServicePorts(RoleCoordinators, "default")
-			workerPorts := handler.GetServicePorts(RoleWorkers, "default")
-
-			Expect(coordinatorPorts).To(HaveLen(len(workerPorts)))
-			Expect(coordinatorPorts[0].Port).To(Equal(workerPorts[0].Port))
-			Expect(coordinatorPorts[0].Name).To(Equal(workerPorts[0].Name))
-			Expect(coordinatorPorts[0].TargetPort).To(Equal(workerPorts[0].TargetPort))
-		})
-	})
 })
 
 var _ = Describe("TrinoRoleGroupHandler Interface Compliance", func() {
 	It("should implement the RoleGroupHandler interface", func() {
-		handler := NewTrinoRoleGroupHandler(constants.DefaultImage)
+		handler := NewTrinoRoleGroupHandler()
 
 		// This test verifies compile-time interface compliance
 		// If the handler doesn't implement the interface, this won't compile
@@ -313,7 +197,7 @@ var _ = Describe("TrinoRoleGroupHandler Error Handling", func() {
 	)
 
 	BeforeEach(func() {
-		handler = NewTrinoRoleGroupHandler(constants.DefaultImage)
+		handler = NewTrinoRoleGroupHandler()
 		buildCtx = &reconciler.RoleGroupBuildContext{
 			ClusterName:      "test-trino",
 			ClusterNamespace: "default",

--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -128,9 +128,9 @@ func (h *BaseRoleGroupHandler[CR]) BuildResources(
 	resources.HeadlessService = headlessSvc
 
 	// Build Service (if ports are defined)
-	servicePorts := h.GetServicePorts(buildCtx.RoleName, buildCtx.RoleGroupName)
-	if len(servicePorts) > 0 {
-		resources.Service = h.buildService(buildCtx, labels, servicePorts)
+	svcPorts := h.servicePorts(buildCtx.RoleName, buildCtx.RoleGroupName)
+	if len(svcPorts) > 0 {
+		resources.Service = h.buildService(buildCtx, labels, svcPorts)
 	}
 
 	// Build StatefulSet
@@ -154,24 +154,24 @@ func (h *BaseRoleGroupHandler[CR]) BuildResources(
 	return resources, nil
 }
 
-// GetContainerImage returns the container image for a role.
-func (h *BaseRoleGroupHandler[CR]) GetContainerImage(roleName string) string {
+// containerImage returns the container image for a role.
+func (h *BaseRoleGroupHandler[CR]) containerImage(roleName string) string {
 	if image, ok := h.RoleImages[roleName]; ok {
 		return image
 	}
 	return h.Image
 }
 
-// GetContainerPorts returns the container ports for a role group.
-func (h *BaseRoleGroupHandler[CR]) GetContainerPorts(roleName, _ string) []corev1.ContainerPort {
+// containerPorts returns the container ports for a role group.
+func (h *BaseRoleGroupHandler[CR]) containerPorts(roleName, _ string) []corev1.ContainerPort {
 	if ports, ok := h.RoleContainerPorts[roleName]; ok {
 		return ports
 	}
 	return nil
 }
 
-// GetServicePorts returns the service ports for a role group.
-func (h *BaseRoleGroupHandler[CR]) GetServicePorts(roleName, _ string) []corev1.ServicePort {
+// servicePorts returns the service ports for a role group.
+func (h *BaseRoleGroupHandler[CR]) servicePorts(roleName, _ string) []corev1.ServicePort {
 	if ports, ok := h.RoleServicePorts[roleName]; ok {
 		return ports
 	}
@@ -269,7 +269,7 @@ func (h *BaseRoleGroupHandler[CR]) buildHeadlessService(buildCtx *RoleGroupBuild
 		Spec: corev1.ServiceSpec{
 			ClusterIP: corev1.ClusterIPNone,
 			Selector:  labels,
-			Ports:     h.GetServicePorts(buildCtx.RoleName, buildCtx.RoleGroupName),
+			Ports:     h.servicePorts(buildCtx.RoleName, buildCtx.RoleGroupName),
 		},
 	}
 }
@@ -305,9 +305,9 @@ func (h *BaseRoleGroupHandler[CR]) buildStatefulSet(
 	stsBuilder.WithLabels(labels).
 		WithAnnotations(h.buildAnnotations(buildCtx)).
 		WithReplicas(buildCtx.RoleGroupSpec.GetReplicas()).
-		WithImage(h.GetContainerImage(buildCtx.RoleName), h.ImagePullPolicy).
+		WithImage(h.containerImage(buildCtx.RoleName), h.ImagePullPolicy).
 		WithConfig(buildCtx.MergedConfig).
-		WithPorts(h.GetContainerPorts(buildCtx.RoleName, buildCtx.RoleGroupName))
+		WithPorts(h.containerPorts(buildCtx.RoleName, buildCtx.RoleGroupName))
 
 	// Set resources if configured
 	roleGroupConfig := buildCtx.RoleGroupSpec.GetConfig()
@@ -429,4 +429,4 @@ func (h *BaseRoleGroupHandler[CR]) FetchSecret(ctx context.Context, k8sClient cl
 }
 
 // Verify that BaseRoleGroupHandler implements RoleGroupHandler.
-var _ RoleGroupHandler[common.ClusterInterface] = &BaseRoleGroupHandler[common.ClusterInterface]{}
+var _ RoleGroupHandler[common.ClusterInterface] = (*BaseRoleGroupHandler[common.ClusterInterface])(nil)

--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -429,4 +429,4 @@ func (h *BaseRoleGroupHandler[CR]) FetchSecret(ctx context.Context, k8sClient cl
 }
 
 // Verify that BaseRoleGroupHandler implements RoleGroupHandler.
-var _ RoleGroupHandler[common.ClusterInterface] = (*BaseRoleGroupHandler[common.ClusterInterface])(nil)
+var _ RoleGroupHandler[common.ClusterInterface] = &BaseRoleGroupHandler[common.ClusterInterface]{}

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -87,57 +87,6 @@ var _ = Describe("BaseRoleGroupHandler", func() {
 		})
 	})
 
-	Describe("GetContainerImage", func() {
-		It("should return default image when role not in RoleImages", func() {
-			image := handler.GetContainerImage("unknown-role")
-			Expect(image).To(Equal("test-image:latest"))
-		})
-
-		It("should return role-specific image when set", func() {
-			handler.SetRoleImage("namenode", "hadoop-namenode:v1")
-			image := handler.GetContainerImage("namenode")
-			Expect(image).To(Equal("hadoop-namenode:v1"))
-		})
-
-		It("should return default image for other roles after setting one", func() {
-			handler.SetRoleImage("namenode", "hadoop-namenode:v1")
-			image := handler.GetContainerImage("datanode")
-			Expect(image).To(Equal("test-image:latest"))
-		})
-	})
-
-	Describe("GetContainerPorts", func() {
-		It("should return nil when role not in RoleContainerPorts", func() {
-			ports := handler.GetContainerPorts("unknown-role", "default")
-			Expect(ports).To(BeNil())
-		})
-
-		It("should return ports when set", func() {
-			expectedPorts := []corev1.ContainerPort{
-				{Name: "http", ContainerPort: 8080},
-			}
-			handler.SetRoleContainerPorts("web", expectedPorts)
-			ports := handler.GetContainerPorts("web", "default")
-			Expect(ports).To(Equal(expectedPorts))
-		})
-	})
-
-	Describe("GetServicePorts", func() {
-		It("should return nil when role not in RoleServicePorts", func() {
-			ports := handler.GetServicePorts("unknown-role", "default")
-			Expect(ports).To(BeNil())
-		})
-
-		It("should return ports when set", func() {
-			expectedPorts := []corev1.ServicePort{
-				{Name: "http", Port: 80, TargetPort: intstr.FromInt(8080)},
-			}
-			handler.SetRoleServicePorts("web", expectedPorts)
-			ports := handler.GetServicePorts("web", "default")
-			Expect(ports).To(Equal(expectedPorts))
-		})
-	})
-
 	Describe("SetRoleImage", func() {
 		It("should set image for a role", func() {
 			handler.SetRoleImage("test-role", "custom-image:v2")
@@ -415,56 +364,6 @@ var _ = Describe("RoleGroupHandlerFuncs", func() {
 
 			_, _ = funcs.BuildResources(context.Background(), nil, nil, nil)
 			Expect(called).To(BeTrue())
-		})
-	})
-
-	Describe("GetContainerImage", func() {
-		It("should return empty string when function is nil", func() {
-			image := funcs.GetContainerImage("test-role")
-			Expect(image).To(BeEmpty())
-		})
-
-		It("should call the function when set", func() {
-			funcs.GetContainerImageFunc = func(roleName string) string {
-				return "custom-image:v1"
-			}
-
-			image := funcs.GetContainerImage("test-role")
-			Expect(image).To(Equal("custom-image:v1"))
-		})
-	})
-
-	Describe("GetContainerPorts", func() {
-		It("should return nil when function is nil", func() {
-			ports := funcs.GetContainerPorts("test-role", "default")
-			Expect(ports).To(BeNil())
-		})
-
-		It("should call the function when set", func() {
-			expectedPorts := []corev1.ContainerPort{{Name: "http", ContainerPort: 8080}}
-			funcs.GetContainerPortsFunc = func(roleName, roleGroupName string) []corev1.ContainerPort {
-				return expectedPorts
-			}
-
-			ports := funcs.GetContainerPorts("test-role", "default")
-			Expect(ports).To(Equal(expectedPorts))
-		})
-	})
-
-	Describe("GetServicePorts", func() {
-		It("should return nil when function is nil", func() {
-			ports := funcs.GetServicePorts("test-role", "default")
-			Expect(ports).To(BeNil())
-		})
-
-		It("should call the function when set", func() {
-			expectedPorts := []corev1.ServicePort{{Name: "http", Port: 80}}
-			funcs.GetServicePortsFunc = func(roleName, roleGroupName string) []corev1.ServicePort {
-				return expectedPorts
-			}
-
-			ports := funcs.GetServicePorts("test-role", "default")
-			Expect(ports).To(Equal(expectedPorts))
 		})
 	})
 

--- a/pkg/reconciler/generic_reconciler_test.go
+++ b/pkg/reconciler/generic_reconciler_test.go
@@ -492,27 +492,6 @@ func (a *handlerAdapter) BuildResources(ctx context.Context, k8sClient client.Cl
 	return a.handler.BuildResources(ctx, k8sClient, cr, buildCtx)
 }
 
-// GetContainerImage implements reconciler.RoleGroupHandler
-func (a *handlerAdapter) GetContainerImage(roleName string) string {
-	return a.handler.Image
-}
-
-// GetContainerPorts implements reconciler.RoleGroupHandler
-func (a *handlerAdapter) GetContainerPorts(roleName, roleGroupName string) []corev1.ContainerPort {
-	if ports, ok := a.handler.ContainerPorts[roleName]; ok {
-		return ports
-	}
-	return nil
-}
-
-// GetServicePorts implements reconciler.RoleGroupHandler
-func (a *handlerAdapter) GetServicePorts(roleName, roleGroupName string) []corev1.ServicePort {
-	if ports, ok := a.handler.ServicePorts[roleName]; ok {
-		return ports
-	}
-	return nil
-}
-
 // Verify interface implementations
 var _ common.ClusterInterface = &testutil.ClusterWrapper{}
 var _ reconciler.RoleGroupHandler[*testutil.ClusterWrapper] = &handlerAdapter{}

--- a/pkg/reconciler/role_group_handler.go
+++ b/pkg/reconciler/role_group_handler.go
@@ -86,6 +86,10 @@ type RoleGroupBuildContext struct {
 //
 // The GenericReconciler handles the "when" and "how to apply" resources,
 // while the RoleGroupHandler handles the "what" - the product-specific resource definitions.
+//
+// Implementations can embed BaseRoleGroupHandler to get default behaviour for
+// common resources (ConfigMap, Services, StatefulSet, PDB). Override BuildResources
+// or individual build steps as needed for product-specific logic.
 type RoleGroupHandler[CR common.ClusterInterface] interface {
 	// BuildResources builds all Kubernetes resources for a role group.
 	// The GenericReconciler will apply these resources in the correct order.
@@ -99,18 +103,6 @@ type RoleGroupHandler[CR common.ClusterInterface] interface {
 	//
 	// Returns RoleGroupResources containing all built resources, or an error.
 	BuildResources(ctx context.Context, k8sClient client.Client, cr CR, buildCtx *RoleGroupBuildContext) (*RoleGroupResources, error)
-
-	// GetContainerImage returns the container image for a given role.
-	// This allows different roles to use different images.
-	GetContainerImage(roleName string) string
-
-	// GetContainerPorts returns the container ports for a role group.
-	// These ports are used for the main container in the StatefulSet.
-	GetContainerPorts(roleName, roleGroupName string) []corev1.ContainerPort
-
-	// GetServicePorts returns the service ports for a role group.
-	// These ports are exposed by the Service (if one is created).
-	GetServicePorts(roleName, roleGroupName string) []corev1.ServicePort
 }
 
 // RoleGroupHandlerFuncs is an adapter to allow using functions as RoleGroupHandler.
@@ -118,15 +110,6 @@ type RoleGroupHandler[CR common.ClusterInterface] interface {
 type RoleGroupHandlerFuncs[CR common.ClusterInterface] struct {
 	// BuildResourcesFunc is the function for building resources.
 	BuildResourcesFunc func(ctx context.Context, k8sClient client.Client, cr CR, buildCtx *RoleGroupBuildContext) (*RoleGroupResources, error)
-
-	// GetContainerImageFunc is the function for getting container images.
-	GetContainerImageFunc func(roleName string) string
-
-	// GetContainerPortsFunc is the function for getting container ports.
-	GetContainerPortsFunc func(roleName, roleGroupName string) []corev1.ContainerPort
-
-	// GetServicePortsFunc is the function for getting service ports.
-	GetServicePortsFunc func(roleName, roleGroupName string) []corev1.ServicePort
 }
 
 // BuildResources implements RoleGroupHandler.
@@ -135,30 +118,6 @@ func (f *RoleGroupHandlerFuncs[CR]) BuildResources(ctx context.Context, k8sClien
 		return &RoleGroupResources{}, nil
 	}
 	return f.BuildResourcesFunc(ctx, k8sClient, cr, buildCtx)
-}
-
-// GetContainerImage implements RoleGroupHandler.
-func (f *RoleGroupHandlerFuncs[CR]) GetContainerImage(roleName string) string {
-	if f.GetContainerImageFunc == nil {
-		return ""
-	}
-	return f.GetContainerImageFunc(roleName)
-}
-
-// GetContainerPorts implements RoleGroupHandler.
-func (f *RoleGroupHandlerFuncs[CR]) GetContainerPorts(roleName, roleGroupName string) []corev1.ContainerPort {
-	if f.GetContainerPortsFunc == nil {
-		return nil
-	}
-	return f.GetContainerPortsFunc(roleName, roleGroupName)
-}
-
-// GetServicePorts implements RoleGroupHandler.
-func (f *RoleGroupHandlerFuncs[CR]) GetServicePorts(roleName, roleGroupName string) []corev1.ServicePort {
-	if f.GetServicePortsFunc == nil {
-		return nil
-	}
-	return f.GetServicePortsFunc(roleName, roleGroupName)
 }
 
 // Verify that RoleGroupHandlerFuncs implements RoleGroupHandler.


### PR DESCRIPTION
## Problem

`RoleGroupHandler` interface currently requires three methods that are **never called by `GenericReconciler`**:

- `GetContainerImage(roleName string) string`
- `GetContainerPorts(roleName, roleGroupName string) []corev1.ContainerPort`
- `GetServicePorts(roleName, roleGroupName string) []corev1.ServicePort`

These methods exist as internal helpers inside `BaseRoleGroupHandler` — they are called from `buildStatefulSet` and `buildHeadlessService` within that struct. The `GenericReconciler` only ever calls `BuildResources`.

Placing them in the public interface means every operator that implements `RoleGroupHandler` directly (without embedding `BaseRoleGroupHandler`) is **forced to implement methods whose return values are completely ignored** at the SDK call-site. This is the exact situation in the `trino-operator` example where `TrinoRoleGroupHandler` provides these three methods but they have no effect — `CoordinatorsHandler`/`WorkersHandler` build all resources themselves.

## Fix

- **`RoleGroupHandler` interface**: only `BuildResources` is required. Remove the three methods.
- **`RoleGroupHandlerFuncs` adapter**: remove the three corresponding `Func` fields and method stubs — only `BuildResourcesFunc` remains.
- **`BaseRoleGroupHandler`**: rename the three methods to unexported helpers (`containerImage`, `containerPorts`, `servicePorts`) since they are purely internal. Update all internal call sites.
- **`TrinoRoleGroupHandler`**: remove the now-unnecessary implementations and their dead imports (`corev1`, `intstr`, `constants`).
- **Tests**: remove test cases for the deleted public methods.

## Why not refactor TrinoRoleGroupHandler to embed BaseRoleGroupHandler?

`BaseRoleGroupHandler` generates config from `buildCtx.MergedConfig.ConfigFiles`, mounting them at `/etc/config`. Trino uses a custom config-generation pipeline (`TrinoConfigBuilder`, `JVMConfigBuilder`, `CatalogConfigBuilder`) with a fixed `/etc/trino` mount path. Forcing Trino into `BaseRoleGroupHandler`'s config model would require either abandoning that pipeline or overriding every build step — defeating the purpose of the base class. The direct-build approach is the correct design for Trino; the interface just should not penalise it.