### PR TITLE
feat(builder): default PodSpec.EnableServiceLinks to false, overridable via PodOverrides

### DIFF
--- a/pkg/builder/statefulset_builder.go
+++ b/pkg/builder/statefulset_builder.go
@@ -59,6 +59,12 @@ type StatefulSetBuilder struct {
 	SecurityContext    *corev1.SecurityContext
 	PodSecurityContext *corev1.PodSecurityContext
 
+	// EnableServiceLinks controls the pod's .spec.enableServiceLinks. When nil, the field is left
+	// unset (backward compatible — direct builder users are unaffected and k8s applies its own
+	// default of true). Callers set it via WithEnableServiceLinks; per-role-group PodOverrides can
+	// still override it (see applyPodOverrides).
+	EnableServiceLinks *bool
+
 	// Affinity
 	Affinity *corev1.Affinity
 
@@ -280,6 +286,16 @@ func (b *StatefulSetBuilder) WithSecurityContext(containerCtx *corev1.SecurityCo
 	return b
 }
 
+// WithEnableServiceLinks sets the pod's .spec.enableServiceLinks. The kubedoop framework defaults
+// this to false (kubedoop products use DNS + config, never the injected <SVC>_SERVICE_HOST/PORT
+// env vars), but the value is fully overridable via per-role-group PodOverrides. When this option
+// is never called, the field stays nil and k8s applies its own default (true), keeping direct
+// builder users backward compatible.
+func (b *StatefulSetBuilder) WithEnableServiceLinks(enable bool) *StatefulSetBuilder {
+	b.EnableServiceLinks = &enable
+	return b
+}
+
 // WithPodOverrides sets the pod template overrides.
 func (b *StatefulSetBuilder) WithPodOverrides(overrides *corev1.PodTemplateSpec) *StatefulSetBuilder {
 	b.PodOverrides = overrides
@@ -472,6 +488,12 @@ func (b *StatefulSetBuilder) buildPodSpec() corev1.PodSpec {
 		},
 	}
 
+	// Only set EnableServiceLinks when explicitly configured, so direct builder users that never
+	// call WithEnableServiceLinks are unaffected (k8s applies its own default of true).
+	if b.EnableServiceLinks != nil {
+		spec.EnableServiceLinks = b.EnableServiceLinks
+	}
+
 	return spec
 }
 
@@ -645,6 +667,12 @@ func (b *StatefulSetBuilder) applyPodOverrides(sts *appsv1.StatefulSet) {
 	// Override priority class name
 	if b.PodOverrides.Spec.PriorityClassName != "" {
 		sts.Spec.Template.Spec.PriorityClassName = b.PodOverrides.Spec.PriorityClassName
+	}
+
+	// Override enableServiceLinks. This runs at the end of Build(), so a user PodOverride wins over
+	// the framework default set via WithEnableServiceLinks before the build.
+	if b.PodOverrides.Spec.EnableServiceLinks != nil {
+		sts.Spec.Template.Spec.EnableServiceLinks = b.PodOverrides.Spec.EnableServiceLinks
 	}
 
 	// Override pod-level security context. PodOverrides REPLACES the whole pod security context

--- a/pkg/builder/statefulset_builder_test.go
+++ b/pkg/builder/statefulset_builder_test.go
@@ -732,6 +732,66 @@ var _ = Describe("StatefulSetBuilder", func() {
 		})
 	})
 
