### PR TITLE
feat(sidecar): mount shared log volume into Vector at KubedoopLogDir

### DIFF
--- a/pkg/sidecar/vector.go
+++ b/pkg/sidecar/vector.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/zncdatadev/operator-go/pkg/constant"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -31,20 +32,30 @@ const (
 	VectorConfigVolumeName = "vector-config"
 	// VectorDataVolumeName is the name of the data volume.
 	VectorDataVolumeName = "vector-data"
-	// VectorLogVolumeName is the name of the shared log volume.
-	VectorLogVolumeName = "vector-logs"
+	// VectorLogVolumeName is the default name of the shared log volume that carries the
+	// product's application logs from the main container into the Vector sidecar.
+	//
+	// Convention: the product writes its logs (e.g. "<container>.stdout.log") to a volume
+	// mounted at constant.KubedoopLogDir on the main container, and the framework mounts the
+	// SAME volume read-only into the Vector container at the same path, so Vector's glob
+	// "<KubedoopLogDir>/*.stdout.log" sees the files. By default the framework creates this
+	// volume as an emptyDir; use WithLogVolume to instead reuse a product-supplied volume.
+	VectorLogVolumeName = "log"
 	// VectorConfigMountPath is the mount path for Vector config.
 	VectorConfigMountPath = "/etc/vector"
 	// VectorDataMountPath is the mount path for Vector data.
 	VectorDataMountPath = "/var/lib/vector"
-	// VectorLogMountPath is the mount path for shared logs.
-	VectorLogMountPath = "/var/log/vector"
+	// VectorLogMountPath is the mount path of the shared product log volume in both the main
+	// container and the Vector sidecar. It is the canonical Kubedoop log directory, matching
+	// where products write logs and where the Vector config globs for log files.
+	VectorLogMountPath = constant.KubedoopLogDir
 )
 
 // VectorSidecarProvider injects the Vector log collection sidecar.
 type VectorSidecarProvider struct {
 	name          string
 	configMapName string
+	logVolumeName string
 }
 
 // NewVectorSidecarProvider creates a new VectorSidecarProvider.
@@ -52,12 +63,28 @@ func NewVectorSidecarProvider() *VectorSidecarProvider {
 	return &VectorSidecarProvider{
 		name:          VectorSidecarName,
 		configMapName: "vector-config",
+		logVolumeName: VectorLogVolumeName,
 	}
 }
 
 // WithConfigMapName sets a custom ConfigMap name for the Vector configuration.
 func (p *VectorSidecarProvider) WithConfigMapName(name string) *VectorSidecarProvider {
 	p.configMapName = name
+	return p
+}
+
+// WithLogVolume points the provider at a product-supplied log volume instead of the default
+// framework-managed emptyDir.
+//
+// When set, the provider mounts the named volume read-only into the Vector container at
+// constant.KubedoopLogDir and does NOT create its own emptyDir for it; the product owns the
+// volume's declaration (and its main-container mount at constant.KubedoopLogDir). This lets a
+// product that already writes logs to its own volume — e.g. a size-limited emptyDir — have
+// Vector read them automatically, without hand-wiring a VolumeMount onto the Vector container.
+func (p *VectorSidecarProvider) WithLogVolume(name string) *VectorSidecarProvider {
+	if name != "" {
+		p.logVolumeName = name
+	}
 	return p
 }
 
@@ -112,8 +139,11 @@ func (p *VectorSidecarProvider) Inject(podSpec *corev1.PodSpec, config *SidecarC
 				Name:      VectorDataVolumeName,
 				MountPath: VectorDataMountPath,
 			},
+			// Mount the shared product log volume read-only so Vector can read the files the
+			// main container writes to constant.KubedoopLogDir. This removes the need for each
+			// product to hand-wire the log mount onto the Vector container.
 			{
-				Name:      VectorLogVolumeName,
+				Name:      p.logVolumeName,
 				MountPath: VectorLogMountPath,
 				ReadOnly:  true,
 			},
