### PR TITLE
refactor: replace manual pointer helpers with ptr.To

### DIFF
--- a/pkg/security/pod_security.go
+++ b/pkg/security/pod_security.go
@@ -18,6 +18,7 @@ package security
 
 import (
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
 )
 
 const (
@@ -166,14 +167,11 @@ func (b *PodSecurityBuilder) BuildPodSecurityContext() *corev1.PodSecurityContex
 
 // BuildDefaultSecurityContext creates a container security context with secure defaults.
 func (b *PodSecurityBuilder) BuildDefaultSecurityContext() *corev1.SecurityContext {
-	nonRoot := true
-	allowEscalation := false
-
 	return &corev1.SecurityContext{
-		RunAsUser:                ptrInt64(DefaultRunAsUser),
-		RunAsGroup:               ptrInt64(DefaultRunAsGroup),
-		RunAsNonRoot:             &nonRoot,
-		AllowPrivilegeEscalation: &allowEscalation,
+		RunAsUser:                ptr.To(DefaultRunAsUser),
+		RunAsGroup:               ptr.To(DefaultRunAsGroup),
+		RunAsNonRoot:             ptr.To(true),
+		AllowPrivilegeEscalation: ptr.To(false),
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		},
@@ -185,22 +183,15 @@ func (b *PodSecurityBuilder) BuildDefaultSecurityContext() *corev1.SecurityConte
 
 // BuildDefaultPodSecurityContext creates a pod security context with secure defaults.
 func (b *PodSecurityBuilder) BuildDefaultPodSecurityContext() *corev1.PodSecurityContext {
-	nonRoot := true
-
 	return &corev1.PodSecurityContext{
-		RunAsUser:    ptrInt64(DefaultRunAsUser),
-		RunAsGroup:   ptrInt64(DefaultRunAsGroup),
-		RunAsNonRoot: &nonRoot,
-		FSGroup:      ptrInt64(DefaultFSGroup),
+		RunAsUser:    ptr.To(DefaultRunAsUser),
+		RunAsGroup:   ptr.To(DefaultRunAsGroup),
+		RunAsNonRoot: ptr.To(true),
+		FSGroup:      ptr.To(DefaultFSGroup),
 		SeccompProfile: &corev1.SeccompProfile{
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		},
 	}
-}
-
-// ptrInt64 returns a pointer to an int64.
-func ptrInt64(v int64) *int64 {
-	return &v
 }
 
 // DefaultPodSecurityBuilder returns a builder with secure defaults.

--- a/pkg/security/secret_class.go
+++ b/pkg/security/secret_class.go
@@ -56,12 +56,6 @@ const (
 	KerberosServiceNamesDelimiter = CommonDelimiter
 )
 
-// SecretStorageClassPtr returns a pointer to the SecretStorageClass.
-func SecretStorageClassPtr() *string {
-	v := SecretStorageClass
-	return &v
-}
-
 // SecretFormat defines the format of secrets provisioned by secret-operator.
 type SecretFormat string
 

--- a/pkg/vector/provider.go
+++ b/pkg/vector/provider.go
@@ -23,6 +23,7 @@ import (
 	"github.com/zncdatadev/operator-go/pkg/sidecar"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -205,17 +206,14 @@ func (p *VectorSidecarProvider) Inject(podSpec *corev1.PodSpec, config *sidecar.
 // defaultSecurityContext returns a hardened security context for the Vector container.
 func defaultSecurityContext() *corev1.SecurityContext {
 	return &corev1.SecurityContext{
-		RunAsNonRoot:             ptrBool(true),
-		ReadOnlyRootFilesystem:   ptrBool(true),
-		AllowPrivilegeEscalation: ptrBool(false),
+		RunAsNonRoot:             ptr.To(true),
+		ReadOnlyRootFilesystem:   ptr.To(true),
+		AllowPrivilegeEscalation: ptr.To(false),
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		},
 	}
 }
-
-// ptrBool returns a pointer to the given bool value.
-func ptrBool(b bool) *bool { return &b }
 
 // ConfigMapName returns the ConfigMap name used by this provider.
 func (p *VectorSidecarProvider) ConfigMapName() string {


### PR DESCRIPTION
## Summary
- Replace `ptrInt64` (5 call sites) and `&variable` bool patterns in `pkg/security/pod_security.go` with `ptr.To()` from `k8s.io/utils/ptr`
- Replace `ptrBool` (3 call sites) in `pkg/vector/provider.go` with `ptr.To()`
- Delete `SecretStorageClassPtr` from `pkg/security/secret_class.go` (zero callers confirmed in this repo)

**Note:** `ListenerStorageClassPtr` in `pkg/listener/volume_builder.go` is NOT deleted — upstream already refactored it to use `ptr.To()` in a prior merge, and `provisioner_test.go` now has callers for it.

**API breaking change:** `SecretStorageClassPtr` is an exported function. Team confirms zero external consumers of this library. If this assumption is incorrect, callers can trivially migrate to `ptr.To(security.SecretStorageClass)`.

## Test plan
- [x] `make lint` passes with 0 issues
- [x] `make test` passes (all packages green)
- [x] All replacements are semantically equivalent (no behavioral changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)