### PR TITLE
chore: add .serena to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -199,3 +199,4 @@ cover.out
 _bmad*
 .omc
 .claude/worktrees
+.serena


### PR DESCRIPTION
## Summary
- Add `.serena` directory to `.gitignore` to prevent AI tool artifacts from being tracked

## Test plan
- [ ] Verify `git status` no longer shows `.serena/` as untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)