### PR TITLE
feat(reconciler): let role group handlers ship extra product resources (applied before workload)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,7 +137,7 @@ The `GenericReconciler` provides a fixed reconciliation flow with customizable e
      - RoleGroup PreReconcile Extensions
      - Build RoleGroupBuildContext
      - Delegate to RoleGroupHandler.BuildResources()
-     - Apply Resources (CM -> HeadlessSvc -> Service -> STS -> PDB)
+     - Apply Resources (CM -> HeadlessSvc -> Service -> Extras -> STS -> PDB -> MetricsSvc)
      - RoleGroup PostReconcile Extensions
    - Role PostReconcile Extensions
 6. Cleanup Orphaned Resources
@@ -161,6 +161,8 @@ handler.SetRoleServicePorts("coordinator", svcPorts)
 ```
 
 `RoleGroupHandlerFuncs` is a function adapter for simple handlers that don't need a full struct.
+
+Besides the fixed fields (ConfigMap, Services, StatefulSet, PDB, MetricsService), `RoleGroupResources.ExtraResources []client.Object` lets products ship arbitrary per-role-group resources (e.g. a `listeners.kubedoop.dev` Listener CR) through the framework's apply path: same controller owner reference, applied BEFORE the StatefulSet because extras are typically pod-scheduling prerequisites. The cleaner does not discover arbitrary-GVK extras — extras of removed role groups are reclaimed only via owner-reference GC when the CR is deleted (see the field's doc comment).
 
 ### 4. RoleInterface and RoleGroupInfo
 `RoleInterface` defines role-level operations for interacting with role configurations:

--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -139,7 +139,7 @@ type GenericReconcilerConfig[CR common.ClusterInterface] struct {
 //     - RoleGroup PreReconcile Extensions
 //     - Build RoleGroupBuildContext
 //     - Delegate to RoleGroupHandler.BuildResources()
-//     - Apply Resources (CM -> HeadlessSvc -> Service -> STS -> PDB -> MetricsSvc)
+//     - Apply Resources (CM -> HeadlessSvc -> Service -> Extras -> STS -> PDB -> MetricsSvc)
 //     - Track in Status
 //     - RoleGroup PostReconcile Extensions
 //     - Role PostReconcile Extensions
@@ -620,7 +620,9 @@ func (r *GenericReconciler[CR]) resolveVectorAggregatorAddress(ctx context.Conte
 }
 
 // applyResources applies all resources in the correct dependency order.
-// Order: ConfigMap -> Headless Service -> Service -> StatefulSet -> PDB -> MetricsService
+// Order: ConfigMap -> Headless Service -> Service -> ExtraResources -> StatefulSet -> PDB -> MetricsService
+// ExtraResources are applied before the StatefulSet because they are typically prerequisites
+// for pod scheduling (e.g. a Listener CR referenced by an ephemeral CSI volume).
 func (r *GenericReconciler[CR]) applyResources(ctx context.Context, cr CR, resources *RoleGroupResources, buildCtx *RoleGroupBuildContext) error {
 	owner := r.getAsClientObject(cr)
 
@@ -645,21 +647,35 @@ func (r *GenericReconciler[CR]) applyResources(ctx context.Context, cr CR, resou
 		}
 	}
 
-	// 4. Apply StatefulSet
+	// 4. Apply extra product resources BEFORE the StatefulSet: extras are typically
+	// prerequisites for pod scheduling (e.g. a Listener CR that pods reference through an
+	// ephemeral CSI volume — without it the pods hang in ContainerCreating). They go through
+	// the same applyResource path as the fixed fields, so they get the same controller owner
+	// reference and are GC'd with the CR. Nil entries are skipped (see RoleGroupResources).
+	for _, extra := range resources.ExtraResources {
+		if extra == nil {
+			continue
+		}
+		if err := r.applyResource(ctx, owner, extra); err != nil {
+			return NewResourceApplyError(r.resourceKind(extra), extra.GetNamespace(), extra.GetName(), "failed to apply extra resource", err)
+		}
+	}
+
+	// 5. Apply StatefulSet
 	if resources.StatefulSet != nil {
 		if err := r.applyResource(ctx, owner, resources.StatefulSet); err != nil {
 			return NewResourceApplyError("StatefulSet", buildCtx.ClusterNamespace, buildCtx.ResourceName, "failed to apply", err)
 		}
 	}
 
-	// 5. Apply PodDisruptionBudget
+	// 6. Apply PodDisruptionBudget
 	if resources.PodDisruptionBudget != nil {
 		if err := r.applyResource(ctx, owner, resources.PodDisruptionBudget); err != nil {
 			return NewResourceApplyError("PodDisruptionBudget", buildCtx.ClusterNamespace, buildCtx.ResourceName, "failed to apply", err)
 		}
 	}
 
-	// 6. Apply MetricsService
+	// 7. Apply MetricsService
 	if resources.MetricsService != nil {
 		if err := r.applyResource(ctx, owner, resources.MetricsService); err != nil {
 			return NewResourceApplyError("Service", buildCtx.ClusterNamespace, buildCtx.ResourceName+"-metrics", "failed to apply metrics service", err)
@@ -667,6 +683,16 @@ func (r *GenericReconciler[CR]) applyResources(ctx context.Context, cr CR, resou
 	}
 
 	return nil
+}
+
+// resourceKind resolves a human-readable kind for an arbitrary resource (used in error
+// messages for ExtraResources, whose GVK is not fixed). Typed objects usually carry an empty
+// TypeMeta, so the scheme registration is preferred; the Go type name is the fallback.
+func (r *GenericReconciler[CR]) resourceKind(obj client.Object) string {
+	if gvks, _, err := r.scheme.ObjectKinds(obj); err == nil && len(gvks) > 0 {
+		return gvks[0].Kind
+	}
+	return fmt.Sprintf("%T", obj)
 }
 
 // applyResource applies a single resource using CreateOrUpdate.

--- a/pkg/reconciler/generic_reconciler_test.go
+++ b/pkg/reconciler/generic_reconciler_test.go
@@ -1168,6 +1168,198 @@ var _ = Describe("RoleGroupResourceName", func() {
 	})
 })
 
+// createRecordingClient wraps a client.Client and records the order of successful Create
+// calls (as "<go-type>/<name>"), so tests can assert apply ordering — e.g. that extra
+// resources are created before the StatefulSet. All other operations pass through.
+type createRecordingClient struct {
+	client.Client
+	created []string
+}
+
+func (c *createRecordingClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if err := c.Client.Create(ctx, obj, opts...); err != nil {
+		return err
+	}
+	c.created = append(c.created, fmt.Sprintf("%T/%s", obj, obj.GetName()))
+	return nil
+}
+
+// indexOf returns the position of the given "<go-type>/<name>" entry in the recorded create
+// order, or -1 if it was never created.
+func (c *createRecordingClient) indexOf(entry string) int {
+	for i, e := range c.created {
+		if e == entry {
+			return i
+		}
+	}
+	return -1
+}
+
+var _ = Describe("GenericReconciler ExtraResources", func() {
+	var (
+		namespace string
+		crName    string
+		mockCR    *testutil.MockCluster
+		recClient *createRecordingClient
+	)
+
+	BeforeEach(func() {
+		namespace = testNamespace
+		crName = fmt.Sprintf("extra-res-cr-%d", time.Now().UnixNano())
+		mockCR = testutil.NewMockCluster(crName, namespace).
+			WithRoles(map[string]v1alpha1.RoleSpec{
+				"broker": {
+					RoleGroups: map[string]v1alpha1.RoleGroupSpec{
+						"default": {Replicas: ptr.To(int32(1))},
+					},
+				},
+			})
+		Expect(k8sClient.Create(ctx, mockCR)).To(Succeed())
+		recClient = &createRecordingClient{Client: k8sClient}
+	})
+
+	AfterEach(func() {
+		_ = k8sClient.Delete(ctx, mockCR)
+	})
+
+	newReconciler := func(handler reconciler.RoleGroupHandler[*testutil.ClusterWrapper]) *reconciler.GenericReconciler[*testutil.ClusterWrapper] {
+		cfg := &reconciler.GenericReconcilerConfig[*testutil.ClusterWrapper]{
+			Client:           recClient,
+			Scheme:           testScheme,
+			Recorder:         recorder,
+			RoleGroupHandler: handler,
+			Prototype:        testutil.WrapMockCluster(testutil.NewMockCluster("proto", namespace)),
+		}
+		r, err := reconciler.NewGenericReconciler(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		return r
+	}
+
+	It("applies extras with a controller owner reference, after the ConfigMap and before the StatefulSet", func() {
+		handler := &reconciler.RoleGroupHandlerFuncs[*testutil.ClusterWrapper]{
+			BuildResourcesFunc: func(_ context.Context, _ client.Client, _ *testutil.ClusterWrapper, buildCtx *reconciler.RoleGroupBuildContext) (*reconciler.RoleGroupResources, error) {
+				// A Secret stands in for an arbitrary product resource (e.g. a Listener CR)
+				// that must exist before the workload pods are scheduled.
+				extra := &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      buildCtx.ResourceName + "-bootstrap",
+						Namespace: buildCtx.ClusterNamespace,
+					},
+					StringData: map[string]string{"listener": "bootstrap"},
+				}
+				return &reconciler.RoleGroupResources{
+					ConfigMap:      testutil.NewTestConfigMap(buildCtx.ResourceName, buildCtx.ClusterNamespace),
+					ExtraResources: []client.Object{extra},
+					StatefulSet:    testutil.NewTestStatefulSetBuilder(buildCtx.ResourceName, buildCtx.ClusterNamespace).WithImage("test-image:latest", corev1.PullIfNotPresent).Build(),
+				}, nil
+			},
+		}
+		r := newReconciler(handler)
+
+		req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: crName}}
+		_, err := r.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+
+		resourceName := reconciler.RoleGroupResourceName(crName, "broker", "default")
+
+		// The extra is applied with a controller owner reference to the cluster CR, so it is
+		// garbage-collected with the CR.
+		secret := &corev1.Secret{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: resourceName + "-bootstrap"}, secret)).To(Succeed())
+		fetchedCR := &testutil.MockCluster{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: crName}, fetchedCR)).To(Succeed())
+		controllerRef := metav1.GetControllerOf(secret)
+		Expect(controllerRef).NotTo(BeNil())
+		Expect(controllerRef.UID).To(Equal(fetchedCR.UID))
+
+		// Apply order: ConfigMap -> extra -> StatefulSet. Extras must precede the StatefulSet
+		// because they are pod-scheduling prerequisites (e.g. Listener CRs mounted via CSI).
+		cmIdx := recClient.indexOf("*v1.ConfigMap/" + resourceName)
+		extraIdx := recClient.indexOf("*v1.Secret/" + resourceName + "-bootstrap")
+		stsIdx := recClient.indexOf("*v1.StatefulSet/" + resourceName)
+		Expect(cmIdx).To(BeNumerically(">=", 0))
+		Expect(extraIdx).To(BeNumerically(">=", 0))
+		Expect(stsIdx).To(BeNumerically(">=", 0))
+		Expect(cmIdx).To(BeNumerically("<", extraIdx))
+		Expect(extraIdx).To(BeNumerically("<", stsIdx))
+	})
+
+	It("is idempotent for extras across repeated reconciles", func() {
+		handler := &reconciler.RoleGroupHandlerFuncs[*testutil.ClusterWrapper]{
+			BuildResourcesFunc: func(_ context.Context, _ client.Client, _ *testutil.ClusterWrapper, buildCtx *reconciler.RoleGroupBuildContext) (*reconciler.RoleGroupResources, error) {
+				return &reconciler.RoleGroupResources{
+					ExtraResources: []client.Object{
+						&corev1.Secret{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      buildCtx.ResourceName + "-extra",
+								Namespace: buildCtx.ClusterNamespace,
+							},
+						},
+					},
+				}, nil
+			},
+		}
+		r := newReconciler(handler)
+
+		req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: crName}}
+		_, err := r.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = r.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+
+		resourceName := reconciler.RoleGroupResourceName(crName, "broker", "default")
+		secret := &corev1.Secret{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: resourceName + "-extra"}, secret)).To(Succeed())
+		// Created exactly once — the second reconcile updated instead of re-creating.
+		Expect(recClient.indexOf("*v1.Secret/" + resourceName + "-extra")).To(BeNumerically(">=", 0))
+		count := 0
+		for _, e := range recClient.created {
+			if e == "*v1.Secret/"+resourceName+"-extra" {
+				count++
+			}
+		}
+		Expect(count).To(Equal(1))
+	})
+
+	It("behaves exactly as before when ExtraResources is nil, and skips nil entries", func() {
+		handler := &reconciler.RoleGroupHandlerFuncs[*testutil.ClusterWrapper]{
+			BuildResourcesFunc: func(_ context.Context, _ client.Client, _ *testutil.ClusterWrapper, buildCtx *reconciler.RoleGroupBuildContext) (*reconciler.RoleGroupResources, error) {
+				return &reconciler.RoleGroupResources{
+					ConfigMap:   testutil.NewTestConfigMap(buildCtx.ResourceName, buildCtx.ClusterNamespace),
+					StatefulSet: testutil.NewTestStatefulSetBuilder(buildCtx.ResourceName, buildCtx.ClusterNamespace).WithImage("test-image:latest", corev1.PullIfNotPresent).Build(),
+					// ExtraResources intentionally nil (backward compatible), covering the
+					// pre-existing contract.
+				}, nil
+			},
+		}
+		r := newReconciler(handler)
+
+		req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: crName}}
+		_, err := r.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+
+		resourceName := reconciler.RoleGroupResourceName(crName, "broker", "default")
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: resourceName}, &corev1.ConfigMap{})).To(Succeed())
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: resourceName}, &appsv1.StatefulSet{})).To(Succeed())
+		// Only the ConfigMap and StatefulSet were created.
+		Expect(recClient.created).To(ConsistOf(
+			"*v1.ConfigMap/"+resourceName,
+			"*v1.StatefulSet/"+resourceName,
+		))
+
+		// A slice holding only nil entries is equally a no-op.
+		handler.BuildResourcesFunc = func(_ context.Context, _ client.Client, _ *testutil.ClusterWrapper, buildCtx *reconciler.RoleGroupBuildContext) (*reconciler.RoleGroupResources, error) {
+			return &reconciler.RoleGroupResources{
+				ExtraResources: []client.Object{nil},
+			}, nil
+		}
+		recClient.created = nil
+		_, err = r.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(recClient.created).To(BeEmpty())
+	})
+})
+
 var _ = Describe("GenericReconciler ProductConfig", func() {
 	var (
 		namespace string

--- a/pkg/reconciler/role_group_handler.go
+++ b/pkg/reconciler/role_group_handler.go
@@ -53,6 +53,29 @@ type RoleGroupResources struct {
 
 	// MetricsService is a headless service with Prometheus scrape annotations (optional).
 	MetricsService *corev1.Service
+
+	// ExtraResources are additional product-specific resources for this role group that the
+	// framework's fixed fields have no slot for — e.g. a listeners.kubedoop.dev Listener CR
+	// that the pods reference by name through an ephemeral CSI volume. They flow through the
+	// same apply path as the fixed fields: each object gets a controller owner reference to
+	// the cluster CR (so it is garbage-collected when the CR is deleted) and is created or
+	// updated idempotently. Each object's type must be registered in the reconciler's scheme,
+	// and products should label extras with the role group's labels (see
+	// BaseRoleGroupHandler.SelectorLabels) like any other resource they build.
+	//
+	// Ordering: extras are applied after the ConfigMap and Services but BEFORE the
+	// StatefulSet, in slice order. Extras are typically prerequisites for pod scheduling —
+	// e.g. a Listener CR must exist before the pods that mount its CSI volume are created,
+	// otherwise the pods hang in ContainerCreating.
+	//
+	// Cleanup: RoleGroupCleaner only deletes the framework's fixed, well-known resources
+	// (PDB, StatefulSet, ConfigMap, Services) when a role group is removed or renamed; it
+	// cannot discover arbitrary-GVK extras. Extras of a removed role group therefore remain
+	// until the cluster CR itself is deleted (owner-reference GC). Products that need eager
+	// removal must delete such extras themselves (e.g. in a role group extension).
+	//
+	// A nil/empty slice behaves exactly as before this field existed; nil entries are skipped.
+	ExtraResources []client.Object
 }
 
 // VolumeProvider supplies extra pod volumes and their container mounts (typically CSI


### PR DESCRIPTION
## Summary

- Add `RoleGroupResources.ExtraResources []client.Object` so product operators can attach arbitrary per-role-group resources to the framework's apply path.
- Apply order becomes: ConfigMap → HeadlessService → Service → **ExtraResources** → StatefulSet → PDB → MetricsService. Extras go before the StatefulSet because they are typically pod-scheduling prerequisites; slice order preserved, nil entries skipped.
- Extras flow through the same `applyResource` path: idempotent CreateOrUpdate, controller owner reference (GC'd with the CR), same event emission. Types must be registered in the reconciler scheme.
- Cleanup semantics documented on the field: `RoleGroupCleaner` keeps deleting only its fixed well-known-name kinds (it already doesn't touch the MetricsService); extras of removed/renamed role groups are reclaimed via owner-reference GC when the CR is deleted.
- Nil/empty `ExtraResources` is byte-for-byte the old behavior.

## Motivation

kafka-operator must create a `listeners.kubedoop.dev/v1alpha1` Listener CR ("bootstrap listener") per role group, and it must exist BEFORE the StatefulSet — pods mount an ephemeral CSI volume referencing it by name and otherwise hang in ContainerCreating. Today there is no slot for such product CRs, forcing products to bypass the framework's apply/ownership path. Other operators (hdfs/hbase per-role-group listeners) have the same need.

## Test plan

- New envtest specs: owner-ref + strict create-order assertion (CM < extra < STS), idempotency across two reconciles, nil-slice/nil-entry no-op.
- `go build ./...`, `go test ./pkg/reconciler/...`, full non-e2e suite, `golangci-lint run` (v2.12.2) all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)