+	Describe("WithEnableServiceLinks", func() {
+		It("should leave EnableServiceLinks unset by default (backward compatible)", func() {
+			sts := stsBuilder.
+				WithImage(image, corev1.PullIfNotPresent).
+				Build()
+
+			Expect(sts.Spec.Template.Spec.EnableServiceLinks).To(BeNil())
+		})
+
+		It("should set the field on the builder", func() {
+			result := stsBuilder.WithEnableServiceLinks(false)
+
+			Expect(result).To(Equal(stsBuilder))
+			Expect(stsBuilder.EnableServiceLinks).NotTo(BeNil())
+			Expect(*stsBuilder.EnableServiceLinks).To(BeFalse())
+		})
+
+		It("should build a StatefulSet with EnableServiceLinks=false when configured", func() {
+			sts := stsBuilder.
+				WithImage(image, corev1.PullIfNotPresent).
+				WithEnableServiceLinks(false).
+				Build()
+
+			Expect(sts.Spec.Template.Spec.EnableServiceLinks).NotTo(BeNil())
+			Expect(*sts.Spec.Template.Spec.EnableServiceLinks).To(BeFalse())
+		})
+
+		It("should let a PodOverride override the default to true", func() {
+			overrides := &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					EnableServiceLinks: boolPtr(true),
+				},
+			}
+			sts := stsBuilder.
+				WithImage(image, corev1.PullIfNotPresent).
+				WithEnableServiceLinks(false).
+				WithPodOverrides(overrides).
+				Build()
+
+			Expect(sts.Spec.Template.Spec.EnableServiceLinks).NotTo(BeNil())
+			Expect(*sts.Spec.Template.Spec.EnableServiceLinks).To(BeTrue())
+		})
+
+		It("should keep the builder default when PodOverrides does not set EnableServiceLinks", func() {
+			overrides := &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					PriorityClassName: "high-priority",
+				},
+			}
+			sts := stsBuilder.
+				WithImage(image, corev1.PullIfNotPresent).
+				WithEnableServiceLinks(false).
+				WithPodOverrides(overrides).
+				Build()
+
+			Expect(sts.Spec.Template.Spec.EnableServiceLinks).NotTo(BeNil())
+			Expect(*sts.Spec.Template.Spec.EnableServiceLinks).To(BeFalse())
+		})
+	})
+
 	Describe("WithStorage", func() {
 		It("should set storage configuration", func() {
 			capacity := resource.MustParse("10Gi")

--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -546,6 +546,14 @@ func (h *BaseRoleGroupHandler[CR]) buildStatefulSet(
 	containerSecurityCtx, podSecurityCtx := h.resolveSecurityContext()
 	stsBuilder.WithSecurityContext(containerSecurityCtx, podSecurityCtx)
 
+	// Default enableServiceLinks to false — the kubedoop standard. Products use DNS + config and
+	// never the <SVC>_SERVICE_HOST/PORT env vars kubelet injects for every Service in the
+	// namespace, which only bloat env and slow startup. This is set before pod overrides are
+	// applied, so a value supplied via MergedConfig.PodOverrides takes precedence. The builder's
+	// WithEnableServiceLinks itself serves as the escape hatch (e.g. a product embedding this
+	// handler could reconfigure the builder), so no separate handler field is needed.
+	stsBuilder.WithEnableServiceLinks(false)
+
 	// Set pod overrides if present
 	if buildCtx.MergedConfig.PodOverrides != nil {
 		stsBuilder.WithPodOverrides(buildCtx.MergedConfig.PodOverrides)

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -566,6 +566,32 @@ var _ = Describe("StatefulSet building", func() {
 		Expect(resources.StatefulSet.Spec.Template.Spec.PriorityClassName).To(Equal("high-priority"))
 	})
 
+	It("should default EnableServiceLinks to false (kubedoop standard)", func() {
+		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
+		Expect(err).NotTo(HaveOccurred())
+
+		esl := resources.StatefulSet.Spec.Template.Spec.EnableServiceLinks
+		Expect(esl).NotTo(BeNil())
+		Expect(*esl).To(BeFalse())
+	})
+
+	It("should let PodOverrides override EnableServiceLinks to true", func() {
+		buildCtx.MergedConfig = &config.MergedConfig{
+			PodOverrides: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					EnableServiceLinks: ptr.To(true),
+				},
+			},
+		}
+
+		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
+		Expect(err).NotTo(HaveOccurred())
+
+		esl := resources.StatefulSet.Spec.Template.Spec.EnableServiceLinks
+		Expect(esl).NotTo(BeNil())
+		Expect(*esl).To(BeTrue())
+	})
+
 	It("should set container ports when configured", func() {
 		handler.SetRoleContainerPorts("test-role", []corev1.ContainerPort{
 			{Name: "http", ContainerPort: 8080},


### PR DESCRIPTION
## What

Make `PodSpec.EnableServiceLinks = false` a **framework-level default** (the kubedoop standard), fully overridable via `PodOverrides`.

## Why

With the k8s default (`enableServiceLinks: true`), kubelet injects `<SVC>_SERVICE_HOST/PORT/...` environment variables for **every** Service in the namespace into **every** container. Kubedoop products discover peers/services via DNS + config and never read these vars — so they only bloat the container environment and slow pod startup.

This mirrors exactly how the default **SecurityContext** is handled (a framework default that a user can override through `PodOverrides`) — deliberately **not** a per-product bool field like `PublishNotReadyAddresses`.

## How

- **`pkg/builder/statefulset_builder.go`**
  - New `EnableServiceLinks *bool` field + `WithEnableServiceLinks(bool)` option.
  - `buildPodSpec` sets `podSpec.EnableServiceLinks` **only when the field is non-nil**, so direct builder users who never call the option are unaffected (k8s keeps applying its own default of `true`) — backward compatible.
  - `applyPodOverrides` adds `EnableServiceLinks` to the overridable allowlist. Because `applyPodOverrides` runs at the **end** of `Build()`, a value supplied via `PodOverrides` wins over the builder default. Ordering matters: the default is set on the builder *before* the override is applied.

- **`pkg/reconciler/base_role_group_handler.go`**
  - `buildStatefulSet` defaults to `false` via `stsBuilder.WithEnableServiceLinks(false)` (the kubedoop standard), set before pod overrides so a user `PodOverrides.Spec.EnableServiceLinks` takes precedence. No handler escape-hatch field is added — the builder option itself already serves as one.

## Tests

- Builder: default leaves the field `nil` (backward compatible); `WithEnableServiceLinks(false)` builds a pod template with `EnableServiceLinks: false`; a `PodOverrides.Spec.EnableServiceLinks = true` overrides the default to `true`; and a `PodOverrides` that doesn't set the field keeps the builder default.
- Handler: `BuildResources` yields a StatefulSet whose pod template defaults `EnableServiceLinks: false`, and `PodOverrides.Spec.EnableServiceLinks = true` overrides it to `true`.

## Note for products

Once merged, products can drop any manual `podSpec.EnableServiceLinks = false` they set after the base build. Doing so is actually a **correctness improvement**: a product mutating the field after the base build currently clobbers any user-supplied `PodOverrides.EnableServiceLinks`; relying on the framework default preserves the intended default-then-override precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)