### PR TITLE
feat(builder): unify secret/listener volume injection via VolumeProvisioner

### DIFF
--- a/pkg/builder/volume_provisioner.go
+++ b/pkg/builder/volume_provisioner.go
@@ -1,0 +1,45 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder
+
+import corev1 "k8s.io/api/core/v1"
+
+// VolumeProvisioner is implemented by components that contribute a set of pod Volumes together
+// with the matching container VolumeMounts — for example the security SecretProvisioner and the
+// listener ListenerProvisioner. It is the single abstraction the StatefulSet builder (and, by
+// extension, the reconciler's role group handler) uses to inject any such provisioner uniformly,
+// without depending on its concrete type. New provisioners satisfy it simply by exposing the two
+// methods below.
+type VolumeProvisioner interface {
+	// Volumes returns the volumes to add to the pod spec.
+	Volumes() []corev1.Volume
+	// VolumeMounts returns the volume mounts to add to the workload's containers.
+	VolumeMounts() []corev1.VolumeMount
+}
+
+// AddVolumeProvisioner injects a VolumeProvisioner's volumes and volume mounts into the builder.
+// It is the shared implementation behind the provisioners' AutoInject helpers, so secret, listener
+// and any future volume provisioner are wired in exactly the same way.
+func (b *StatefulSetBuilder) AddVolumeProvisioner(p VolumeProvisioner) *StatefulSetBuilder {
+	for _, v := range p.Volumes() {
+		b.AddVolume(v)
+	}
+	for _, m := range p.VolumeMounts() {
+		b.AddVolumeMount(m)
+	}
+	return b
+}

--- a/pkg/builder/volume_provisioner_test.go
+++ b/pkg/builder/volume_provisioner_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package builder_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/zncdatadev/operator-go/pkg/builder"
+	"github.com/zncdatadev/operator-go/pkg/listener"
+	"github.com/zncdatadev/operator-go/pkg/security"
+)
+
+// The two first-party provisioners must satisfy the unified VolumeProvisioner interface, so a
+// single handler hook (WithVolumeProvisioners) can inject either. These compile-time assertions
+// guard that contract.
+var (
+	_ builder.VolumeProvisioner = (*security.SecretProvisioner)(nil)
+	_ builder.VolumeProvisioner = (*listener.ListenerProvisioner)(nil)
+)
+
+// fakeVolumeProvisioner is a minimal VolumeProvisioner for testing the injection helper.
+type fakeVolumeProvisioner struct {
+	volumes []corev1.Volume
+	mounts  []corev1.VolumeMount
+}
+
+func (f *fakeVolumeProvisioner) Volumes() []corev1.Volume           { return f.volumes }
+func (f *fakeVolumeProvisioner) VolumeMounts() []corev1.VolumeMount { return f.mounts }
+
+var _ = Describe("AddVolumeProvisioner", func() {
+	It("injects the provisioner's volumes and mounts into the builder", func() {
+		stsBuilder := builder.NewStatefulSetBuilder("test-sts", "test-ns")
+		p := &fakeVolumeProvisioner{
+			volumes: []corev1.Volume{{Name: "listener"}, {Name: "tls"}},
+			mounts: []corev1.VolumeMount{
+				{Name: "listener", MountPath: "/kubedoop/listener"},
+				{Name: "tls", MountPath: "/kubedoop/tls"},
+			},
+		}
+
+		result := stsBuilder.AddVolumeProvisioner(p)
+
+		Expect(result).To(BeIdenticalTo(stsBuilder), "should return the builder for chaining")
+		Expect(stsBuilder.Volumes).To(HaveLen(2))
+		Expect(stsBuilder.Volumes[0].Name).To(Equal("listener"))
+		Expect(stsBuilder.Volumes[1].Name).To(Equal("tls"))
+		Expect(stsBuilder.VolumeMounts).To(HaveLen(2))
+		Expect(stsBuilder.VolumeMounts[0].MountPath).To(Equal("/kubedoop/listener"))
+		Expect(stsBuilder.VolumeMounts[1].MountPath).To(Equal("/kubedoop/tls"))
+	})
+
+	It("appends across multiple provisioners in order", func() {
+		stsBuilder := builder.NewStatefulSetBuilder("test-sts", "test-ns")
+		stsBuilder.
+			AddVolumeProvisioner(&fakeVolumeProvisioner{volumes: []corev1.Volume{{Name: "a"}}}).
+			AddVolumeProvisioner(&fakeVolumeProvisioner{volumes: []corev1.Volume{{Name: "b"}}})
+
+		Expect(stsBuilder.Volumes).To(HaveLen(2))
+		Expect(stsBuilder.Volumes[0].Name).To(Equal("a"))
+		Expect(stsBuilder.Volumes[1].Name).To(Equal("b"))
+	})
+})

