### PR TITLE
fix: register INI format in RegisterDefaultFormats

### DIFF
--- a/pkg/config/generator.go
+++ b/pkg/config/generator.go
@@ -93,6 +93,7 @@ func (g *MultiFormatConfigGenerator) RegisterDefaultFormats() {
 	g.RegisterFormat(".yaml", NewYAMLAdapter())
 	g.RegisterFormat(".yml", NewYAMLAdapter())
 	g.RegisterFormat(".env", NewEnvAdapter())
+	g.RegisterFormat(".ini", NewINIAdapter())
 }
 
 // Generate generates configuration file content with format detection based on extension.

--- a/pkg/config/generator_test.go
+++ b/pkg/config/generator_test.go
@@ -204,6 +204,13 @@ var _ = Describe("MultiFormatConfigGenerator", func() {
 			Expect(content).To(ContainSubstring("KEY=value"))
 		})
 
+		It("should generate INI format for .ini extension", func() {
+			data := map[string]string{"key": "value"}
+			content, err := generator.Generate("config.ini", data)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(content).To(ContainSubstring("key = value"))
+		})
+
 		It("should fall back to Properties format for unknown extension", func() {
 			data := map[string]string{"key": "value"}
 			content, err := generator.Generate("config.unknown", data)


### PR DESCRIPTION
## Summary
- Add `.ini` format registration to `RegisterDefaultFormats()` in `pkg/config/generator.go`
- The INI adapter (`ini_adapter.go`) already existed but was not registered by default, requiring manual `generator.RegisterFormat(".ini", config.NewINIAdapter())` calls

## Test plan
- [x] `make test` passes (all existing tests including INI adapter tests)
- [ ] Verify `.ini` files work with `MultiFormatConfigGenerator` without manual registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)