### PR TITLE
docs(reconciler): correct RoleGroupBuildContext.ResourceName format comment

### DIFF
--- a/pkg/reconciler/role_group_handler.go
+++ b/pkg/reconciler/role_group_handler.go
@@ -101,7 +101,9 @@ type RoleGroupBuildContext struct {
 	// MergedConfig is the merged configuration from role and role group overrides.
 	MergedConfig *config.MergedConfig
 
-	// ResourceName is the derived resource name: {cluster}-{group}.
+	// ResourceName is the derived resource name for the role group: "{cluster}-{role}-{group}"
+	// (see RoleGroupResourceName, which also truncates over-long names with a hash suffix). The
+	// role segment prevents collisions between same-named groups of different roles.
 	ResourceName string
 
 	// ServiceAccountName is the name of the ServiceAccount the workload pods should run as.


### PR DESCRIPTION
The doc comment on `RoleGroupBuildContext.ResourceName` said the derived name is
`{cluster}-{group}`, but the actual value produced by `RoleGroupResourceName` is
`{cluster}-{role}-{group}` (the role segment prevents collisions between same-named role groups of
different roles, e.g. `namenode/default` vs `datanode/default`; over-long names are truncated with a
hash suffix).

The stale comment is misleading for anyone deriving pod/service FQDNs from the resource name.
Corrected it and pointed it at `RoleGroupResourceName` so it can't drift again.

Comment-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)