### PR TITLE
fix(reconciler): bind auto-created ServiceAccount to workload pods

### DIFF
--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -408,6 +408,13 @@ func (h *BaseRoleGroupHandler[CR]) buildStatefulSet(
 		WithConfig(buildCtx.MergedConfig).
 		WithPorts(h.containerPorts(buildCtx.RoleName, buildCtx.RoleGroupName))
 
+	// Bind the reconciler-managed ServiceAccount to the pod template when configured, so the
+	// created SA is actually used. Empty leaves ServiceAccountName unset (pods use the namespace
+	// default SA), preserving backward compatibility.
+	if buildCtx.ServiceAccountName != "" {
+		stsBuilder.WithServiceAccount(buildCtx.ServiceAccountName)
+	}
+
 	// Set resources if configured
 	roleGroupConfig := buildCtx.RoleGroupSpec.GetConfig()
 	if roleGroupConfig != nil && roleGroupConfig.Resources != nil {

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -459,6 +459,22 @@ var _ = Describe("StatefulSet building", func() {
 		Expect(containers[0].Image).To(Equal("test-image:latest"))
 	})
 
+	It("should bind the ServiceAccount to the pod template when configured", func() {
+		buildCtx.ServiceAccountName = "test-cluster-sa"
+		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.StatefulSet.Spec.Template.Spec.ServiceAccountName).To(Equal("test-cluster-sa"))
+	})
+
+	It("should leave ServiceAccountName unset when not configured", func() {
+		// buildCtx.ServiceAccountName defaults to "" — backward compatible: pods use the
+		// namespace default SA, the pod template ServiceAccountName must stay empty.
+		Expect(buildCtx.ServiceAccountName).To(BeEmpty())
+		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.StatefulSet.Spec.Template.Spec.ServiceAccountName).To(BeEmpty())
+	})
+
 	It("should add config volume when config files present", func() {
 		buildCtx.MergedConfig = &config.MergedConfig{
 			ConfigFiles: map[string]map[string]string{

--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -474,6 +474,9 @@ func (r *GenericReconciler[CR]) buildRoleGroupContext(cr CR, roleName string, ro
 		RoleGroupSpec:    *groupSpec,
 		MergedConfig:     mergedConfig,
 		ResourceName:     resourceName,
+		// Propagate the reconciler-managed ServiceAccount so the workload pods actually run as
+		// the SA the reconciler creates. Empty when no SA is configured (backward compatible).
+		ServiceAccountName: r.serviceAccountName,
 	}
 }
 

--- a/pkg/reconciler/role_group_handler.go
+++ b/pkg/reconciler/role_group_handler.go
@@ -85,6 +85,13 @@ type RoleGroupBuildContext struct {
 	// ResourceName is the derived resource name: {cluster}-{group}.
 	ResourceName string
 
+	// ServiceAccountName is the name of the ServiceAccount the workload pods should run as.
+	// It is populated by GenericReconciler from its configured ServiceAccountName (the SA the
+	// reconciler auto-creates). When non-empty, the base StatefulSet builder binds it to the
+	// pod template via WithServiceAccount, so the created SA is actually used. Empty means no
+	// binding — pods fall back to the namespace default SA (backward compatible).
+	ServiceAccountName string
+
 	// SidecarManager is the sidecar manager for this role group, always set (non-nil) by
 	// GenericReconciler. Built-in sidecars (e.g. Vector when EnableVectorAgent is set) are
 	// pre-registered; products register their own containers (e.g. init containers via


### PR DESCRIPTION
## The bug

`GenericReconciler` creates (and `Owns`) a `ServiceAccount` when `ServiceAccountName` is configured (`pkg/reconciler/generic_reconciler.go`: `ensureServiceAccount`), but it **never binds that SA to the workload pod template**. The `StatefulSetBuilder` already supports binding (`ServiceAccountName` field + `WithServiceAccount`, written into the built pod spec), but `base_role_group_handler.buildStatefulSet` never called it, and `RoleGroupBuildContext` had no field to carry the name.

As a result the auto-created SA was unused: pods ran as the namespace `default` ServiceAccount unless the product manually set `podSpec.ServiceAccountName` as a workaround.

## The fix

Minimal and backward-compatible — wire the reconciler-managed SA through to the pod template:

- Add a `ServiceAccountName string` field to `RoleGroupBuildContext`.
- Populate it in `GenericReconciler.buildRoleGroupContext` from `r.serviceAccountName`.
- In `base_role_group_handler.buildStatefulSet`, call `stsBuilder.WithServiceAccount(buildCtx.ServiceAccountName)` **only when non-empty**.

An empty name changes nothing, so existing operators that don't configure a SA are unaffected (pods still use the namespace default SA).

## Tests

Extended `pkg/reconciler/base_role_group_handler_test.go` ("StatefulSet building"):
- asserts the built StatefulSet's pod template has the expected `ServiceAccountName` when configured;
- asserts it stays unset when not configured (backward-compatibility guard).

## Note for products

Once merged, product operators that currently set `podSpec.ServiceAccountName` manually to match the reconciler-created SA can drop that workaround — the framework now binds it automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)