### PR TITLE
feat(reconciler): identity-label selectors, native-sidecar injection, role-scoped names

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,6 +21,8 @@ jobs:
 
       - name: Run linter
         uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2
 
   md-lint:
     name: Markdown Lint

--- a/.gitignore
+++ b/.gitignore
@@ -200,3 +200,4 @@ _bmad*
 .omc
 .claude/worktrees
 .serena
+.worktree/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,10 @@ linters:
           - dupl
           - lll
         path: pkg/*
+      # Repeated literals in test fixtures and test helpers are expected; goconst is noise there.
+      - linters:
+          - goconst
+        path: (_test\.go$|^pkg/testutil/)
     paths:
       - third_party$
       - builtin$

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.7.1
 CONTROLLER_TOOLS_VERSION ?= v0.19.0
-GOLANGCI_LINT_VERSION ?= v2.10.1
+GOLANGCI_LINT_VERSION ?= v2.12.2
 
 #ENVTEST_VERSION is the version of controller-runtime release branch to fetch the envtest setup script (i.e. release-0.20)
 ENVTEST_VERSION ?= $(shell v='$(call gomodver,sigs.k8s.io/controller-runtime)'; \

--- a/pkg/builder/metrics_service_builder.go
+++ b/pkg/builder/metrics_service_builder.go
@@ -40,6 +40,7 @@ type MetricsServiceBuilder struct {
 	port         int32
 	portName     string
 	labels       map[string]string
+	selector     map[string]string
 	scheme       string
 	path         string
 }
@@ -78,6 +79,13 @@ func (b *MetricsServiceBuilder) WithPortName(name string) *MetricsServiceBuilder
 	return b
 }
 
+// WithSelector sets a dedicated pod selector (default: the labels). Use this to decouple the
+// selector from the descriptive labels.
+func (b *MetricsServiceBuilder) WithSelector(selector map[string]string) *MetricsServiceBuilder {
+	b.selector = selector
+	return b
+}
+
 // Build creates the metrics Service.
 func (b *MetricsServiceBuilder) Build() *corev1.Service {
 	serviceLabels := maps.Clone(b.labels)
@@ -95,7 +103,11 @@ func (b *MetricsServiceBuilder) Build() *corev1.Service {
 		annotations["prometheus.io/path"] = b.path
 	}
 
-	selector := maps.Clone(b.labels)
+	selectorSource := b.selector
+	if selectorSource == nil {
+		selectorSource = b.labels
+	}
+	selector := maps.Clone(selectorSource)
 	if selector == nil {
 		selector = map[string]string{}
 	}

--- a/pkg/builder/statefulset_builder.go
+++ b/pkg/builder/statefulset_builder.go
@@ -28,9 +28,14 @@ import (
 
 // StatefulSetBuilder constructs StatefulSet resources.
 type StatefulSetBuilder struct {
-	Name            string
-	Namespace       string
-	Labels          map[string]string
+	Name      string
+	Namespace string
+	Labels    map[string]string
+	// SelectorLabels, when set, is used for the StatefulSet's immutable .spec.selector
+	// (and must be a subset of Labels, which are applied to the pod template). When empty,
+	// Labels is used for the selector. Decoupling the selector from the full descriptive
+	// labels keeps the immutable selector stable and free of user-mutable labels.
+	SelectorLabels  map[string]string
 	Annotations     map[string]string
 	Replicas        int32
 	Image           string
@@ -42,6 +47,10 @@ type StatefulSetBuilder struct {
 	EnvVars         []corev1.EnvVar
 	Command         []string
 	Args            []string
+
+	// InitContainers are run before the main container starts. Products use these for
+	// one-shot preparation steps (e.g. generating node ids, fetching secrets).
+	InitContainers []corev1.Container
 
 	// Resource requirements
 	Resources *corev1.ResourceRequirements
@@ -107,6 +116,22 @@ func (b *StatefulSetBuilder) WithLabels(labels map[string]string) *StatefulSetBu
 		b.Labels[k] = v
 	}
 	return b
+}
+
+// WithSelectorLabels sets the labels used for the StatefulSet's immutable .spec.selector.
+// They must be a subset of the pod template labels (WithLabels).
+func (b *StatefulSetBuilder) WithSelectorLabels(labels map[string]string) *StatefulSetBuilder {
+	b.SelectorLabels = labels
+	return b
+}
+
+// selectorMatchLabels returns the labels for .spec.selector, falling back to the full
+// labels when no dedicated selector labels are set.
+func (b *StatefulSetBuilder) selectorMatchLabels() map[string]string {
+	if len(b.SelectorLabels) > 0 {
+		return b.SelectorLabels
+	}
+	return b.Labels
 }
 
 // WithAnnotations sets the annotations.
@@ -203,6 +228,30 @@ func (b *StatefulSetBuilder) AddEnvVar(name, value string) *StatefulSetBuilder {
 		Name:  name,
 		Value: value,
 	})
+	return b
+}
+
+// WithCommand sets the main container entrypoint command.
+func (b *StatefulSetBuilder) WithCommand(command []string) *StatefulSetBuilder {
+	b.Command = command
+	return b
+}
+
+// WithArgs sets the main container args.
+func (b *StatefulSetBuilder) WithArgs(args []string) *StatefulSetBuilder {
+	b.Args = args
+	return b
+}
+
+// AddInitContainer appends an init container that runs before the main container.
+func (b *StatefulSetBuilder) AddInitContainer(container corev1.Container) *StatefulSetBuilder {
+	b.InitContainers = append(b.InitContainers, container)
+	return b
+}
+
+// WithInitContainers replaces the init containers.
+func (b *StatefulSetBuilder) WithInitContainers(containers []corev1.Container) *StatefulSetBuilder {
+	b.InitContainers = containers
 	return b
 }
 
@@ -378,7 +427,7 @@ func (b *StatefulSetBuilder) Build() *appsv1.StatefulSet {
 			ServiceName:         b.Name + "-headless",
 			PodManagementPolicy: appsv1.ParallelPodManagement,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: b.Labels,
+				MatchLabels: b.selectorMatchLabels(),
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
@@ -411,6 +460,7 @@ func (b *StatefulSetBuilder) buildPodSpec() corev1.PodSpec {
 		SecurityContext:               b.PodSecurityContext,
 		Affinity:                      b.Affinity,
 		Volumes:                       b.Volumes,
+		InitContainers:                b.InitContainers,
 		Containers: []corev1.Container{
 			b.buildContainer(),
 		},

--- a/pkg/builder/statefulset_builder.go
+++ b/pkg/builder/statefulset_builder.go
@@ -119,9 +119,15 @@ func (b *StatefulSetBuilder) WithLabels(labels map[string]string) *StatefulSetBu
 }
 
 // WithSelectorLabels sets the labels used for the StatefulSet's immutable .spec.selector.
-// They must be a subset of the pod template labels (WithLabels).
+// The labels are cloned (to avoid external mutation) and also merged into the pod template
+// labels, enforcing the invariant that the selector is a subset of the template labels —
+// otherwise the API server would reject the StatefulSet.
 func (b *StatefulSetBuilder) WithSelectorLabels(labels map[string]string) *StatefulSetBuilder {
-	b.SelectorLabels = labels
+	b.SelectorLabels = make(map[string]string, len(labels))
+	for k, v := range labels {
+		b.SelectorLabels[k] = v
+		b.Labels[k] = v
+	}
 	return b
 }
 

--- a/pkg/config/logging_generator.go
+++ b/pkg/config/logging_generator.go
@@ -147,20 +147,79 @@ func GenerateLog4j2(configs map[string]LoggerConfig) (string, error) {
 //
 // </configuration>
 func GenerateLogback(configs map[string]LoggerConfig) (string, error) {
-	var sb strings.Builder
+	return GenerateLogbackWithOptions(configs, LogbackOptions{})
+}
 
-	sb.WriteString(`<?xml version="1.0" encoding="UTF-8"?>
-<configuration>
-  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+// LogbackOptions tunes logback generation. The zero value reproduces the console-only
+// output of GenerateLogback.
+type LogbackOptions struct {
+	// FileOutputPath, when set, adds a bounded RollingFileAppender writing to this path in
+	// addition to the console appender. The filename must match the log consumer's glob —
+	// e.g. the Vector sidecar collects "<LogDir>/*.stdout.log", so pass
+	// "<LogDir>/<app>.stdout.log". Without this, log aggregation has nothing to read.
+	FileOutputPath string
+
+	// Pattern overrides the encoder pattern for both appenders.
+	Pattern string
+
+	// MaxFileSize / MaxHistory / TotalSizeCap bound the rolling file appender so it cannot
+	// exhaust the log volume. Sensible defaults are applied when left zero.
+	MaxFileSize  string
+	MaxHistory   int
+	TotalSizeCap string
+}
+
+// GenerateLogbackWithOptions generates logback XML with optional file output.
+func GenerateLogbackWithOptions(configs map[string]LoggerConfig, opts LogbackOptions) (string, error) {
+	pattern := opts.Pattern
+	if pattern == "" {
+		pattern = "%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n"
+	}
+
+	var sb strings.Builder
+	sb.WriteString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<configuration>\n")
+	fmt.Fprintf(&sb, `  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n</pattern>
+      <pattern>%s</pattern>
     </encoder>
   </appender>
+`, pattern)
 
-  <root level="INFO">
-    <appender-ref ref="STDOUT" />
-  </root>
-`)
+	hasFile := opts.FileOutputPath != ""
+	if hasFile {
+		maxFileSize := opts.MaxFileSize
+		if maxFileSize == "" {
+			maxFileSize = "5MB"
+		}
+		totalSizeCap := opts.TotalSizeCap
+		if totalSizeCap == "" {
+			totalSizeCap = "8MB"
+		}
+		maxHistory := opts.MaxHistory
+		if maxHistory <= 0 {
+			maxHistory = 1
+		}
+		fmt.Fprintf(&sb, `
+  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+    <file>%s</file>
+    <encoder>
+      <pattern>%s</pattern>
+    </encoder>
+    <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+      <fileNamePattern>%s.%%d{yyyy-MM-dd}.%%i</fileNamePattern>
+      <maxFileSize>%s</maxFileSize>
+      <maxHistory>%d</maxHistory>
+      <totalSizeCap>%s</totalSizeCap>
+    </rollingPolicy>
+  </appender>
+`, escapeXML(opts.FileOutputPath), pattern, escapeXML(opts.FileOutputPath), maxFileSize, maxHistory, totalSizeCap)
+	}
+
+	sb.WriteString("\n  <root level=\"INFO\">\n    <appender-ref ref=\"STDOUT\" />\n")
+	if hasFile {
+		sb.WriteString("    <appender-ref ref=\"FILE\" />\n")
+	}
+	sb.WriteString("  </root>\n")
 
 	if len(configs) == 0 {
 		sb.WriteString("</configuration>\n")

--- a/pkg/config/logging_generator.go
+++ b/pkg/config/logging_generator.go
@@ -175,6 +175,9 @@ func GenerateLogbackWithOptions(configs map[string]LoggerConfig, opts LogbackOpt
 	if pattern == "" {
 		pattern = "%d{yyyy-MM-dd HH:mm:ss} %-5level %logger{36} - %msg%n"
 	}
+	// Escape the (possibly caller-supplied) pattern so reserved XML characters cannot
+	// produce invalid logback XML.
+	pattern = escapeXML(pattern)
 
 	var sb strings.Builder
 	sb.WriteString("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<configuration>\n")

--- a/pkg/config/logging_generator_test.go
+++ b/pkg/config/logging_generator_test.go
@@ -442,3 +442,25 @@ var _ = Describe("LoggerConfig", func() {
 		Expect(loggerConfig.Level).To(Equal(config.LogLevelDebug))
 	})
 })
+
+var _ = Describe("GenerateLogbackWithOptions", func() {
+	It("emits only a console appender when no file output is requested (matches GenerateLogback)", func() {
+		withOpts, err := config.GenerateLogbackWithOptions(nil, config.LogbackOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		plain, err := config.GenerateLogback(nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(withOpts).To(Equal(plain))
+		Expect(withOpts).NotTo(ContainSubstring("RollingFileAppender"))
+	})
+
+	It("adds a bounded rolling file appender matching the consumer glob", func() {
+		out, err := config.GenerateLogbackWithOptions(nil, config.LogbackOptions{
+			FileOutputPath: "/kubedoop/log/zookeeper.stdout.log",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(out).To(ContainSubstring(`class="ch.qos.logback.core.rolling.RollingFileAppender"`))
+		Expect(out).To(ContainSubstring("<file>/kubedoop/log/zookeeper.stdout.log</file>"))
+		Expect(out).To(ContainSubstring("<totalSizeCap>8MB</totalSizeCap>"))
+		Expect(out).To(ContainSubstring(`<appender-ref ref="FILE" />`))
+	})
+})

--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -82,6 +82,25 @@ type BaseRoleGroupHandler[CR common.ClusterInterface] struct {
 	// Product-specific annotations to add to all resources.
 	ExtraAnnotations map[string]string
 
+	// StorageMountPath, when non-empty, opts the role group into a data PVC. The base
+	// StatefulSet then gets a VolumeClaimTemplate built from RoleGroupConfig.Resources.Storage
+	// mounted at this path, keeping the volume/mount contract consistent. Left empty for
+	// backward compatibility (no data PVC unless a product opts in).
+	StorageMountPath string
+
+	// PublishNotReadyAddresses, when true, sets the same flag on the headless Service so
+	// peers can resolve each other's DNS before readiness (required by quorum systems).
+	PublishNotReadyAddresses bool
+
+	// LabelDomain, when set (e.g. "zookeeper.kubedoop.dev"), enables product-owned identity
+	// labels — "<domain>/cluster", "<domain>/role", "<domain>/role-group" — that are used
+	// for resource selectors (StatefulSet, Services, PDB) instead of the descriptive
+	// app.kubernetes.io/* labels. The product-domain prefix guarantees the selectors never
+	// match another product's pods, and decoupling from app.kubernetes.io/* keeps the
+	// immutable StatefulSet selector stable and free of user-mutable labels.
+	// When empty, selectors fall back to the descriptive labels (backward compatible).
+	LabelDomain string
+
 	// SidecarManager manages sidecar injection into pods.
 	// Optional - if nil, no sidecars are injected.
 	sidecarManager *sidecar.SidecarManager
@@ -189,7 +208,18 @@ func (h *BaseRoleGroupHandler[CR]) servicePorts(roleName, _ string) []corev1.Ser
 	return nil
 }
 
-// buildLabels creates the labels for resources.
+// ClusterLabelKey returns the identity label key for the cluster, under the given domain.
+func ClusterLabelKey(domain string) string { return domain + "/cluster" }
+
+// RoleLabelKey returns the identity label key for the role, under the given domain.
+func RoleLabelKey(domain string) string { return domain + "/role" }
+
+// RoleGroupLabelKey returns the identity label key for the role group, under the given domain.
+func RoleGroupLabelKey(domain string) string { return domain + "/role-group" }
+
+// buildLabels creates the descriptive labels for resources. When LabelDomain is set, the
+// product-owned identity labels are added too (they are also used as selectors — see
+// buildSelectorLabels).
 func (h *BaseRoleGroupHandler[CR]) buildLabels(buildCtx *RoleGroupBuildContext) map[string]string {
 	labels := make(map[string]string)
 
@@ -206,12 +236,46 @@ func (h *BaseRoleGroupHandler[CR]) buildLabels(buildCtx *RoleGroupBuildContext) 
 	// Role group label
 	labels[buildCtx.ClusterName+"-"+buildCtx.RoleGroupName] = "true"
 
+	// Product-owned identity labels (also used for selectors).
+	for k, v := range h.identityLabels(buildCtx) {
+		labels[k] = v
+	}
+
 	// Add extra labels
 	for k, v := range h.ExtraLabels {
 		labels[k] = v
 	}
 
 	return labels
+}
+
+// identityLabels returns the product-owned identity labels when LabelDomain is set, else nil.
+func (h *BaseRoleGroupHandler[CR]) identityLabels(buildCtx *RoleGroupBuildContext) map[string]string {
+	if h.LabelDomain == "" {
+		return nil
+	}
+	return map[string]string{
+		ClusterLabelKey(h.LabelDomain):   buildCtx.ClusterName,
+		RoleLabelKey(h.LabelDomain):      buildCtx.RoleName,
+		RoleGroupLabelKey(h.LabelDomain): buildCtx.RoleGroupName,
+	}
+}
+
+// buildSelectorLabels returns the labels used for resource selectors. When LabelDomain is
+// set, these are the product-owned identity labels (cluster + role + role-group), which are
+// product-namespaced and stable. Otherwise it falls back to the full descriptive labels for
+// backward compatibility.
+func (h *BaseRoleGroupHandler[CR]) buildSelectorLabels(buildCtx *RoleGroupBuildContext) map[string]string {
+	if h.LabelDomain == "" {
+		return h.buildLabels(buildCtx)
+	}
+	return h.identityLabels(buildCtx)
+}
+
+// SelectorLabels exposes the role group's selector labels so embedding products can build
+// matching selectors for resources they add themselves (e.g. a metrics Service).
+func (h *BaseRoleGroupHandler[CR]) SelectorLabels(buildCtx *RoleGroupBuildContext) map[string]string {
+	return h.buildSelectorLabels(buildCtx)
 }
 
 // buildAnnotations creates the annotations for resources.
@@ -278,9 +342,10 @@ func (h *BaseRoleGroupHandler[CR]) buildHeadlessService(buildCtx *RoleGroupBuild
 			Annotations: h.buildAnnotations(buildCtx),
 		},
 		Spec: corev1.ServiceSpec{
-			ClusterIP: corev1.ClusterIPNone,
-			Selector:  labels,
-			Ports:     h.servicePorts(buildCtx.RoleName, buildCtx.RoleGroupName),
+			ClusterIP:                corev1.ClusterIPNone,
+			PublishNotReadyAddresses: h.PublishNotReadyAddresses,
+			Selector:                 h.buildSelectorLabels(buildCtx),
+			Ports:                    h.servicePorts(buildCtx.RoleName, buildCtx.RoleGroupName),
 		},
 	}
 }
@@ -295,7 +360,7 @@ func (h *BaseRoleGroupHandler[CR]) buildService(buildCtx *RoleGroupBuildContext,
 			Annotations: h.buildAnnotations(buildCtx),
 		},
 		Spec: corev1.ServiceSpec{
-			Selector: labels,
+			Selector: h.buildSelectorLabels(buildCtx),
 			Ports:    ports,
 		},
 	}
@@ -314,6 +379,7 @@ func (h *BaseRoleGroupHandler[CR]) buildStatefulSet(
 
 	// Set basic properties
 	stsBuilder.WithLabels(labels).
+		WithSelectorLabels(h.buildSelectorLabels(buildCtx)).
 		WithAnnotations(h.buildAnnotations(buildCtx)).
 		WithReplicas(buildCtx.RoleGroupSpec.GetReplicas()).
 		WithImage(h.containerImage(buildCtx.RoleName), h.ImagePullPolicy).
@@ -324,6 +390,12 @@ func (h *BaseRoleGroupHandler[CR]) buildStatefulSet(
 	roleGroupConfig := buildCtx.RoleGroupSpec.GetConfig()
 	if roleGroupConfig != nil && roleGroupConfig.Resources != nil {
 		stsBuilder.WithResources(roleGroupConfig.Resources)
+		// Opt-in data PVC: when a product sets StorageMountPath, build a VolumeClaimTemplate
+		// from the configured storage and mount it, so the volume/mount contract is enforced
+		// by the builder instead of being hand-assembled by each product.
+		if h.StorageMountPath != "" && roleGroupConfig.Resources.Storage != nil {
+			stsBuilder.WithStorage(roleGroupConfig.Resources.Storage, h.StorageMountPath)
+		}
 	}
 
 	// Set pod overrides if present
@@ -392,7 +464,7 @@ func (h *BaseRoleGroupHandler[CR]) buildPodDisruptionBudget(buildCtx *RoleGroupB
 		},
 		Spec: policyv1.PodDisruptionBudgetSpec{
 			Selector: &metav1.LabelSelector{
-				MatchLabels: labels,
+				MatchLabels: h.buildSelectorLabels(buildCtx),
 			},
 		},
 	}

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/zncdatadev/operator-go/pkg/reconciler"
 	"github.com/zncdatadev/operator-go/pkg/testutil"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
@@ -746,5 +747,95 @@ var _ = Describe("BaseRoleGroupHandler with PDB", func() {
 		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(resources.PodDisruptionBudget).To(BeNil())
+	})
+})
+
+var _ = Describe("BaseRoleGroupHandler enhancements", func() {
+	var ctx context.Context
+	var mockCR *testutil.ClusterWrapper
+
+	newBuildCtx := func(storage *v1alpha1.StorageResource) *reconciler.RoleGroupBuildContext {
+		cfg := &v1alpha1.RoleGroupConfigSpec{}
+		if storage != nil {
+			cfg.Resources = &v1alpha1.ResourcesSpec{Storage: storage}
+		}
+		return &reconciler.RoleGroupBuildContext{
+			ClusterName:      "test-cluster",
+			ClusterNamespace: "default",
+			RoleName:         "server",
+			RoleSpec:         &v1alpha1.RoleSpec{},
+			RoleGroupName:    "default",
+			RoleGroupSpec:    v1alpha1.RoleGroupSpec{Replicas: ptr.To(int32(3)), Config: cfg},
+			MergedConfig:     &config.MergedConfig{},
+			ResourceName:     "test-cluster-default",
+		}
+	}
+
+	var buildCtx *reconciler.RoleGroupBuildContext
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		mockCR = testutil.WrapMockCluster(testutil.NewMockCluster("test-cluster", "default"))
+		buildCtx = newBuildCtx(&v1alpha1.StorageResource{Capacity: resource.MustParse("10Gi")})
+	})
+
+	It("creates a data PVC from storage when StorageMountPath is set", func() {
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("img:1", testScheme)
+		handler.StorageMountPath = "/kubedoop/data"
+
+		resources, err := handler.BuildResources(ctx, k8sClient, mockCR, buildCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.StatefulSet.Spec.VolumeClaimTemplates).To(HaveLen(1))
+		pvc := resources.StatefulSet.Spec.VolumeClaimTemplates[0]
+		q := pvc.Spec.Resources.Requests[corev1.ResourceStorage]
+		Expect(q.String()).To(Equal("10Gi"))
+		mounts := resources.StatefulSet.Spec.Template.Spec.Containers[0].VolumeMounts
+		Expect(mounts).To(ContainElement(HaveField("MountPath", "/kubedoop/data")))
+	})
+
+	It("does not create a data PVC when StorageMountPath is unset (backward compatible)", func() {
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("img:1", testScheme)
+		resources, err := handler.BuildResources(ctx, k8sClient, mockCR, buildCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.StatefulSet.Spec.VolumeClaimTemplates).To(BeEmpty())
+	})
+
+	It("sets PublishNotReadyAddresses on the headless service when enabled", func() {
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("img:1", testScheme)
+		handler.PublishNotReadyAddresses = true
+		resources, err := handler.BuildResources(ctx, k8sClient, mockCR, buildCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.HeadlessService.Spec.PublishNotReadyAddresses).To(BeTrue())
+	})
+
+	It("uses product-owned identity labels for selectors when LabelDomain is set", func() {
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("img:1", testScheme)
+		handler.LabelDomain = "zookeeper.kubedoop.dev"
+		resources, err := handler.BuildResources(ctx, k8sClient, mockCR, buildCtx)
+		Expect(err).NotTo(HaveOccurred())
+
+		// The immutable StatefulSet selector is the identity subset, decoupled from
+		// the descriptive app.kubernetes.io/* labels.
+		sel := resources.StatefulSet.Spec.Selector.MatchLabels
+		Expect(sel).To(HaveKeyWithValue("zookeeper.kubedoop.dev/cluster", "test-cluster"))
+		Expect(sel).To(HaveKeyWithValue("zookeeper.kubedoop.dev/role", "server"))
+		Expect(sel).To(HaveKeyWithValue("zookeeper.kubedoop.dev/role-group", "default"))
+		Expect(sel).NotTo(HaveKey("app.kubernetes.io/component"))
+
+		// Descriptive labels and identity labels are both on the pod template.
+		tmpl := resources.StatefulSet.Spec.Template.Labels
+		Expect(tmpl).To(HaveKeyWithValue("app.kubernetes.io/component", "server"))
+		Expect(tmpl).To(HaveKeyWithValue("zookeeper.kubedoop.dev/cluster", "test-cluster"))
+
+		// The headless Service selector is identity-only too.
+		Expect(resources.HeadlessService.Spec.Selector).To(HaveKey("zookeeper.kubedoop.dev/role"))
+		Expect(resources.HeadlessService.Spec.Selector).NotTo(HaveKey("app.kubernetes.io/component"))
+	})
+
+	It("falls back to descriptive labels for selectors when LabelDomain is empty", func() {
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("img:1", testScheme)
+		resources, err := handler.BuildResources(ctx, k8sClient, mockCR, buildCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.StatefulSet.Spec.Selector.MatchLabels).To(HaveKeyWithValue("app.kubernetes.io/component", "server"))
 	})
 })

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -767,7 +767,7 @@ var _ = Describe("BaseRoleGroupHandler enhancements", func() {
 			RoleGroupName:    "default",
 			RoleGroupSpec:    v1alpha1.RoleGroupSpec{Replicas: ptr.To(int32(3)), Config: cfg},
 			MergedConfig:     &config.MergedConfig{},
-			ResourceName:     "test-cluster-default",
+			ResourceName:     reconciler.RoleGroupResourceName("test-cluster", "server", "default"),
 		}
 	}
 

--- a/pkg/reconciler/cleaner.go
+++ b/pkg/reconciler/cleaner.go
@@ -91,9 +91,9 @@ func (c *RoleGroupCleaner) Cleanup(
 	// that are no longer orphaned (re-added to spec). This ensures the grace period is
 	// respected correctly on any future re-orphaning.
 	if c.grayDeleteGracePeriod > 0 {
-		for _, roleSpec := range spec.Roles {
+		for roleName, roleSpec := range spec.Roles {
 			for groupName := range roleSpec.RoleGroups {
-				resourceName := fmt.Sprintf("%s-%s", clusterName, groupName)
+				resourceName := RoleGroupResourceName(clusterName, roleName, groupName)
 				if err := c.clearGrayDeleteAnnotation(ctx, namespace, resourceName, ownerUID); err != nil {
 					logger.V(1).Info("Failed to clear gray-delete annotation from active resource",
 						"resource", resourceName, "error", err)
@@ -110,7 +110,7 @@ func (c *RoleGroupCleaner) Cleanup(
 
 	for roleName, groups := range orphanedGroups {
 		for _, groupName := range groups {
-			resourceName := fmt.Sprintf("%s-%s", clusterName, groupName)
+			resourceName := RoleGroupResourceName(clusterName, roleName, groupName)
 
 			if err := c.cleanupRoleGroup(ctx, namespace, resourceName, ownerUID, deletePVCs); err != nil {
 				return fmt.Errorf("failed to cleanup role group %s/%s: %w", roleName, groupName, err)

--- a/pkg/reconciler/cleaner_test.go
+++ b/pkg/reconciler/cleaner_test.go
@@ -157,7 +157,7 @@ var _ = Describe("RoleGroupCleaner", func() {
 
 		It("should cleanup orphaned role group resources", func() {
 			// Create resources for an orphaned role group
-			resourceName := "cleanup-test-orphaned"
+			resourceName := reconciler.RoleGroupResourceName("cleanup-test", "test-role", "orphaned")
 
 			// Create ConfigMap
 			cm := &corev1.ConfigMap{
@@ -831,13 +831,13 @@ var _ = Describe("RoleGroupCleaner ownerReference validation", func() {
 		namespace = cleanerTestNamespace
 	})
 
-	// The cleaner constructs resource names as: clusterName + "-" + groupName
+	// The cleaner constructs resource names as: reconciler.RoleGroupResourceName(clusterName, "role", groupName)
 	// Tests must create resources using that naming convention.
 
 	It("should skip deletion when StatefulSet is not owned by the cluster", func() {
 		clusterName := "ownerref-skip"
 		groupName := "grp1"
-		resourceName := clusterName + "-" + groupName // "ownerref-skip-grp1"
+		resourceName := reconciler.RoleGroupResourceName(clusterName, "role", groupName) // "ownerref-skip-grp1"
 
 		sts := &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
@@ -877,7 +877,7 @@ var _ = Describe("RoleGroupCleaner ownerReference validation", func() {
 	It("should delete StatefulSet when ownerUID matches", func() {
 		clusterName := "ownerref-del"
 		groupName := "grp2"
-		resourceName := clusterName + "-" + groupName // "ownerref-del-grp2"
+		resourceName := reconciler.RoleGroupResourceName(clusterName, "role", groupName) // "ownerref-del-grp2"
 		ownerUID := types.UID("test-cluster-uid-456")
 
 		sts := &appsv1.StatefulSet{
@@ -926,7 +926,7 @@ var _ = Describe("RoleGroupCleaner ownerReference validation", func() {
 	It("should skip deletion when ConfigMap is not owned by the cluster", func() {
 		clusterName := "ownerref-cm-skip"
 		groupName := "grp3"
-		resourceName := clusterName + "-" + groupName // "ownerref-cm-skip-grp3"
+		resourceName := reconciler.RoleGroupResourceName(clusterName, "role", groupName) // "ownerref-cm-skip-grp3"
 
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
@@ -958,7 +958,7 @@ var _ = Describe("RoleGroupCleaner ownerReference validation", func() {
 		// When no ownerUID is set, all resources are treated as owned and deleted
 		clusterName := "ownerref-nouid"
 		groupName := "grp4"
-		resourceName := clusterName + "-" + groupName // "ownerref-nouid-grp4"
+		resourceName := reconciler.RoleGroupResourceName(clusterName, "role", groupName) // "ownerref-nouid-grp4"
 
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: namespace},
@@ -993,7 +993,7 @@ var _ = Describe("RoleGroupCleaner gray deletion", func() {
 	It("should annotate resource on first detection and defer deletion", func() {
 		clusterName := "gray-defer"
 		groupName := "grp1"
-		resourceName := clusterName + "-" + groupName
+		resourceName := reconciler.RoleGroupResourceName(clusterName, "role", groupName)
 
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: cleanerTestNamespace},
@@ -1024,7 +1024,7 @@ var _ = Describe("RoleGroupCleaner gray deletion", func() {
 	It("should delete resource after grace period has elapsed", func() {
 		clusterName := "gray-elapsed"
 		groupName := "grp2"
-		resourceName := clusterName + "-" + groupName
+		resourceName := reconciler.RoleGroupResourceName(clusterName, "role", groupName)
 
 		// Create ConfigMap pre-annotated with a past timestamp
 		past := time.Now().UTC().Add(-2 * time.Minute).Format(time.RFC3339)
@@ -1058,7 +1058,7 @@ var _ = Describe("RoleGroupCleaner gray deletion", func() {
 	It("should delete immediately when GrayDeleteGracePeriod is 0", func() {
 		clusterName := "gray-immediate"
 		groupName := "grp3"
-		resourceName := clusterName + "-" + groupName
+		resourceName := reconciler.RoleGroupResourceName(clusterName, "role", groupName)
 
 		cm := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: cleanerTestNamespace},

--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -18,8 +18,11 @@ package reconciler
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	stderrors "errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
@@ -427,12 +430,34 @@ func (r *GenericReconciler[CR]) reconcileRoleGroup(ctx context.Context, cr CR, r
 	return nil
 }
 
+// maxRoleGroupNameLen bounds the role group resource name so that, even with the longest
+// suffix the framework appends ("-headless" = 9 chars), the result stays within the 63-char
+// DNS label limit that applies to Service names and StatefulSet .spec.serviceName.
+const maxRoleGroupNameLen = 54
+
+// RoleGroupResourceName returns the canonical resource name for a role group:
+// "<cluster>-<role>-<group>". Including the role prevents collisions between role groups of
+// different roles that share a group name (e.g. namenode/default vs datanode/default).
+//
+// If the name would exceed maxRoleGroupNameLen, it is deterministically truncated and a short
+// hash suffix is appended to preserve uniqueness while staying within the 63-char DNS limit.
+func RoleGroupResourceName(clusterName, roleName, groupName string) string {
+	name := fmt.Sprintf("%s-%s-%s", clusterName, roleName, groupName)
+	if len(name) <= maxRoleGroupNameLen {
+		return name
+	}
+	sum := sha256.Sum256([]byte(name))
+	suffix := hex.EncodeToString(sum[:])[:8]
+	head := strings.TrimRight(name[:maxRoleGroupNameLen-len(suffix)-1], "-")
+	return head + "-" + suffix
+}
+
 // buildRoleGroupContext creates the build context for a role group.
 func (r *GenericReconciler[CR]) buildRoleGroupContext(cr CR, roleName string, roleSpec *v1alpha1.RoleSpec, groupName string, groupSpec *v1alpha1.RoleGroupSpec) *RoleGroupBuildContext {
 	// Merge configurations
 	mergedConfig := r.configMerger.Merge(roleSpec.GetOverrides(), groupSpec.GetOverrides())
 
-	resourceName := fmt.Sprintf("%s-%s", cr.GetName(), groupName)
+	resourceName := RoleGroupResourceName(cr.GetName(), roleName, groupName)
 
 	return &RoleGroupBuildContext{
 		ClusterName:      cr.GetName(),
@@ -450,10 +475,14 @@ func (r *GenericReconciler[CR]) buildRoleGroupContext(cr CR, roleName string, ro
 
 // buildSidecarManager creates a SidecarManager based on CRD configuration.
 // It reads Logging configuration from Role and RoleGroup specs, merging them
-// to determine which sidecar providers should be registered.
-// Returns nil if no sidecar configuration is found.
+// to determine which built-in sidecar providers should be registered.
+//
+// It ALWAYS returns a non-nil manager (possibly empty). This guarantees products always
+// have a SidecarManager to register their own containers with (e.g. init containers via
+// StaticContainerProvider), so pod container injection always flows through the manager
+// rather than being mutated directly.
 func (r *GenericReconciler[CR]) buildSidecarManager(ctx context.Context, buildCtx *RoleGroupBuildContext) *sidecar.SidecarManager {
-	var mgr *sidecar.SidecarManager
+	mgr := sidecar.NewSidecarManager()
 
 	// Merge Logging config from Role and RoleGroup levels
 	roleLogging := buildCtx.RoleSpec.GetConfig().Logging
@@ -461,13 +490,8 @@ func (r *GenericReconciler[CR]) buildSidecarManager(ctx context.Context, buildCt
 
 	logging := mergeLogging(roleLogging, groupLogging)
 
-	if logging == nil {
-		return nil
-	}
-
 	// Register Vector sidecar if enabled
-	if logging.EnableVectorAgent != nil && *logging.EnableVectorAgent {
-		mgr = sidecar.NewSidecarManager()
+	if logging != nil && logging.EnableVectorAgent != nil && *logging.EnableVectorAgent {
 		mgr.Register(
 			sidecar.NewVectorSidecarProvider(),
 			&sidecar.SidecarConfig{Enabled: true},
@@ -572,7 +596,7 @@ func (r *GenericReconciler[CR]) handleStoppedCluster(ctx context.Context, cr CR)
 	// Scale all role groups to 0
 	for roleName, roleSpec := range spec.Roles {
 		for groupName := range roleSpec.GetRoleGroups() {
-			resourceName := fmt.Sprintf("%s-%s", cr.GetName(), groupName)
+			resourceName := RoleGroupResourceName(cr.GetName(), roleName, groupName)
 			if err := r.scaleToZero(ctx, cr.GetNamespace(), resourceName); err != nil {
 				logger.Error(err, "Failed to scale role group to zero", "role", roleName, "group", groupName)
 				// Continue with other groups

--- a/pkg/reconciler/generic_reconciler_test.go
+++ b/pkg/reconciler/generic_reconciler_test.go
@@ -575,7 +575,7 @@ var _ = Describe("GenericReconciler Integration Tests", func() {
 
 			// Verify ConfigMap was created
 			cm := &corev1.ConfigMap{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: crName + "-default"}, cm)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: reconciler.RoleGroupResourceName(crName, "test-role", "default")}, cm)).To(Succeed())
 		})
 
 		It("should create Service during reconciliation", func() {
@@ -586,7 +586,7 @@ var _ = Describe("GenericReconciler Integration Tests", func() {
 
 			// Verify Service was created
 			svc := &corev1.Service{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: crName + "-default"}, svc)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: reconciler.RoleGroupResourceName(crName, "test-role", "default")}, svc)).To(Succeed())
 		})
 
 		It("should create StatefulSet during reconciliation", func() {
@@ -597,7 +597,7 @@ var _ = Describe("GenericReconciler Integration Tests", func() {
 
 			// Verify StatefulSet was created
 			sts := &appsv1.StatefulSet{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: crName + "-default"}, sts)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: reconciler.RoleGroupResourceName(crName, "test-role", "default")}, sts)).To(Succeed())
 		})
 
 		It("should track role group in status", func() {
@@ -790,7 +790,7 @@ var _ = Describe("GenericReconciler Integration Tests", func() {
 
 			// Verify only one StatefulSet exists (by direct name lookup)
 			sts := &appsv1.StatefulSet{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: crName + "-default"}, sts)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: reconciler.RoleGroupResourceName(crName, "test-role", "default")}, sts)).To(Succeed())
 		})
 	})
 
@@ -837,7 +837,7 @@ var _ = Describe("GenericReconciler Integration Tests", func() {
 
 			// Verify custom image was used
 			sts := &appsv1.StatefulSet{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: crName + "-default"}, sts)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: reconciler.RoleGroupResourceName(crName, "test-role", "default")}, sts)).To(Succeed())
 			Expect(sts.Spec.Template.Spec.Containers[0].Image).To(Equal("custom-image:v1"))
 			Expect(sts.Spec.Template.Spec.Containers[0].ImagePullPolicy).To(Equal(corev1.PullAlways))
 		})
@@ -897,7 +897,7 @@ var _ = Describe("GenericReconciler scaleToZero", func() {
 		replicas := int32(3)
 		sts := &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      crName + "-default",
+				Name:      reconciler.RoleGroupResourceName(crName, "test-role", "default"),
 				Namespace: namespace,
 			},
 			Spec: appsv1.StatefulSetSpec{
@@ -1150,5 +1150,20 @@ var _ = Describe("GenericReconciler cleanupRoleGroup errors", func() {
 
 		// Cleanup - may or may not error depending on timing
 		_ = cleaner.Cleanup(canceledCtx, namespace, "cleanup-error", spec, status, "", nil)
+	})
+})
+
+var _ = Describe("RoleGroupResourceName", func() {
+	It("joins cluster, role and group", func() {
+		Expect(reconciler.RoleGroupResourceName("zk", "server", "default")).To(Equal("zk-server-default"))
+	})
+
+	It("truncates with a deterministic hash suffix within the 63-char DNS limit (incl -headless)", func() {
+		longCluster := "this-is-a-very-long-zookeeper-cluster-name-that-overflows"
+		name := reconciler.RoleGroupResourceName(longCluster, "server", "default")
+		Expect(len(name)).To(BeNumerically("<=", 54))
+		Expect(len(name + "-headless")).To(BeNumerically("<=", 63))
+		// Deterministic: same inputs yield the same truncated name.
+		Expect(reconciler.RoleGroupResourceName(longCluster, "server", "default")).To(Equal(name))
 	})
 })

--- a/pkg/reconciler/health.go
+++ b/pkg/reconciler/health.go
@@ -86,7 +86,7 @@ func (h *HealthManager) Check(ctx context.Context, namespace, clusterName string
 
 	for roleName, roleSpec := range spec.Roles {
 		for groupName, groupSpec := range roleSpec.RoleGroups {
-			resourceName := fmt.Sprintf("%s-%s", clusterName, groupName)
+			resourceName := RoleGroupResourceName(clusterName, roleName, groupName)
 			healthy, available, isProgressing, err := h.checkRoleGroupHealth(ctx, namespace, resourceName, groupSpec.GetReplicas())
 			if err != nil {
 				logger.Error(err, "Failed to check role group health", "role", roleName, "group", groupName)

--- a/pkg/reconciler/health_test.go
+++ b/pkg/reconciler/health_test.go
@@ -318,7 +318,7 @@ var _ = Describe("HealthManager with StatefulSet", func() {
 			replicas := int32(2)
 			sts := &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "health-test-available",
+					Name:      reconciler.RoleGroupResourceName("health-test", "test-role", "available"),
 					Namespace: namespace,
 				},
 				Spec: appsv1.StatefulSetSpec{
@@ -373,7 +373,7 @@ var _ = Describe("HealthManager with StatefulSet", func() {
 			replicas := int32(2)
 			sts := &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "health-test-progressing",
+					Name:      reconciler.RoleGroupResourceName("health-test", "test-role", "progressing"),
 					Namespace: namespace,
 				},
 				Spec: appsv1.StatefulSetSpec{

--- a/pkg/reconciler/role_group_handler.go
+++ b/pkg/reconciler/role_group_handler.go
@@ -84,9 +84,11 @@ type RoleGroupBuildContext struct {
 	// ResourceName is the derived resource name: {cluster}-{group}.
 	ResourceName string
 
-	// SidecarManager is the auto-created sidecar manager based on CRD configuration.
-	// Set by GenericReconciler when sidecar-related config (e.g., EnableVectorAgent) is detected.
-	// Nil if no sidecars are configured.
+	// SidecarManager is the sidecar manager for this role group, always set (non-nil) by
+	// GenericReconciler. Built-in sidecars (e.g. Vector when EnableVectorAgent is set) are
+	// pre-registered; products register their own containers (e.g. init containers via
+	// sidecar.StaticContainerProvider) and call InjectAll so all pod container injection
+	// flows through the manager. May be empty if nothing is configured.
 	SidecarManager *sidecar.SidecarManager
 }
 

--- a/pkg/security/secret_provisioner.go
+++ b/pkg/security/secret_provisioner.go
@@ -30,6 +30,9 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+// defaultSecretStorageSize is the default PVC storage request for secret volumes.
+const defaultSecretStorageSize = "10Mi"
+
 // SecretVolumeRegistration declares a CSI secret volume need.
 // Created via convenience constructors (TLS, Kerberos) or Custom builder.
 type SecretVolumeRegistration struct {
@@ -58,7 +61,7 @@ func TLS(volumeName, secretClass string) *SecretVolumeRegistration {
 		format:      TLSP12,
 		scope:       string(PodScope) + CommonDelimiter + string(NodeScope),
 		password:    "changeit",
-		storageSize: "10Mi",
+		storageSize: defaultSecretStorageSize,
 	}
 }
 
@@ -69,7 +72,7 @@ func TLSPEMFormat(volumeName, secretClass string) *SecretVolumeRegistration {
 		secretClass: secretClass,
 		format:      TLSPEM,
 		scope:       string(PodScope) + CommonDelimiter + string(NodeScope),
-		storageSize: "10Mi",
+		storageSize: defaultSecretStorageSize,
 	}
 }
 
@@ -86,7 +89,7 @@ func KerberosVolume(volumeName, secretClass, serviceName string, additionalServi
 		secretClass:      secretClass,
 		format:           Kerberos,
 		scope:            string(PodScope) + CommonDelimiter + string(NodeScope),
-		storageSize:      "10Mi",
+		storageSize:      defaultSecretStorageSize,
 		kerberosSvcNames: svcNames,
 	}
 }
@@ -103,7 +106,7 @@ func ServiceTLS(volumeName, secretClass, serviceName string) *SecretVolumeRegist
 		format:      TLSP12,
 		scope:       string(PodScope) + CommonDelimiter + string(NodeScope) + CommonDelimiter + "service=" + serviceName,
 		password:    "changeit",
-		storageSize: "10Mi",
+		storageSize: defaultSecretStorageSize,
 	}
 }
 
@@ -115,7 +118,7 @@ func ListenerVolume(volumeName, secretClass string, format SecretFormat) *Secret
 		secretClass: secretClass,
 		format:      format,
 		scope:       string(ListenerVolumeScope),
-		storageSize: "10Mi",
+		storageSize: defaultSecretStorageSize,
 	}
 }
 
@@ -126,7 +129,7 @@ func Custom(volumeName, secretClass string, format SecretFormat) *SecretVolumeRe
 		secretClass: secretClass,
 		format:      format,
 		scope:       string(PodScope) + CommonDelimiter + string(NodeScope),
-		storageSize: "10Mi",
+		storageSize: defaultSecretStorageSize,
 	}
 }
 

--- a/pkg/sidecar/jmx_exporter.go
+++ b/pkg/sidecar/jmx_exporter.go
@@ -165,8 +165,10 @@ func (p *JMXExporterSidecarProvider) Inject(podSpec *corev1.PodSpec, config *Sid
 		AddVolumeMounts(container, config.VolumeMounts)
 	}
 
-	// Add container to pod (idempotent — replace if exists)
-	AddOrReplaceContainer(podSpec, container)
+	// JMX Exporter is a long-running sidecar: inject it as a native sidecar (init container
+	// with restartPolicy: Always).
+	container.RestartPolicy = SidecarRestartPolicy()
+	addOrReplaceInitContainer(podSpec, container)
 
 	// Add required volumes if not present
 	volumes := []corev1.Volume{

--- a/pkg/sidecar/jmx_exporter_test.go
+++ b/pkg/sidecar/jmx_exporter_test.go
@@ -73,8 +73,8 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 			config := &sidecar.SidecarConfig{Enabled: true, Image: testImage}
 			err := provider.Inject(podSpec, config)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(podSpec.Containers).To(HaveLen(2))
-			Expect(podSpec.Containers[1].Name).To(Equal(sidecar.JMXExporterSidecarName))
+			Expect(podSpec.InitContainers).To(HaveLen(1))
+			Expect(podSpec.InitContainers[0].Name).To(Equal(sidecar.JMXExporterSidecarName))
 		})
 
 		It("should return error when image is not specified", func() {
@@ -91,14 +91,14 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 			}
 			err := provider.Inject(podSpec, config)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(podSpec.Containers[1].Image).To(Equal("custom/jmx-exporter:latest"))
+			Expect(podSpec.InitContainers[0].Image).To(Equal("custom/jmx-exporter:latest"))
 		})
 
 		It("should use default port", func() {
 			config := &sidecar.SidecarConfig{Enabled: true, Image: testImage}
 			err := provider.Inject(podSpec, config)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(podSpec.Containers[1].Ports[0].ContainerPort).To(Equal(int32(sidecar.JMXExporterPort)))
+			Expect(podSpec.InitContainers[0].Ports[0].ContainerPort).To(Equal(int32(sidecar.JMXExporterPort)))
 		})
 
 		It("should use custom port from provider", func() {
@@ -106,7 +106,7 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 			config := &sidecar.SidecarConfig{Enabled: true, Image: testImage}
 			err := provider.Inject(podSpec, config)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(podSpec.Containers[1].Ports[0].ContainerPort).To(Equal(int32(9999)))
+			Expect(podSpec.InitContainers[0].Ports[0].ContainerPort).To(Equal(int32(9999)))
 		})
 
 		It("should use custom port from config", func() {
@@ -119,7 +119,7 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 			}
 			err := provider.Inject(podSpec, config)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(podSpec.Containers[1].Ports[0].ContainerPort).To(Equal(int32(8888)))
+			Expect(podSpec.InitContainers[0].Ports[0].ContainerPort).To(Equal(int32(8888)))
 		})
 
 		It("should add config volume mount", func() {
@@ -127,7 +127,7 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 			err := provider.Inject(podSpec, config)
 			Expect(err).NotTo(HaveOccurred())
 
-			volumeMounts := podSpec.Containers[1].VolumeMounts
+			volumeMounts := podSpec.InitContainers[0].VolumeMounts
 			Expect(volumeMounts).NotTo(BeEmpty())
 			Expect(volumeMounts[0].Name).To(Equal(sidecar.JMXExporterConfigVolumeName))
 			Expect(volumeMounts[0].MountPath).To(Equal(sidecar.JMXExporterConfigMountPath))
@@ -157,7 +157,7 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 			err := provider.Inject(podSpec, config)
 			Expect(err).NotTo(HaveOccurred())
 
-			probe := podSpec.Containers[1].ReadinessProbe
+			probe := podSpec.InitContainers[0].ReadinessProbe
 			Expect(probe).NotTo(BeNil())
 			Expect(probe.HTTPGet).NotTo(BeNil())
 			Expect(probe.HTTPGet.Path).To(Equal("/metrics"))
@@ -178,7 +178,7 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 			err := provider.Inject(podSpec, config)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(podSpec.Containers[1].Resources.Limits).To(HaveKey(corev1.ResourceCPU))
+			Expect(podSpec.InitContainers[0].Resources.Limits).To(HaveKey(corev1.ResourceCPU))
 		})
 
 		It("should apply custom environment variables", func() {
@@ -192,7 +192,7 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 			err := provider.Inject(podSpec, config)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(podSpec.Containers[1].Env).NotTo(BeEmpty())
+			Expect(podSpec.InitContainers[0].Env).NotTo(BeEmpty())
 		})
 
 		It("should apply custom volume mounts", func() {
@@ -208,7 +208,7 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			var found bool
-			for _, m := range podSpec.Containers[1].VolumeMounts {
+			for _, m := range podSpec.InitContainers[0].VolumeMounts {
 				if m.Name == "custom" {
 					found = true
 					break
@@ -231,8 +231,8 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 			err := provider.Inject(podSpec, config)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(podSpec.Containers[1].SecurityContext).NotTo(BeNil())
-			Expect(*podSpec.Containers[1].SecurityContext.RunAsNonRoot).To(BeTrue())
+			Expect(podSpec.InitContainers[0].SecurityContext).NotTo(BeNil())
+			Expect(*podSpec.InitContainers[0].SecurityContext.RunAsNonRoot).To(BeTrue())
 		})
 
 		It("should apply custom image pull policy when provided", func() {
@@ -244,7 +244,7 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 			err := provider.Inject(podSpec, config)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(podSpec.Containers[1].ImagePullPolicy).To(Equal(corev1.PullAlways))
+			Expect(podSpec.InitContainers[0].ImagePullPolicy).To(Equal(corev1.PullAlways))
 		})
 
 		It("should use default pull policy when not specified", func() {
@@ -252,7 +252,7 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 			err := provider.Inject(podSpec, config)
 			Expect(err).NotTo(HaveOccurred())
 
-			Expect(podSpec.Containers[1].ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
+			Expect(podSpec.InitContainers[0].ImagePullPolicy).To(Equal(corev1.PullIfNotPresent))
 		})
 
 		It("should return error with nil config", func() {
@@ -265,18 +265,18 @@ var _ = Describe("JMXExporterSidecarProvider", func() {
 			config := &sidecar.SidecarConfig{Enabled: true, Image: testImage}
 			err := provider.Inject(podSpec, config)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(podSpec.Containers).To(HaveLen(2))
+			Expect(podSpec.InitContainers).To(HaveLen(1))
 
 			// Inject again
 			err = provider.Inject(podSpec, config)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Should still have 2 containers (main + jmx-exporter), not 3
-			Expect(podSpec.Containers).To(HaveLen(2))
+			Expect(podSpec.InitContainers).To(HaveLen(1))
 
 			// Count jmx-exporter containers
 			jmxCount := 0
-			for _, c := range podSpec.Containers {
+			for _, c := range podSpec.InitContainers {
 				if c.Name == sidecar.JMXExporterSidecarName {
 					jmxCount++
 				}

--- a/pkg/sidecar/manager.go
+++ b/pkg/sidecar/manager.go
@@ -309,6 +309,76 @@ func AddOrReplaceContainer(podSpec *corev1.PodSpec, container *corev1.Container)
 	podSpec.Containers = append(podSpec.Containers, *container)
 }
 
+// FindInitContainerIndex returns the index of an init container by name, or -1 if not found.
+func FindInitContainerIndex(podSpec *corev1.PodSpec, name string) int {
+	for i := range podSpec.InitContainers {
+		if podSpec.InitContainers[i].Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+// addOrReplaceInitContainer finds an existing init container by name or appends a new one.
+//
+// It is intentionally unexported: under the native-sidecar model the SidecarManager is the
+// single owner of pod container injection. Providers (Vector, JMX, StaticContainerProvider)
+// use this from their Inject methods; products must NOT mutate the pod directly — they
+// register a provider and let InjectAll place containers, so the Enabled gating, ordering
+// and deduplication of the manager always apply.
+//
+// All managed containers go into podSpec.InitContainers: a long-running sidecar is simply
+// an init container whose RestartPolicy is Always (see SidecarRestartPolicy); a one-shot
+// init (e.g. node-id generation) has a nil RestartPolicy. This relies on the kubelet's
+// native sidecar semantics (Kubernetes 1.28+) for startup and shutdown ordering.
+func addOrReplaceInitContainer(podSpec *corev1.PodSpec, container *corev1.Container) {
+	if idx := FindInitContainerIndex(podSpec, container.Name); idx >= 0 {
+		podSpec.InitContainers[idx] = *container
+		return
+	}
+	podSpec.InitContainers = append(podSpec.InitContainers, *container)
+}
+
+// SidecarRestartPolicy returns the RestartPolicy that turns an init container into a native
+// sidecar (Kubernetes 1.28+): the kubelet starts it before the main container, keeps it
+// running alongside, and terminates it only after the main container exits. Set this on a
+// container's RestartPolicy before registering it (e.g. via StaticContainerProvider) to
+// make it a long-running sidecar instead of a one-shot init container.
+func SidecarRestartPolicy() *corev1.ContainerRestartPolicy {
+	policy := corev1.ContainerRestartPolicyAlways
+	return &policy
+}
+
+// StaticContainerProvider injects a fixed, product-supplied container into InitContainers.
+// It is the simplest way to register a bespoke container — whether a one-shot init (e.g.
+// node-id generation, RestartPolicy nil) or a sidecar (RestartPolicy set via
+// SidecarRestartPolicy) — so it flows through the SidecarManager like any other.
+type StaticContainerProvider struct {
+	container corev1.Container
+}
+
+var _ SidecarProvider = &StaticContainerProvider{}
+
+// NewStaticContainerProvider creates a provider that injects the given container verbatim.
+// The provider name is the container name. Set container.RestartPolicy to make it a sidecar.
+func NewStaticContainerProvider(container corev1.Container) *StaticContainerProvider {
+	return &StaticContainerProvider{container: container}
+}
+
+// Name returns the container name.
+func (p *StaticContainerProvider) Name() string { return p.container.Name }
+
+// Inject adds a copy of the static container to InitContainers.
+func (p *StaticContainerProvider) Inject(podSpec *corev1.PodSpec, _ *SidecarConfig) error {
+	addOrReplaceInitContainer(podSpec, p.container.DeepCopy())
+	return nil
+}
+
+// Validate has no dependencies for a static container.
+func (p *StaticContainerProvider) Validate(_ context.Context, _ client.Client, _ string) error {
+	return nil
+}
+
 // FindMainContainer finds the main container for shared volume mounting.
 // Uses MainContainerName from config if set, otherwise defaults to the first container.
 func FindMainContainer(podSpec *corev1.PodSpec, mainContainerName string) *corev1.Container {

--- a/pkg/sidecar/manager_test.go
+++ b/pkg/sidecar/manager_test.go
@@ -685,3 +685,53 @@ func (p *mockSidecarProvider) Inject(podSpec *corev1.PodSpec, config *sidecar.Si
 func (p *mockSidecarProvider) Validate(ctx context.Context, c client.Client, namespace string) error {
 	return nil
 }
+
+var _ = Describe("Native-sidecar container injection", func() {
+	var podSpec *corev1.PodSpec
+
+	BeforeEach(func() {
+		podSpec = &corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "main"}},
+		}
+	})
+
+	Describe("SidecarRestartPolicy", func() {
+		It("returns the Always restart policy that marks a native sidecar", func() {
+			Expect(*sidecar.SidecarRestartPolicy()).To(Equal(corev1.ContainerRestartPolicyAlways))
+		})
+	})
+
+	// Container placement is only reachable through the manager/providers — products cannot
+	// mutate the pod directly — so it is exercised via StaticContainerProvider.
+	Describe("StaticContainerProvider", func() {
+		It("injects a one-shot init container (nil RestartPolicy) into InitContainers", func() {
+			provider := sidecar.NewStaticContainerProvider(corev1.Container{Name: "prepare", Image: "img:1"})
+			Expect(provider.Name()).To(Equal("prepare"))
+			Expect(provider.Inject(podSpec, &sidecar.SidecarConfig{Enabled: true})).To(Succeed())
+			Expect(podSpec.InitContainers).To(HaveLen(1))
+			Expect(podSpec.InitContainers[0].Name).To(Equal("prepare"))
+			Expect(podSpec.InitContainers[0].RestartPolicy).To(BeNil())
+			// Never placed as a regular container under the native-sidecar model.
+			Expect(podSpec.Containers).To(HaveLen(1))
+		})
+
+		It("injects a sidecar (RestartPolicy Always) into InitContainers", func() {
+			provider := sidecar.NewStaticContainerProvider(corev1.Container{
+				Name:          "aux",
+				RestartPolicy: sidecar.SidecarRestartPolicy(),
+			})
+			Expect(provider.Inject(podSpec, &sidecar.SidecarConfig{Enabled: true})).To(Succeed())
+			Expect(podSpec.InitContainers).To(HaveLen(1))
+			Expect(*podSpec.InitContainers[0].RestartPolicy).To(Equal(corev1.ContainerRestartPolicyAlways))
+		})
+
+		It("deduplicates by container name on repeated injection", func() {
+			p1 := sidecar.NewStaticContainerProvider(corev1.Container{Name: "prepare", Image: "v1"})
+			p2 := sidecar.NewStaticContainerProvider(corev1.Container{Name: "prepare", Image: "v2"})
+			Expect(p1.Inject(podSpec, &sidecar.SidecarConfig{Enabled: true})).To(Succeed())
+			Expect(p2.Inject(podSpec, &sidecar.SidecarConfig{Enabled: true})).To(Succeed())
+			Expect(podSpec.InitContainers).To(HaveLen(1))
+			Expect(podSpec.InitContainers[0].Image).To(Equal("v2"))
+		})
+	})
+})

--- a/pkg/sidecar/vector.go
+++ b/pkg/sidecar/vector.go
@@ -139,8 +139,11 @@ func (p *VectorSidecarProvider) Inject(podSpec *corev1.PodSpec, config *SidecarC
 		AddVolumeMounts(container, config.VolumeMounts)
 	}
 
-	// Add container to pod (idempotent — replace if exists)
-	AddOrReplaceContainer(podSpec, container)
+	// Vector is a long-running sidecar: inject it as a native sidecar (init container with
+	// restartPolicy: Always) so the kubelet keeps it running until the main container exits,
+	// guaranteeing logs are shipped through shutdown.
+	container.RestartPolicy = SidecarRestartPolicy()
+	addOrReplaceInitContainer(podSpec, container)
 
 	// Add required volumes if not present
 	volumes := []corev1.Volume{

--- a/pkg/sidecar/vector_test.go
+++ b/pkg/sidecar/vector_test.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sidecar_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/zncdatadev/operator-go/pkg/sidecar"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("VectorSidecarProvider", func() {
+	It("always injects Vector as a native sidecar (init container, restartPolicy Always)", func() {
+		podSpec := &corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}}
+		provider := sidecar.NewVectorSidecarProvider()
+
+		Expect(provider.Inject(podSpec, &sidecar.SidecarConfig{Enabled: true, Image: "vector:1"})).To(Succeed())
+
+		idx := sidecar.FindInitContainerIndex(podSpec, "vector")
+		Expect(idx).To(BeNumerically(">=", 0))
+		Expect(podSpec.InitContainers[idx].RestartPolicy).NotTo(BeNil())
+		Expect(*podSpec.InitContainers[idx].RestartPolicy).To(Equal(corev1.ContainerRestartPolicyAlways))
+		// Never placed as a regular container.
+		Expect(sidecar.FindContainer(podSpec, "vector")).To(BeNil())
+	})
+})

--- a/pkg/testutil/matchers.go
+++ b/pkg/testutil/matchers.go
@@ -89,7 +89,7 @@ func (m *haveOwnerReferenceMatcher) Match(actual interface{}) (bool, error) {
 				}
 			}()
 			val := reflect.ValueOf(obj)
-			if val.Kind() == reflect.Ptr {
+			if val.Kind() == reflect.Pointer {
 				val = val.Elem()
 			}
 
@@ -216,7 +216,7 @@ type haveReplicasMatcher struct {
 
 func (m *haveReplicasMatcher) Match(actual interface{}) (bool, error) {
 	val := reflect.ValueOf(actual)
-	if val.Kind() == reflect.Ptr {
+	if val.Kind() == reflect.Pointer {
 		val = val.Elem()
 	}
 

--- a/pkg/vector/config.go
+++ b/pkg/vector/config.go
@@ -53,7 +53,7 @@ func RenderVectorConfig(data VectorConfigData) (string, error) {
 		return "", fmt.Errorf("LogDir is required")
 	}
 
-	tmpl, err := template.New("vector").Funcs(template.FuncMap{
+	tmpl, err := template.New(VectorSidecarName).Funcs(template.FuncMap{
 		"APIPort": func() int { return VectorAPIPort },
 	}).Parse(vectorConfigTemplate)
 	if err != nil {

--- a/pkg/vector/provider.go
+++ b/pkg/vector/provider.go
@@ -108,7 +108,7 @@ func (p *VectorSidecarProvider) Inject(podSpec *corev1.PodSpec, config *sidecar.
 		Image:           image,
 		ImagePullPolicy: pullPolicy,
 		Command: []string{
-			"vector",
+			VectorSidecarName,
 			"--config",
 			VectorConfigMountPath + "/" + VectorConfigFileName,
 		},


### PR DESCRIPTION
## Summary

Framework enhancements that let product operators (e.g. zookeeper) build resources idiomatically through `BaseRoleGroupHandler` instead of hand-rolling raw objects, plus correctness fixes to labels, sidecar injection and resource naming.

### `BaseRoleGroupHandler`
- Opt-in data PVC via `WithStorage` (`StorageMountPath`) — the base previously called `WithResources` but never built the PVC.
- `PublishNotReadyAddresses` knob for the headless Service (required by quorum systems).
- Product-owned **identity labels** via `LabelDomain` → `<domain>/{cluster,role,role-group}`, used for **all resource selectors** and decoupled from the descriptive `app.kubernetes.io/*` labels. This keeps the immutable StatefulSet selector stable and product-isolated (a product-domain prefix can never match another product's pods). Backward compatible: when `LabelDomain` is empty, selectors fall back to the descriptive labels.

### `StatefulSetBuilder`
- Init containers (`AddInitContainer`/`WithInitContainers`), `WithCommand`/`WithArgs`.
- `WithSelectorLabels` so the immutable `.spec.selector` can use a stable subset.

### Sidecar — unify on the native-sidecar model
- All manager-injected containers go into `InitContainers`; `restartPolicy: Always` (`SidecarRestartPolicy`) marks long-running sidecars (K8s 1.28+ native sidecars). Vector/JMX default to native sidecars (fixes shutdown ordering).
- `StaticContainerProvider` lets products inject one-shot init containers (e.g. node-id generation) **through the manager**, keeping `InitContainers` under a single writer.
- The mutation primitive is unexported so products cannot bypass the manager.

### Config / builders
- `config.GenerateLogbackWithOptions` adds a bounded rolling **file appender** so the Vector source actually has files to collect.
- `MetricsServiceBuilder.WithSelector` for a dedicated selector.

### Resource naming
- `RoleGroupResourceName` → `"<cluster>-<role>-<group>"` (was `"<cluster>-<group>"`), preventing collisions between role groups of different roles that share a group name (e.g. namenode/default vs datanode/default). Includes deterministic truncation + hash suffix to respect the 63-char DNS label limit. Applied consistently across reconcile, cleanup, health and scale-to-zero.

## Compatibility
- `LabelDomain` and `StorageMountPath` are opt-in; existing products are unaffected unless they set them.
- The native-sidecar model requires **Kubernetes ≥ 1.28**.
- The resource-name change is a **breaking change** for already-deployed resources (names gain the role segment).

## Testing
`go test ./...` passes, including new tests for identity-label selectors, native-sidecar placement, the logback file appender, and `RoleGroupResourceName` truncation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)