@@ -145,7 +175,7 @@ func (p *VectorSidecarProvider) Inject(podSpec *corev1.PodSpec, config *SidecarC
 	container.RestartPolicy = SidecarRestartPolicy()
 	addOrReplaceInitContainer(podSpec, container)
 
-	// Add required volumes if not present
+	// Add required volumes if not present.
 	volumes := []corev1.Volume{
 		{
 			Name: VectorConfigVolumeName,
@@ -163,17 +193,26 @@ func (p *VectorSidecarProvider) Inject(podSpec *corev1.PodSpec, config *SidecarC
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
 		},
-		{
+	}
+
+	// The log volume is only framework-managed when using the default name. When the product
+	// supplies its own log volume via WithLogVolume, it owns the volume declaration, so we do
+	// not create an emptyDir for it (AddVolumes dedups by name, so this is also safe if the
+	// product happens to use the default name and pre-declares its own volume).
+	if p.logVolumeName == VectorLogVolumeName {
+		volumes = append(volumes, corev1.Volume{
 			Name: VectorLogVolumeName,
 			VolumeSource: corev1.VolumeSource{
 				EmptyDir: &corev1.EmptyDirVolumeSource{},
 			},
-		},
+		})
 	}
 
 	AddVolumes(podSpec, volumes)
 
-	// Mount log volume on main container for shared log access
+	// Mount the log volume on the main container for shared log access. When the product owns
+	// the log volume (WithLogVolume) it normally mounts it itself, but AddVolumeMounts dedups
+	// by name so adding it here is idempotent and keeps the default path consistent.
 	mainContainer := FindMainContainer(podSpec, config.MainContainerName)
 	if config.MainContainerName != "" && mainContainer == nil {
 		return fmt.Errorf("main container %q not found for vector log volume mount", config.MainContainerName)
@@ -181,7 +220,7 @@ func (p *VectorSidecarProvider) Inject(podSpec *corev1.PodSpec, config *SidecarC
 	if mainContainer != nil {
 		AddVolumeMounts(mainContainer, []corev1.VolumeMount{
 			{
-				Name:      VectorLogVolumeName,
+				Name:      p.logVolumeName,
 				MountPath: VectorLogMountPath,
 			},
 		})

--- a/pkg/sidecar/vector_test.go
+++ b/pkg/sidecar/vector_test.go
@@ -19,9 +19,30 @@ package sidecar_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/zncdatadev/operator-go/pkg/constant"
 	"github.com/zncdatadev/operator-go/pkg/sidecar"
 	corev1 "k8s.io/api/core/v1"
 )
+
+// findVolumeMount returns the named VolumeMount from the container, or nil.
+func findVolumeMount(c *corev1.Container, name string) *corev1.VolumeMount {
+	for i := range c.VolumeMounts {
+		if c.VolumeMounts[i].Name == name {
+			return &c.VolumeMounts[i]
+		}
+	}
+	return nil
+}
+
+// findVolume returns the named Volume from the pod spec, or nil.
+func findVolume(podSpec *corev1.PodSpec, name string) *corev1.Volume {
+	for i := range podSpec.Volumes {
+		if podSpec.Volumes[i].Name == name {
+			return &podSpec.Volumes[i]
+		}
+	}
+	return nil
+}
 
 var _ = Describe("VectorSidecarProvider", func() {
 	It("always injects Vector as a native sidecar (init container, restartPolicy Always)", func() {
@@ -36,5 +57,70 @@ var _ = Describe("VectorSidecarProvider", func() {
 		Expect(*podSpec.InitContainers[idx].RestartPolicy).To(Equal(corev1.ContainerRestartPolicyAlways))
 		// Never placed as a regular container.
 		Expect(sidecar.FindContainer(podSpec, "vector")).To(BeNil())
+	})
+
+	It("mounts the shared log volume read-only into the Vector container at KubedoopLogDir", func() {
+		podSpec := &corev1.PodSpec{Containers: []corev1.Container{{Name: "main"}}}
+		provider := sidecar.NewVectorSidecarProvider()
+
+		Expect(provider.Inject(podSpec, &sidecar.SidecarConfig{Enabled: true, Image: "vector:1"})).To(Succeed())
+
+		vectorContainer := sidecar.FindInitContainer(podSpec, "vector")
+		Expect(vectorContainer).NotTo(BeNil())
+
+		logMount := findVolumeMount(vectorContainer, sidecar.VectorLogVolumeName)
+		Expect(logMount).NotTo(BeNil(), "Vector container must mount the shared log volume")
+		Expect(logMount.MountPath).To(Equal(constant.KubedoopLogDir))
+		Expect(logMount.ReadOnly).To(BeTrue(), "Vector must read logs read-only")
+
+		// The default framework-managed log volume is created as an emptyDir.
+		logVolume := findVolume(podSpec, sidecar.VectorLogVolumeName)
+		Expect(logVolume).NotTo(BeNil())
+		Expect(logVolume.EmptyDir).NotTo(BeNil())
+
+		// The main container also mounts the same volume (read-write) at KubedoopLogDir.
+		mainMount := findVolumeMount(&podSpec.Containers[0], sidecar.VectorLogVolumeName)
+		Expect(mainMount).NotTo(BeNil())
+		Expect(mainMount.MountPath).To(Equal(constant.KubedoopLogDir))
+		Expect(mainMount.ReadOnly).To(BeFalse())
+	})
+
+	It("reuses a product-supplied log volume via WithLogVolume without creating an emptyDir", func() {
+		const productLogVolume = "zk-log"
+		podSpec := &corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name: "main",
+				VolumeMounts: []corev1.VolumeMount{
+					{Name: productLogVolume, MountPath: constant.KubedoopLogDir},
+				},
+			}},
+			Volumes: []corev1.Volume{{
+				Name:         productLogVolume,
+				VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+			}},
+		}
+		provider := sidecar.NewVectorSidecarProvider().WithLogVolume(productLogVolume)
+
+		Expect(provider.Inject(podSpec, &sidecar.SidecarConfig{Enabled: true, Image: "vector:1"})).To(Succeed())
+
+		vectorContainer := sidecar.FindInitContainer(podSpec, "vector")
+		Expect(vectorContainer).NotTo(BeNil())
+
+		// Vector reads the product's log volume read-only at KubedoopLogDir.
+		logMount := findVolumeMount(vectorContainer, productLogVolume)
+		Expect(logMount).NotTo(BeNil(), "Vector must mount the product log volume")
+		Expect(logMount.MountPath).To(Equal(constant.KubedoopLogDir))
+		Expect(logMount.ReadOnly).To(BeTrue())
+
+		// The framework must NOT create its own default emptyDir log volume.
+		Expect(findVolume(podSpec, sidecar.VectorLogVolumeName)).To(BeNil())
+		// Exactly one volume with the product name (no duplicate created).
+		count := 0
+		for _, v := range podSpec.Volumes {
+			if v.Name == productLogVolume {
+				count++
+			}
+		}
+		Expect(count).To(Equal(1))
 	})
 })


### PR DESCRIPTION
## What

When the framework injects the Vector log-aggregation sidecar (`pkg/sidecar/vector.go`), it now also mounts the product's **log volume** into the Vector container, so products no longer have to hand-wire it.

Previously the framework injected Vector and mounted only its own `vector-logs` emptyDir at `/var/log/vector`, while products write their app logs to `constant.KubedoopLogDir` (`/kubedoop/log/`) and Vector globs `<KubedoopLogDir>/*.stdout.log`. Each product therefore bridged the gap manually, e.g. in zookeeper-operator's `customizeStatefulSet`:

```go
if vectorContainer := sidecar.FindInitContainer(podSpec, "vector"); vectorContainer != nil {
    vectorContainer.VolumeMounts = append(vectorContainer.VolumeMounts, corev1.VolumeMount{
        Name:      zkv1alpha1.LogDirName,
        MountPath: constant.KubedoopLogDir,
        ReadOnly:  true,
    })
}
```

## Change

The Vector sidecar now mounts a shared log volume **read-only at `constant.KubedoopLogDir`**, matching where products write logs and where the Vector config globs for log files. `VectorLogMountPath` is now `constant.KubedoopLogDir` (was `/var/log/vector`).

## Log-volume convention

The product mounts a log volume at `constant.KubedoopLogDir` on its main container; the framework mounts the **same** volume read-only into the Vector container at the same path. Two modes:

- **Default** — the provider creates the log volume as an emptyDir named `log` (constant `VectorLogVolumeName`, was `vector-logs`), mounting it on the main container (read-write) and the Vector sidecar (read-only). Self-contained; nothing to wire.
- **`WithLogVolume(name)`** — the provider reuses a product-supplied log volume of the given name instead of creating its own emptyDir, mounting it read-only into Vector at `KubedoopLogDir`. The product owns the volume declaration and the main-container mount (e.g. a size-limited emptyDir). This is the path for products like zookeeper-operator that already declare their own log volume.

`AddVolumes`/`AddVolumeMounts` dedup by name, so injection stays idempotent and a product pre-declaring its own volume is never clobbered.

## Backward compatibility

- The default path always creates the log volume, so Vector with no product-supplied volume still works (it just collects into the framework emptyDir).
- Only the mount path and default volume name changed; no product depended on the old `/var/log/vector` path (they hand-wired `KubedoopLogDir`).

## Tests

`pkg/sidecar/vector_test.go` now asserts:
- the injected Vector container has a read-only VolumeMount at `KubedoopLogDir` for the log volume, the main container has the matching read-write mount, and the default emptyDir log volume is created;
- with `WithLogVolume(productVol)`, Vector mounts the product's volume read-only at `KubedoopLogDir`, the framework does **not** create its own emptyDir, and no duplicate volume is added.

## Follow-up for products

Once merged, products can drop their manual `FindInitContainer("vector")` + append-mount bridge and instead register the Vector provider with `WithLogVolume(<their log volume name>)`.

## Gates

- `go build ./...` ✓
- `go test ./pkg/...` ✓
- `golangci-lint run ./...` → 0 issues ✓ (pinned v2.12.2)
- `examples/trino-operator`: `go build ./...` ✓ + `go test ./...` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)