### PR TITLE
fix(reconciler): default config mount to kubedoop-canonical path

### DIFF
--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/zncdatadev/operator-go/pkg/builder"
 	"github.com/zncdatadev/operator-go/pkg/common"
 	"github.com/zncdatadev/operator-go/pkg/config"
+	"github.com/zncdatadev/operator-go/pkg/constant"
 	"github.com/zncdatadev/operator-go/pkg/productlogging"
 	"github.com/zncdatadev/operator-go/pkg/security"
 	"github.com/zncdatadev/operator-go/pkg/sidecar"
@@ -93,7 +94,8 @@ type BaseRoleGroupHandler[CR common.ClusterInterface] struct {
 
 	// ConfigMountPath is where the generated config ConfigMap is mounted in the primary
 	// container. Products whose application reads config from a specific directory (e.g.
-	// "/etc/trino") set this. Defaults to "/etc/config" when empty.
+	// "/etc/trino") set this. Defaults to the kubedoop-canonical config mount path
+	// (constant.KubedoopConfigDirMount) when empty.
 	ConfigMountPath string
 
 	// MainContainerName, when set, renames the primary (first) container of the StatefulSet.
@@ -402,12 +404,13 @@ func (h *BaseRoleGroupHandler[CR]) buildAnnotations(_ *RoleGroupBuildContext) ma
 }
 
 // configMountPath returns the directory where the config ConfigMap is mounted, defaulting
-// to "/etc/config" when the product did not set ConfigMountPath.
+// to the kubedoop-canonical config mount path (constant.KubedoopConfigDirMount) when the
+// product did not set ConfigMountPath.
 func (h *BaseRoleGroupHandler[CR]) configMountPath() string {
 	if h.ConfigMountPath != "" {
 		return h.ConfigMountPath
 	}
-	return "/etc/config"
+	return constant.KubedoopConfigDirMount
 }
 
 // buildConfigMap creates the ConfigMap for the role group.

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -526,7 +526,34 @@ var _ = Describe("StatefulSet building", func() {
 			}
 		}
 		Expect(configMount).NotTo(BeNil())
-		Expect(configMount.MountPath).To(Equal("/etc/config"))
+		// With no ConfigMountPath set, the config volume mounts at the kubedoop-canonical
+		// config mount path, not the old foreign "/etc/config".
+		Expect(configMount.MountPath).To(Equal(constant.KubedoopConfigDirMount))
+		Expect(configMount.ReadOnly).To(BeTrue())
+	})
+
+	It("should honor ConfigMountPath override for the config volume mount", func() {
+		handler.ConfigMountPath = "/etc/trino"
+		buildCtx.MergedConfig = &config.MergedConfig{
+			ConfigFiles: map[string]map[string]string{
+				"config.properties": {"key": "value"},
+			},
+		}
+
+		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
+		Expect(err).NotTo(HaveOccurred())
+
+		containers := resources.StatefulSet.Spec.Template.Spec.Containers
+		Expect(containers).NotTo(BeEmpty())
+		var configMount *corev1.VolumeMount
+		for i := range containers[0].VolumeMounts {
+			if containers[0].VolumeMounts[i].Name == "config" {
+				configMount = &containers[0].VolumeMounts[i]
+				break
+			}
+		}
+		Expect(configMount).NotTo(BeNil())
+		Expect(configMount.MountPath).To(Equal("/etc/trino"))
 		Expect(configMount.ReadOnly).To(BeTrue())
 	})
 


### PR DESCRIPTION
## Problem

`BaseRoleGroupHandler` mounts the role-group config ConfigMap at the path returned by `configMountPath()`, which **defaulted to a foreign `/etc/config`** when the product did not set `ConfigMountPath`. `/etc/config` is not a kubedoop path — the framework's own canonical config-mount directory is `constant.KubedoopConfigDirMount` (`/kubedoop/mount/config/`).

Because the default was foreign, products following the kubedoop convention (e.g. zookeeper-operator) had to strip the framework's `/etc/config` volume and re-add their own at the kubedoop path — an "add then remove" wart.

## Fix

Change the default in `configMountPath()` from the hardcoded `"/etc/config"` to `constant.KubedoopConfigDirMount`. The `ConfigMountPath` field is retained, so products with a native config dir (e.g. trino's `/etc/trino`) still override it. Doc comments on the field and on `configMountPath()` are updated accordingly.

The config-volume logic is otherwise unchanged: still gated on `MergedConfig.ConfigFiles`, read-only, volume name `"config"`.

## Tests

- The existing `pkg/reconciler` test that asserted `/etc/config` now asserts `constant.KubedoopConfigDirMount`.
- Added a test asserting that setting `ConfigMountPath` overrides the default.

## Impact

Products that were stripping the framework's `/etc/config` volume and re-adding their own can now drop that workaround. Products with native config dirs are unaffected (they set `ConfigMountPath`); the trino example (`/etc/trino`) builds and tests green.

Closes #497

🤖 Generated with [Claude Code](https://claude.com/claude-code)