### PR TITLE
fix(reconciler): mount config ConfigMap regardless of ConfigFiles

### DIFF
--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -562,24 +562,31 @@ func (h *BaseRoleGroupHandler[CR]) buildStatefulSet(
 		stsBuilder.WithPodOverrides(buildCtx.MergedConfig.PodOverrides)
 	}
 
-	// Add config volume if ConfigMap exists
-	if buildCtx.MergedConfig != nil && len(buildCtx.MergedConfig.ConfigFiles) > 0 {
-		stsBuilder.AddVolume(corev1.Volume{
-			Name: "config",
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{
-						Name: buildCtx.ResourceName,
-					},
+	// Mount the role group ConfigMap as the "config" volume at configMountPath().
+	//
+	// This is intentionally NOT gated on MergedConfig.ConfigFiles. ConfigFiles is populated
+	// only from role/role-group configOverrides, but the role group ConfigMap
+	// (buildCtx.ResourceName) is ALWAYS produced by buildConfigMap — a product can populate its
+	// real config (e.g. zoo.cfg, security.properties, logback.xml) directly into ConfigMap.Data
+	// with no overrides at all. Gating the mount on ConfigFiles would starve those products of
+	// their config in the common no-overrides case, forcing them to hand-create a config volume
+	// and strip the framework's. The mount references buildCtx.ResourceName, which the same
+	// handler's buildConfigMap always creates, so the referenced ConfigMap always exists.
+	stsBuilder.AddVolume(corev1.Volume{
+		Name: "config",
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: buildCtx.ResourceName,
 				},
 			},
-		})
-		stsBuilder.AddVolumeMount(corev1.VolumeMount{
-			Name:      "config",
-			MountPath: h.configMountPath(),
-			ReadOnly:  true,
-		})
-	}
+		},
+	})
+	stsBuilder.AddVolumeMount(corev1.VolumeMount{
+		Name:      "config",
+		MountPath: h.configMountPath(),
+		ReadOnly:  true,
+	})
 
 	// Build the StatefulSet
 	sts := stsBuilder.Build()

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -557,6 +557,42 @@ var _ = Describe("StatefulSet building", func() {
 		Expect(configMount.ReadOnly).To(BeTrue())
 	})
 
+	It("should add config volume and mount even when no config-file overrides are present", func() {
+		// The role group ConfigMap is always produced by buildConfigMap (a product may populate
+		// its real config directly into ConfigMap.Data with no overrides). MergedConfig.ConfigFiles
+		// is empty here, yet the config volume + mount must still be present so the product can read
+		// its config. The mount must NOT be gated on ConfigFiles.
+		buildCtx.MergedConfig = &config.MergedConfig{}
+
+		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
+		Expect(err).NotTo(HaveOccurred())
+
+		volumes := resources.StatefulSet.Spec.Template.Spec.Volumes
+		var configVolume *corev1.Volume
+		for i := range volumes {
+			if volumes[i].Name == "config" {
+				configVolume = &volumes[i]
+				break
+			}
+		}
+		Expect(configVolume).NotTo(BeNil())
+		Expect(configVolume.ConfigMap).NotTo(BeNil())
+		Expect(configVolume.ConfigMap.Name).To(Equal("test-cluster-default"))
+
+		containers := resources.StatefulSet.Spec.Template.Spec.Containers
+		Expect(containers).NotTo(BeEmpty())
+		var configMount *corev1.VolumeMount
+		for i := range containers[0].VolumeMounts {
+			if containers[0].VolumeMounts[i].Name == "config" {
+				configMount = &containers[0].VolumeMounts[i]
+				break
+			}
+		}
+		Expect(configMount).NotTo(BeNil())
+		Expect(configMount.MountPath).To(Equal(constant.KubedoopConfigDirMount))
+		Expect(configMount.ReadOnly).To(BeTrue())
+	})
+
 	It("should use role-specific image when set", func() {
 		handler.SetRoleImage("test-role", "custom-role-image:v2")
 		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)


### PR DESCRIPTION
## Problem

In `pkg/reconciler/base_role_group_handler.go` (`buildStatefulSet`), the config ConfigMap volume (name `config`, mounted at `configMountPath()`, i.e. `constant.KubedoopConfigDirMount` by default after #507) was added **only** when `buildCtx.MergedConfig != nil && len(buildCtx.MergedConfig.ConfigFiles) > 0`.

That tied the config **mount** to config-file **overrides**. But `MergedConfig.ConfigFiles` is populated solely from role/role-group `configOverrides`. The role group ConfigMap (`buildCtx.ResourceName`) is, however, **always** produced by `buildConfigMap` — a product can populate its real config (e.g. `zoo.cfg`, `security.properties`, `logback.xml`) directly into `ConfigMap.Data` with no overrides at all, which is exactly what zookeeper-operator does by overriding `buildConfigMap`.

For such products, in the common no-overrides case `ConfigFiles` is empty, so the framework never mounted the ConfigMap → the app couldn't read its config. As a result these products could not consume the framework's config mount and instead hand-created their own config volume and stripped the framework's — a wart.

## Fix

Decouple the config-volume **mount** from `ConfigFiles`. The `config` volume (referencing the role-group ConfigMap `buildCtx.ResourceName`, read-only, at `configMountPath()`) is now mounted **unconditionally**.

This is safe because the referenced ConfigMap always exists: `buildConfigMap` (a concrete method of `BaseRoleGroupHandler`, invoked by the same `buildStatefulSet`) always returns a non-nil ConfigMap named `buildCtx.ResourceName`, and `BuildResources` always applies it. `configMountPath()` is always non-empty (defaults to `constant.KubedoopConfigDirMount`), so the mount can never point at a missing ConfigMap.

Products that were hand-creating a config volume and stripping the framework's can now consume the framework mount directly.

### Not changed
- The `ConfigMountPath` field and its #507 default (`constant.KubedoopConfigDirMount`) are intact — this change is only about **when** the volume is added, not **where**.
- The `ConfigGenerator` path still legitimately gates on `ConfigFiles` (it needs them to generate).

## Tests
- Added a test asserting the `config` volume + mount are present even when `MergedConfig.ConfigFiles` is empty (the previously-missing case).
- Existing tests still assert the volume/mount are present with overrides and honor the `ConfigMountPath` override.

## Gates
- `go build ./...` ✅
- `go test ./pkg/...` (with envtest) ✅
- `golangci-lint run ./...` → `0 issues` ✅
- `examples/trino-operator`: `go build ./...` + `go test ./...` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)