### PR TITLE
feat(sidecar): use product image for sidecars instead of hardcoded defaults

### DIFF
--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -394,6 +394,16 @@ func (r *GenericReconciler[CR]) reconcileRoleGroup(ctx context.Context, cr CR, r
 	// Auto-create SidecarManager based on CRD configuration
 	buildCtx.SidecarManager = r.buildSidecarManager(ctx, buildCtx)
 
+	// Set product image on sidecar manager so sidecars use the product image
+	if buildCtx.SidecarManager != nil {
+		if handler, ok := r.roleGroupHandler.(*BaseRoleGroupHandler[CR]); ok {
+			image := handler.containerImage(buildCtx.RoleName)
+			if err := buildCtx.SidecarManager.SetProductImage(image, handler.ImagePullPolicy); err != nil {
+				return NewResourceBuildError("sidecar", roleName, groupName, "failed to set product image", err)
+			}
+		}
+	}
+
 	// Delegate to handler for resource building
 	resources, err := r.roleGroupHandler.BuildResources(ctx, r.client, cr, buildCtx)
 	if err != nil {

--- a/pkg/sidecar/jmx_exporter.go
+++ b/pkg/sidecar/jmx_exporter.go
@@ -28,8 +28,6 @@ import (
 const (
 	// JMXExporterSidecarName is the name of the JMX Exporter sidecar container.
 	JMXExporterSidecarName = "jmx-exporter"
-	// JMXExporterDefaultImage is the default JMX Exporter image.
-	JMXExporterDefaultImage = "bitnami/jmx-exporter:0.20.0"
 	// JMXExporterPort is the default JMX Exporter metrics port.
 	JMXExporterPort = 5556
 	// JMXExporterConfigVolumeName is the name of the config volume.
@@ -93,9 +91,8 @@ func (p *JMXExporterSidecarProvider) Inject(podSpec *corev1.PodSpec, config *Sid
 	}
 
 	// Get image
-	image := config.Image
-	if image == "" {
-		image = JMXExporterDefaultImage
+	if config.Image == "" {
+		return fmt.Errorf("sidecar %s: image is required but not set", p.name)
 	}
 
 	// Get pull policy
@@ -113,7 +110,7 @@ func (p *JMXExporterSidecarProvider) Inject(podSpec *corev1.PodSpec, config *Sid
 	// Create JMX Exporter container
 	container := &corev1.Container{
 		Name:            p.name,
-		Image:           image,
+		Image:           config.Image,
 		ImagePullPolicy: pullPolicy,
 		Ports: []corev1.ContainerPort{
 			{

--- a/pkg/sidecar/jmx_exporter_test.go
+++ b/pkg/sidecar/jmx_exporter_test.go
@@ -58,6 +58,8 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 		var provider *sidecar.JMXExporterSidecarProvider
 		var podSpec *corev1.PodSpec
 
+		const testImage = "test-product-image:latest"
+
 		BeforeEach(func() {
 			provider = sidecar.NewJMXExporterSidecarProvider()
 			podSpec = &corev1.PodSpec{
@@ -68,18 +70,18 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 		})
 
 		It("should inject JMX exporter container into pod spec", func() {
-			config := &sidecar.SidecarConfig{Enabled: true}
+			config := &sidecar.SidecarConfig{Enabled: true, Image: testImage}
 			err := provider.Inject(podSpec, config)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(podSpec.Containers).To(HaveLen(2))
 			Expect(podSpec.Containers[1].Name).To(Equal(sidecar.JMXExporterSidecarName))
 		})
 
-		It("should use default image when not specified", func() {
+		It("should return error when image is not specified", func() {
 			config := &sidecar.SidecarConfig{Enabled: true}
 			err := provider.Inject(podSpec, config)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(podSpec.Containers[1].Image).To(Equal(sidecar.JMXExporterDefaultImage))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("image is required"))
 		})
 
 		It("should use custom image when specified", func() {
@@ -93,7 +95,7 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 		})
 
 		It("should use default port", func() {
-			config := &sidecar.SidecarConfig{Enabled: true}
+			config := &sidecar.SidecarConfig{Enabled: true, Image: testImage}
 			err := provider.Inject(podSpec, config)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(podSpec.Containers[1].Ports[0].ContainerPort).To(Equal(int32(sidecar.JMXExporterPort)))
@@ -101,7 +103,7 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 
 		It("should use custom port from provider", func() {
 			provider = provider.WithPort(9999)
-			config := &sidecar.SidecarConfig{Enabled: true}
+			config := &sidecar.SidecarConfig{Enabled: true, Image: testImage}
 			err := provider.Inject(podSpec, config)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(podSpec.Containers[1].Ports[0].ContainerPort).To(Equal(int32(9999)))
@@ -110,6 +112,7 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 		It("should use custom port from config", func() {
 			config := &sidecar.SidecarConfig{
 				Enabled: true,
+				Image:   testImage,
 				Ports: []corev1.ContainerPort{
 					{ContainerPort: 8888},
 				},
@@ -120,7 +123,7 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 		})
 
 		It("should add config volume mount", func() {
-			config := &sidecar.SidecarConfig{Enabled: true}
+			config := &sidecar.SidecarConfig{Enabled: true, Image: testImage}
 			err := provider.Inject(podSpec, config)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -132,7 +135,7 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 		})
 
 		It("should add config volume to pod", func() {
-			config := &sidecar.SidecarConfig{Enabled: true}
+			config := &sidecar.SidecarConfig{Enabled: true, Image: testImage}
 			err := provider.Inject(podSpec, config)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -150,7 +153,7 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 		})
 
 		It("should set readiness probe", func() {
-			config := &sidecar.SidecarConfig{Enabled: true}
+			config := &sidecar.SidecarConfig{Enabled: true, Image: testImage}
 			err := provider.Inject(podSpec, config)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -169,6 +172,7 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 			}
 			config := &sidecar.SidecarConfig{
 				Enabled:   true,
+				Image:     testImage,
 				Resources: &resources,
 			}
 			err := provider.Inject(podSpec, config)
@@ -180,6 +184,7 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 		It("should apply custom environment variables", func() {
 			config := &sidecar.SidecarConfig{
 				Enabled: true,
+				Image:   testImage,
 				EnvVars: map[string]string{
 					"JAVA_OPTS": "-Xmx256m",
 				},
@@ -196,6 +201,7 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 			}
 			config := &sidecar.SidecarConfig{
 				Enabled:      true,
+				Image:        testImage,
 				VolumeMounts: customMounts,
 			}
 			err := provider.Inject(podSpec, config)
@@ -219,6 +225,7 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 			}
 			config := &sidecar.SidecarConfig{
 				Enabled:         true,
+				Image:           testImage,
 				SecurityContext: securityContext,
 			}
 			err := provider.Inject(podSpec, config)
@@ -231,6 +238,7 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 		It("should apply custom image pull policy when provided", func() {
 			config := &sidecar.SidecarConfig{
 				Enabled:         true,
+				Image:           testImage,
 				ImagePullPolicy: corev1.PullAlways,
 			}
 			err := provider.Inject(podSpec, config)
@@ -240,21 +248,21 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 		})
 
 		It("should use default pull policy when not specified", func() {
-			config := &sidecar.SidecarConfig{Enabled: true}
+			config := &sidecar.SidecarConfig{Enabled: true, Image: testImage}
 			err := provider.Inject(podSpec, config)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(podSpec.Containers[1].ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
 		})
 
-		It("should work with nil config", func() {
+		It("should return error with nil config", func() {
 			err := provider.Inject(podSpec, nil)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(podSpec.Containers).To(HaveLen(2))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("image is required"))
 		})
 
 		It("should be idempotent - not duplicate container on repeated inject", func() {
-			config := &sidecar.SidecarConfig{Enabled: true}
+			config := &sidecar.SidecarConfig{Enabled: true, Image: testImage}
 			err := provider.Inject(podSpec, config)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(podSpec.Containers).To(HaveLen(2))
@@ -278,7 +286,7 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 
 		It("should use custom ConfigMap name for volume", func() {
 			provider = sidecar.NewJMXExporterSidecarProvider().WithConfigMapName("custom-jmx-config")
-			config := &sidecar.SidecarConfig{Enabled: true}
+			config := &sidecar.SidecarConfig{Enabled: true, Image: testImage}
 			err := provider.Inject(podSpec, config)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -300,7 +308,6 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 var _ = Describe("JMXExporter constants", func() {
 	It("should have correct default values", func() {
 		Expect(sidecar.JMXExporterSidecarName).To(Equal("jmx-exporter"))
-		Expect(sidecar.JMXExporterDefaultImage).To(ContainSubstring("jmx-exporter"))
 		Expect(int32(sidecar.JMXExporterPort)).To(Equal(int32(5556)))
 		Expect(sidecar.JMXExporterConfigVolumeName).To(Equal("jmx-exporter-config"))
 		Expect(sidecar.JMXExporterConfigMountPath).To(Equal("/opt/jmx_exporter"))

--- a/pkg/sidecar/manager.go
+++ b/pkg/sidecar/manager.go
@@ -188,6 +188,28 @@ func (m *SidecarManager) Count() int {
 	return len(m.providers)
 }
 
+// SetProductImage sets the product image on all enabled sidecar configs that
+// don't already have an image or pull policy set. This is used to propagate
+// the product container image to built-in sidecars (e.g. JMX Exporter) that
+// run as different commands within the same product image.
+func (m *SidecarManager) SetProductImage(image string, pullPolicy corev1.PullPolicy) error {
+	if image == "" {
+		return fmt.Errorf("product image must not be empty")
+	}
+	for _, config := range m.configs {
+		if !config.Enabled {
+			continue
+		}
+		if config.Image == "" {
+			config.Image = image
+		}
+		if config.ImagePullPolicy == "" {
+			config.ImagePullPolicy = pullPolicy
+		}
+	}
+	return nil
+}
+
 // AddVolumes adds volumes to the pod spec.
 func AddVolumes(podSpec *corev1.PodSpec, volumes []corev1.Volume) {
 	existingVolumes := make(map[string]bool)

--- a/pkg/sidecar/manager_test.go
+++ b/pkg/sidecar/manager_test.go
@@ -212,6 +212,80 @@ var _ = Describe("SidecarManager", func() {
 		})
 	})
 
+	Describe("SetProductImage", func() {
+		It("should set image on all enabled configs", func() {
+			provider1 := &mockSidecarProvider{name: "sidecar-1"}
+			provider2 := &mockSidecarProvider{name: "sidecar-2"}
+			config1 := &sidecar.SidecarConfig{Enabled: true}
+			config2 := &sidecar.SidecarConfig{Enabled: true}
+			manager.Register(provider1, config1)
+			manager.Register(provider2, config2)
+
+			err := manager.SetProductImage("product:latest", corev1.PullAlways)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(config1.Image).To(Equal("product:latest"))
+			Expect(config1.ImagePullPolicy).To(Equal(corev1.PullAlways))
+			Expect(config2.Image).To(Equal("product:latest"))
+			Expect(config2.ImagePullPolicy).To(Equal(corev1.PullAlways))
+		})
+
+		It("should not overwrite existing image", func() {
+			provider1 := &mockSidecarProvider{name: "sidecar-1"}
+			provider2 := &mockSidecarProvider{name: "sidecar-2"}
+			config1 := &sidecar.SidecarConfig{Enabled: true, Image: "custom-image:1.0"}
+			config2 := &sidecar.SidecarConfig{Enabled: true}
+			manager.Register(provider1, config1)
+			manager.Register(provider2, config2)
+
+			err := manager.SetProductImage("product:latest", corev1.PullIfNotPresent)
+			Expect(err).NotTo(HaveOccurred())
+
+			// config1 should keep its custom image
+			Expect(config1.Image).To(Equal("custom-image:1.0"))
+			// config2 should get the product image
+			Expect(config2.Image).To(Equal("product:latest"))
+		})
+
+		It("should not overwrite existing ImagePullPolicy", func() {
+			provider := &mockSidecarProvider{name: "sidecar-1"}
+			config := &sidecar.SidecarConfig{
+				Enabled:         true,
+				ImagePullPolicy: corev1.PullNever,
+			}
+			manager.Register(provider, config)
+
+			err := manager.SetProductImage("product:latest", corev1.PullAlways)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(config.ImagePullPolicy).To(Equal(corev1.PullNever))
+		})
+
+		It("should skip disabled configs", func() {
+			provider := &mockSidecarProvider{name: "sidecar-1"}
+			config := &sidecar.SidecarConfig{Enabled: false}
+			manager.Register(provider, config)
+
+			err := manager.SetProductImage("product:latest", corev1.PullAlways)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Disabled config should not be modified
+			Expect(config.Image).To(BeEmpty())
+			Expect(config.ImagePullPolicy).To(BeEmpty())
+		})
+
+		It("should return error when image is empty", func() {
+			err := manager.SetProductImage("", corev1.PullIfNotPresent)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("product image must not be empty"))
+		})
+
+		It("should handle empty manager", func() {
+			err := manager.SetProductImage("product:latest", corev1.PullIfNotPresent)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
 	Describe("WithClient", func() {
 		It("should set client and namespace", func() {
 			fakeClient := testutil.NewFakeClient()

--- a/pkg/sidecar/vector.go
+++ b/pkg/sidecar/vector.go
@@ -27,8 +27,6 @@ import (
 const (
 	// VectorSidecarName is the name of the Vector sidecar container.
 	VectorSidecarName = "vector"
-	// VectorDefaultImage is the default Vector image.
-	VectorDefaultImage = "timberio/vector:0.40.0-debian"
 	// VectorConfigVolumeName is the name of the config volume.
 	VectorConfigVolumeName = "vector-config"
 	// VectorDataVolumeName is the name of the data volume.
@@ -84,9 +82,8 @@ func (p *VectorSidecarProvider) Inject(podSpec *corev1.PodSpec, config *SidecarC
 	}
 
 	// Get image
-	image := config.Image
-	if image == "" {
-		image = VectorDefaultImage
+	if config.Image == "" {
+		return fmt.Errorf("sidecar %s: image is required but not set", p.name)
 	}
 
 	// Get pull policy
@@ -98,7 +95,7 @@ func (p *VectorSidecarProvider) Inject(podSpec *corev1.PodSpec, config *SidecarC
 	// Create Vector container
 	container := &corev1.Container{
 		Name:            p.name,
-		Image:           image,
+		Image:           config.Image,
 		ImagePullPolicy: pullPolicy,
 		Command: []string{
 			"/usr/bin/vector",


### PR DESCRIPTION
## Summary
- Remove hardcoded sidecar image constants (`VectorDefaultImage`, `JMXExporterDefaultImage`)
- Add `SidecarManager.SetProductImage(image, pullPolicy)` to propagate the product image to all enabled sidecar configs
- Sidecar providers now require image via `SidecarConfig.Image`, returning error if empty (fail-fast)
- Providers read `ImagePullPolicy` from config instead of hardcoding `PullIfNotPresent`

## Background
Product images already contain Vector and JMX Exporter programs. Sidecar containers should use the same product image (resolved from `ImageSpec`) with different commands, rather than external hardcoded images.

## Test plan
- [x] 84 tests pass (sidecar package at 98.1% coverage)
- [x] `make lint` passes with 0 issues
- [x] New tests: `SetProductImage` propagation, disabled config skip, empty image validation, `ImagePullPolicy` from config
- [x] Updated tests: error on empty image, error on nil config, removed constant references

🤖 Generated with [Claude Code](https://claude.com/claude-code)