### PR TITLE
feat(reconciler): consume role group affinity and gracefulShutdownTimeout in the base handler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,8 @@ handler.SetRoleContainerPorts("coordinator", ports)
 handler.SetRoleServicePorts("coordinator", svcPorts)
 ```
 
+When building the StatefulSet, `BaseRoleGroupHandler` consumes the role group's `config` (commons `RoleGroupConfigSpec`): `resources` (requests/limits, plus an opt-in data PVC via `StorageMountPath`), `affinity` (a RawExtension unmarshaled into `corev1.Affinity` and set on the pod spec — invalid JSON fails the build), and `gracefulShutdownTimeout` (a Go duration mapped to `terminationGracePeriodSeconds` — unparsable or non-positive values fail the build). All of these are applied before `podOverrides`, so user pod overrides keep precedence. The framework sets affinity only when the config provides one, so products that post-process the built StatefulSet with `if podSpec.Affinity == nil {...}` default guards remain correct.
+
 `RoleGroupHandlerFuncs` is a function adapter for simple handlers that don't need a full struct.
 
 Besides the fixed fields (ConfigMap, Services, StatefulSet, PDB, MetricsService), `RoleGroupResources.ExtraResources []client.Object` lets products ship arbitrary per-role-group resources (e.g. a `listeners.kubedoop.dev` Listener CR) through the framework's apply path: same controller owner reference, applied BEFORE the StatefulSet because extras are typically pod-scheduling prerequisites. The cleaner does not discover arbitrary-GVK extras — extras of removed role groups are reclaimed only via owner-reference GC when the CR is deleted (see the field's doc comment).

--- a/pkg/builder/statefulset_builder.go
+++ b/pkg/builder/statefulset_builder.go
@@ -664,6 +664,12 @@ func (b *StatefulSetBuilder) applyPodOverrides(sts *appsv1.StatefulSet) {
 		sts.Spec.Template.Spec.NodeSelector = b.PodOverrides.Spec.NodeSelector
 	}
 
+	// Override termination grace period, so podOverrides.spec.terminationGracePeriodSeconds
+	// wins over the config-declared gracefulShutdownTimeout (the documented precedence).
+	if b.PodOverrides.Spec.TerminationGracePeriodSeconds != nil {
+		sts.Spec.Template.Spec.TerminationGracePeriodSeconds = b.PodOverrides.Spec.TerminationGracePeriodSeconds
+	}
+
 	// Override priority class name
 	if b.PodOverrides.Spec.PriorityClassName != "" {
 		sts.Spec.Template.Spec.PriorityClassName = b.PodOverrides.Spec.PriorityClassName

--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -18,7 +18,9 @@ package reconciler
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/zncdatadev/operator-go/pkg/builder"
 	"github.com/zncdatadev/operator-go/pkg/common"
@@ -531,15 +533,53 @@ func (h *BaseRoleGroupHandler[CR]) buildStatefulSet(
 		stsBuilder.WithServiceAccount(buildCtx.ServiceAccountName)
 	}
 
-	// Set resources if configured
+	// Wire the role group's declared runtime config (commons RoleGroupConfigSpec) into the
+	// StatefulSet. All of these land on the builder BEFORE pod overrides take effect: the
+	// builder applies PodOverrides last in Build(), so a user-supplied pod override (e.g. an
+	// affinity in podOverrides) always keeps precedence over the config-declared value.
 	roleGroupConfig := buildCtx.RoleGroupSpec.GetConfig()
-	if roleGroupConfig != nil && roleGroupConfig.Resources != nil {
-		stsBuilder.WithResources(roleGroupConfig.Resources)
-		// Opt-in data PVC: when a product sets StorageMountPath, build a VolumeClaimTemplate
-		// from the configured storage and mount it, so the volume/mount contract is enforced
-		// by the builder instead of being hand-assembled by each product.
-		if h.StorageMountPath != "" && roleGroupConfig.Resources.Storage != nil {
-			stsBuilder.WithStorage(roleGroupConfig.Resources.Storage, h.StorageMountPath)
+	if roleGroupConfig != nil {
+		if roleGroupConfig.Resources != nil {
+			stsBuilder.WithResources(roleGroupConfig.Resources)
+			// Opt-in data PVC: when a product sets StorageMountPath, build a VolumeClaimTemplate
+			// from the configured storage and mount it, so the volume/mount contract is enforced
+			// by the builder instead of being hand-assembled by each product.
+			if h.StorageMountPath != "" && roleGroupConfig.Resources.Storage != nil {
+				stsBuilder.WithStorage(roleGroupConfig.Resources.Storage, h.StorageMountPath)
+			}
+		}
+
+		// Affinity: the CRD carries it as a schema-free RawExtension holding a corev1.Affinity.
+		// Invalid JSON fails the build loudly — silently dropping a user's scheduling
+		// constraints could place pods on nodes the user explicitly excluded (same loud-failure
+		// stance as a Vector misconfiguration). Backward compatible: the framework sets affinity
+		// only when the CRD config provides one, so products that post-process the built
+		// StatefulSet with `if podSpec.Affinity == nil { ... }` default guards remain correct.
+		if roleGroupConfig.Affinity != nil && len(roleGroupConfig.Affinity.Raw) > 0 {
+			affinity := &corev1.Affinity{}
+			if err := json.Unmarshal(roleGroupConfig.Affinity.Raw, affinity); err != nil {
+				return nil, fmt.Errorf("invalid affinity in role group config (role %q, group %q): %w",
+					buildCtx.RoleName, buildCtx.RoleGroupName, err)
+			}
+			stsBuilder.WithAffinity(affinity)
+		}
+
+		// GracefulShutdownTimeout maps to the pod's terminationGracePeriodSeconds (see
+		// docs/architecture.md §4.11.2 Graceful Shutdown). An unparsable or non-positive
+		// duration fails the build loudly rather than silently falling back. A positive
+		// sub-second duration rounds up to 1s so it never truncates to 0 (which would mean
+		// immediate SIGKILL). Empty leaves the pod spec untouched (k8s default of 30s applies).
+		if roleGroupConfig.GracefulShutdownTimeout != "" {
+			d, err := time.ParseDuration(roleGroupConfig.GracefulShutdownTimeout)
+			if err != nil {
+				return nil, fmt.Errorf("invalid gracefulShutdownTimeout %q in role group config (role %q, group %q): %w",
+					roleGroupConfig.GracefulShutdownTimeout, buildCtx.RoleName, buildCtx.RoleGroupName, err)
+			}
+			if d <= 0 {
+				return nil, fmt.Errorf("invalid gracefulShutdownTimeout %q in role group config (role %q, group %q): must be a positive duration",
+					roleGroupConfig.GracefulShutdownTimeout, buildCtx.RoleName, buildCtx.RoleGroupName)
+			}
+			stsBuilder.WithTerminationGracePeriod(int64((d + time.Second - 1) / time.Second))
 		}
 	}
 

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -932,6 +932,24 @@ var _ = Describe("RoleGroupConfig affinity and gracefulShutdownTimeout consumpti
 		// config-declared affinity.
 		Expect(resources.StatefulSet.Spec.Template.Spec.Affinity).To(Equal(overrideAffinity))
 	})
+
+	It("lets a PodOverrides terminationGracePeriodSeconds win over gracefulShutdownTimeout", func() {
+		buildCtx.RoleGroupSpec.Config = &v1alpha1.RoleGroupConfigSpec{
+			GracefulShutdownTimeout: "30s",
+		}
+		overrideGrace := int64(120)
+		buildCtx.MergedConfig = &config.MergedConfig{
+			PodOverrides: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{TerminationGracePeriodSeconds: &overrideGrace},
+			},
+		}
+
+		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
+		Expect(err).NotTo(HaveOccurred())
+		// The builder applies PodOverrides last, so the user's pod override replaces the
+		// config-declared termination grace.
+		Expect(resources.StatefulSet.Spec.Template.Spec.TerminationGracePeriodSeconds).To(Equal(&overrideGrace))
+	})
 })
 
 var _ = Describe("ConfigGenerator integration", func() {

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -18,6 +18,7 @@ package reconciler_test
 
 import (
 	"context"
+	"encoding/json"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -36,6 +37,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -778,6 +780,157 @@ var _ = Describe("StatefulSet building", func() {
 		Expect(podSpec.SecurityContext).To(BeNil())
 		Expect(podSpec.Containers).NotTo(BeEmpty())
 		Expect(podSpec.Containers[0].SecurityContext).To(BeNil())
+	})
+})
+
+var _ = Describe("RoleGroupConfig affinity and gracefulShutdownTimeout consumption", func() {
+	var handler *reconciler.BaseRoleGroupHandler[common.ClusterInterface]
+	var buildCtx *reconciler.RoleGroupBuildContext
+
+	// configAffinity is the affinity declared in the CRD role group config (as RawExtension).
+	configAffinity := &corev1.Affinity{
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+				{
+					TopologyKey: corev1.LabelHostname,
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app.kubernetes.io/instance": "test-cluster"},
+					},
+				},
+			},
+		},
+	}
+
+	rawConfigAffinity := func() *k8sruntime.RawExtension {
+		raw, err := json.Marshal(configAffinity)
+		Expect(err).NotTo(HaveOccurred())
+		return &k8sruntime.RawExtension{Raw: raw}
+	}
+
+	BeforeEach(func() {
+		handler = reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("test-image:latest", testScheme)
+		buildCtx = &reconciler.RoleGroupBuildContext{
+			ClusterName:      "test-cluster",
+			ClusterNamespace: "default",
+			ClusterLabels:    map[string]string{},
+			RoleName:         "test-role",
+			RoleSpec:         &v1alpha1.RoleSpec{},
+			RoleGroupName:    "default",
+			RoleGroupSpec:    v1alpha1.RoleGroupSpec{Replicas: ptr.To(int32(1))},
+			MergedConfig:     &config.MergedConfig{},
+			ResourceName:     "test-cluster-default",
+		}
+	})
+
+	It("applies the config affinity (RawExtension) to the pod spec", func() {
+		buildCtx.RoleGroupSpec.Config = &v1alpha1.RoleGroupConfigSpec{
+			Affinity: rawConfigAffinity(),
+		}
+
+		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.StatefulSet.Spec.Template.Spec.Affinity).To(Equal(configAffinity))
+	})
+
+	It("fails the build loudly on invalid affinity JSON", func() {
+		buildCtx.RoleGroupSpec.Config = &v1alpha1.RoleGroupConfigSpec{
+			Affinity: &k8sruntime.RawExtension{Raw: []byte(`{"podAntiAffinity": [`)},
+		}
+
+		_, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("affinity"))
+	})
+
+	It("maps gracefulShutdownTimeout to terminationGracePeriodSeconds", func() {
+		buildCtx.RoleGroupSpec.Config = &v1alpha1.RoleGroupConfigSpec{
+			GracefulShutdownTimeout: "30s",
+		}
+
+		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
+		Expect(err).NotTo(HaveOccurred())
+		grace := resources.StatefulSet.Spec.Template.Spec.TerminationGracePeriodSeconds
+		Expect(grace).NotTo(BeNil())
+		Expect(*grace).To(Equal(int64(30)))
+	})
+
+	It("fails the build loudly on an unparsable gracefulShutdownTimeout", func() {
+		buildCtx.RoleGroupSpec.Config = &v1alpha1.RoleGroupConfigSpec{
+			GracefulShutdownTimeout: "not-a-duration",
+		}
+
+		_, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
+		Expect(err).To(HaveOccurred())
+		// The error names the field and the offending value.
+		Expect(err.Error()).To(ContainSubstring("gracefulShutdownTimeout"))
+		Expect(err.Error()).To(ContainSubstring("not-a-duration"))
+	})
+
+	It("fails the build loudly on a zero or negative gracefulShutdownTimeout", func() {
+		for _, timeout := range []string{"0s", "-30s"} {
+			buildCtx.RoleGroupSpec.Config = &v1alpha1.RoleGroupConfigSpec{
+				GracefulShutdownTimeout: timeout,
+			}
+
+			_, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
+			Expect(err).To(HaveOccurred(), "timeout %q must be rejected", timeout)
+			Expect(err.Error()).To(ContainSubstring("gracefulShutdownTimeout"))
+			Expect(err.Error()).To(ContainSubstring(timeout))
+			Expect(err.Error()).To(ContainSubstring("must be a positive duration"))
+		}
+	})
+
+	It("leaves affinity and terminationGracePeriodSeconds unset when the config fields are empty", func() {
+		// Config present but with neither affinity nor gracefulShutdownTimeout set. Backward
+		// compatible: products that post-process the built StatefulSet with
+		// `if podSpec.Affinity == nil { ... }` default guards remain correct.
+		buildCtx.RoleGroupSpec.Config = &v1alpha1.RoleGroupConfigSpec{}
+
+		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
+		Expect(err).NotTo(HaveOccurred())
+		podSpec := resources.StatefulSet.Spec.Template.Spec
+		Expect(podSpec.Affinity).To(BeNil())
+		Expect(podSpec.TerminationGracePeriodSeconds).To(BeNil())
+	})
+
+	It("leaves the pod spec untouched when the whole role group config is nil", func() {
+		Expect(buildCtx.RoleGroupSpec.Config).To(BeNil())
+
+		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
+		Expect(err).NotTo(HaveOccurred())
+		podSpec := resources.StatefulSet.Spec.Template.Spec
+		Expect(podSpec.Affinity).To(BeNil())
+		Expect(podSpec.TerminationGracePeriodSeconds).To(BeNil())
+	})
+
+	It("lets a PodOverrides affinity win over the config affinity", func() {
+		buildCtx.RoleGroupSpec.Config = &v1alpha1.RoleGroupConfigSpec{
+			Affinity: rawConfigAffinity(),
+		}
+		overrideAffinity := &corev1.Affinity{
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{
+							MatchExpressions: []corev1.NodeSelectorRequirement{
+								{Key: "disktype", Operator: corev1.NodeSelectorOpIn, Values: []string{"ssd"}},
+							},
+						},
+					},
+				},
+			},
+		}
+		buildCtx.MergedConfig = &config.MergedConfig{
+			PodOverrides: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{Affinity: overrideAffinity},
+			},
+		}
+
+		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
+		Expect(err).NotTo(HaveOccurred())
+		// The builder applies PodOverrides last, so the user's pod override replaces the
+		// config-declared affinity.
+		Expect(resources.StatefulSet.Spec.Template.Spec.Affinity).To(Equal(overrideAffinity))
 	})
 })
 


### PR DESCRIPTION
## Summary

RoleGroupConfigSpec declares `Affinity` (RawExtension) and `GracefulShutdownTimeout`, but the base handler never consumed them — every product operator re-implements RawExtension parsing and termination-grace mapping (kafka's `resolveAffinity`/`resolveGracefulShutdownTimeout` is the duplicated pattern this removes; zookeeper simply lost affinity support in its refactor).

- **Affinity**: unmarshalled into `corev1.Affinity` and applied via the builder; invalid JSON fails the build loudly (silently dropping scheduling constraints could place pods on excluded nodes).
- **GracefulShutdownTimeout**: parsed as a Go duration → `terminationGracePeriodSeconds`; unparsable/zero/negative values fail loudly; positive sub-second durations round up to 1s (never truncate to 0 = instant SIGKILL); empty leaves the k8s default.
- **Precedence**: both are set before PodOverrides, which the builder applies last — user pod overrides always win.
- **Backward compatible**: affinity is only set when the CRD config provides one, so products post-processing with `if podSpec.Affinity == nil` default guards remain correct.

## Test plan
- 8 new specs (affinity lands in pod spec / invalid JSON errors / "30s"→30 / bad+non-positive durations error / empty untouched / PodOverrides wins); `make test` full suite green (reconciler coverage 80%), lint clean.

Products can drop their hand-rolled parsing in follow-ups (kafka: keep only the default-affinity fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)