--- a/pkg/listener/provisioner.go
+++ b/pkg/listener/provisioner.go
@@ -140,12 +140,7 @@ func (p *ListenerProvisioner) VolumeMounts() []corev1.VolumeMount {
 // This is a convenience method for operators that use StatefulSetBuilder.
 // Services are NOT injected -- they are separate K8s resources applied by the reconciler.
 func (p *ListenerProvisioner) AutoInject(stsBuilder *builder.StatefulSetBuilder) {
-	for _, vol := range p.Volumes() {
-		stsBuilder.AddVolume(vol)
-	}
-	for _, mount := range p.VolumeMounts() {
-		stsBuilder.AddVolumeMount(mount)
-	}
+	stsBuilder.AddVolumeProvisioner(p)
 }
 
 // Path returns the mount path for a registered volume (no trailing slash).

--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -140,6 +140,11 @@ type BaseRoleGroupHandler[CR common.ClusterInterface] struct {
 	// Optional - if nil, no sidecars are injected.
 	sidecarManager *sidecar.SidecarManager
 
+	// volumeProvisioners contribute pod volumes and their container mounts to the StatefulSet
+	// (e.g. the security SecretProvisioner and the listener ListenerProvisioner). Each is injected
+	// at build time via the shared builder.VolumeProvisioner path. Optional.
+	volumeProvisioners []builder.VolumeProvisioner
+
 	// securityContextConfigured tracks whether the security context fields below were set
 	// explicitly (including to nil to disable the default). When false, the framework applies
 	// its canonical default security context (the kubedoop org-standard 1001 identity plus
@@ -176,6 +181,16 @@ func NewBaseRoleGroupHandler[CR common.ClusterInterface](image string, scheme *r
 // WithSidecarManager sets the SidecarManager for sidecar injection.
 func (h *BaseRoleGroupHandler[CR]) WithSidecarManager(m *sidecar.SidecarManager) *BaseRoleGroupHandler[CR] {
 	h.sidecarManager = m
+	return h
+}
+
+// WithVolumeProvisioners registers volume provisioners whose volumes and container mounts are
+// injected into the role group's StatefulSet at build time. Both the security SecretProvisioner
+// and the listener ListenerProvisioner satisfy builder.VolumeProvisioner, so a product wires
+// SecretClass/TLS/Kerberos volumes and listener volumes through this single hook. Repeated calls
+// append; provisioners are injected in registration order.
+func (h *BaseRoleGroupHandler[CR]) WithVolumeProvisioners(provisioners ...builder.VolumeProvisioner) *BaseRoleGroupHandler[CR] {
+	h.volumeProvisioners = append(h.volumeProvisioners, provisioners...)
 	return h
 }
 
@@ -587,6 +602,11 @@ func (h *BaseRoleGroupHandler[CR]) buildStatefulSet(
 		MountPath: h.configMountPath(),
 		ReadOnly:  true,
 	})
+
+	// Inject volume provisioners (secret, listener, ...) uniformly before the build.
+	for _, p := range h.volumeProvisioners {
+		stsBuilder.AddVolumeProvisioner(p)
+	}
 
 	// Build the StatefulSet
 	sts := stsBuilder.Build()

--- a/pkg/security/secret_provisioner.go
+++ b/pkg/security/secret_provisioner.go
@@ -361,12 +361,7 @@ func (p *SecretProvisioner) MustPath(volumeName string) string {
 // This is a CONVENIENCE method for operators that use StatefulSetBuilder.
 // Operators constructing StatefulSet directly should use Volumes() and VolumeMounts().
 func (p *SecretProvisioner) AutoInject(stsBuilder *builder.StatefulSetBuilder) {
-	for _, vol := range p.Volumes() {
-		stsBuilder.AddVolume(vol)
-	}
-	for _, mount := range p.VolumeMounts() {
-		stsBuilder.AddVolumeMount(mount)
-	}
+	stsBuilder.AddVolumeProvisioner(p)
 }
 
 // mountPath returns the full mount path for a volume name (no trailing slash).


### PR DESCRIPTION
## Motivation

`SecretProvisioner` (`pkg/security`) and `ListenerProvisioner` (`pkg/listener`) had **byte-identical** `AutoInject` methods, yet **neither was wired into `BaseRoleGroupHandler`**. A product operator that embeds the handler had no idiomatic way to add secret-class or listener volumes to its pods — it would have to post-process the built StatefulSet by hand, duplicating the same loop every downstream repo.

## Change

- Add `builder.VolumeProvisioner` interface (`Volumes() []corev1.Volume` + `VolumeMounts() []corev1.VolumeMount`). Both existing provisioners satisfy it structurally — no changes to their public surface.
- Add `StatefulSetBuilder.AddVolumeProvisioner(p)` helper; both `SecretProvisioner.AutoInject` and `ListenerProvisioner.AutoInject` now delegate to it, removing the duplication.
- Add `BaseRoleGroupHandler.WithVolumeProvisioners(...)`, symmetric to `WithSidecarManager`. Registered provisioners' volumes and mounts are injected into the role group StatefulSet at build time (before `Build()`).

Products (e.g. HDFS) can now register `SecretProvisioner` **and** `ListenerProvisioner` through a single handler hook. New volume provisioners plug in for free by implementing the two-method interface.

Listener `Services()` are intentionally out of scope here — they are separate K8s resources, not pod volumes.

## Tests

- Compile-time assertions guard that both first-party provisioners keep satisfying `builder.VolumeProvisioner`.
- Unit tests for `AddVolumeProvisioner` (single + multiple provisioners, ordering).
- `make test` (envtest) green across all packages; `make lint` clean on the touched packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)