### PR TITLE
feat(reconciler): shared ensure-helper for product discovery ConfigMaps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,6 +257,21 @@ Precedence (low → high): **product config < role overrides < role group overri
 
 Use `ProductConfig` for product-intrinsic and derived config (e.g. a ZooKeeper connection string built from the actual resources, a JVM heap sized from resources, role-specific keys) so the product no longer hand-builds ConfigMaps/StatefulSets. Use `ProductDefaulter` for stable, user-facing typed spec defaults.
 
+### 11. Discovery ConfigMaps
+Every product operator publishes "discovery ConfigMaps" — cluster-scoped ConfigMaps (usually named `<cluster>`, optionally suffixed like `<cluster>-nodeport`) carrying client connection info. `reconciler.EnsureDiscoveryConfigMap` (in `pkg/reconciler/discovery.go`) owns the ensure semantics; the product owns computing the data map (address aggregation differs per product) and typically calls it from a `ClusterExtension.PostReconcile`:
+
+```go
+err := reconciler.EnsureDiscoveryConfigMap(ctx, client, scheme, cr, cr.GetName(),
+    map[string]string{"KAFKA": bootstrapServers},
+    reconciler.WithDiscoveryProductName("kafka"),
+    reconciler.WithDiscoveryExtraLabels(map[string]string{
+        reconciler.ClusterLabelKey("kafka.kubedoop.dev"): cr.GetName(),
+    }),
+)
+```
+
+The helper is idempotent (CreateOrUpdate), sets a controller owner reference (the ConfigMap is GC'd with the CR), and applies canonical labels (`app.kubernetes.io/instance`, `app.kubernetes.io/managed-by`, plus `app.kubernetes.io/name` via `WithDiscoveryProductName`); extra labels/annotations are merged via options, but canonical labels always win. Data is replaced wholesale.
+
 ## Building a New Operator
 
 1. **Define CRD** - Create API types implementing `ClusterInterface` (embed `ClusterObject` for defaults)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,7 +258,7 @@ Precedence (low → high): **product config < role overrides < role group overri
 Use `ProductConfig` for product-intrinsic and derived config (e.g. a ZooKeeper connection string built from the actual resources, a JVM heap sized from resources, role-specific keys) so the product no longer hand-builds ConfigMaps/StatefulSets. Use `ProductDefaulter` for stable, user-facing typed spec defaults.
 
 ### 11. Discovery ConfigMaps
-Every product operator publishes "discovery ConfigMaps" — cluster-scoped ConfigMaps (usually named `<cluster>`, optionally suffixed like `<cluster>-nodeport`) carrying client connection info. `reconciler.EnsureDiscoveryConfigMap` (in `pkg/reconciler/discovery.go`) owns the ensure semantics; the product owns computing the data map (address aggregation differs per product) and typically calls it from a `ClusterExtension.PostReconcile`:
+Every product operator publishes "discovery ConfigMaps" — cluster-level ConfigMaps (namespaced, in the CR's namespace; usually named `<cluster>`, optionally suffixed like `<cluster>-nodeport`) carrying client connection info. `reconciler.EnsureDiscoveryConfigMap` (in `pkg/reconciler/discovery.go`) owns the ensure semantics; the product owns computing the data map (address aggregation differs per product) and typically calls it from a `ClusterExtension.PostReconcile`:
 
 ```go
 err := reconciler.EnsureDiscoveryConfigMap(ctx, client, scheme, cr, cr.GetName(),

--- a/pkg/reconciler/AGENTS.md
+++ b/pkg/reconciler/AGENTS.md
@@ -13,6 +13,7 @@ GenericReconciler framework for operator reconciliation logic and state manageme
 | `reconciler.go` | Reconciler interface definitions |
 | `status.go` | Status management utilities |
 | `finalizer.go` | Finalizer handling |
+| `discovery.go` | `EnsureDiscoveryConfigMap` — shared ensure-helper for product discovery ConfigMaps (CreateOrUpdate + controller owner ref + canonical labels; the product computes the data map) |
 
 ## Working Instructions
 

--- a/pkg/reconciler/discovery.go
+++ b/pkg/reconciler/discovery.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	"github.com/zncdatadev/operator-go/pkg/common"
+)
+
+// DiscoveryConfigMapOptions carries the optional metadata for EnsureDiscoveryConfigMap.
+// Use the WithDiscovery* option functions to populate it.
+type DiscoveryConfigMapOptions struct {
+	// ProductName, when set, is published as the "app.kubernetes.io/name" label
+	// (e.g. "kafka", "zookeeper", "hdfs").
+	ProductName string
+
+	// ExtraLabels are merged into the ConfigMap labels, e.g. the product-owned identity
+	// labels (see ClusterLabelKey). The canonical labels the framework owns
+	// (app.kubernetes.io/instance, app.kubernetes.io/managed-by, and — when ProductName is
+	// set — app.kubernetes.io/name) always win over extra labels with the same key.
+	ExtraLabels map[string]string
+
+	// Annotations are merged into the ConfigMap annotations. Unlike labels, annotation keys
+	// not listed here are preserved (e.g. kubectl.kubernetes.io/last-applied-configuration),
+	// so stale keys from earlier reconciles are not pruned.
+	Annotations map[string]string
+}
+
+// DiscoveryConfigMapOption customizes EnsureDiscoveryConfigMap.
+type DiscoveryConfigMapOption func(*DiscoveryConfigMapOptions)
+
+// WithDiscoveryProductName sets the product name published as the
+// "app.kubernetes.io/name" label.
+func WithDiscoveryProductName(product string) DiscoveryConfigMapOption {
+	return func(o *DiscoveryConfigMapOptions) { o.ProductName = product }
+}
+
+// WithDiscoveryExtraLabels merges extra labels into the discovery ConfigMap, e.g. the
+// product identity labels (ClusterLabelKey(domain): cluster name).
+func WithDiscoveryExtraLabels(labels map[string]string) DiscoveryConfigMapOption {
+	return func(o *DiscoveryConfigMapOptions) {
+		if o.ExtraLabels == nil {
+			o.ExtraLabels = make(map[string]string, len(labels))
+		}
+		for k, v := range labels {
+			o.ExtraLabels[k] = v
+		}
+	}
+}
+
+// WithDiscoveryAnnotations merges annotations into the discovery ConfigMap.
+func WithDiscoveryAnnotations(annotations map[string]string) DiscoveryConfigMapOption {
+	return func(o *DiscoveryConfigMapOptions) {
+		if o.Annotations == nil {
+			o.Annotations = make(map[string]string, len(annotations))
+		}
+		for k, v := range annotations {
+			o.Annotations[k] = v
+		}
+	}
+}
+
+// EnsureDiscoveryConfigMap creates or updates a product "discovery ConfigMap": a
+// cluster-scoped ConfigMap, usually named after the CR (optionally suffixed, e.g.
+// "<cluster>-nodeport"), that publishes client connection info for the product.
+//
+// The split of responsibilities is deliberately modest. The framework owns the ensure
+// semantics only:
+//   - idempotent CreateOrUpdate (repeated calls with the same data are no-ops, changed
+//     data is updated in place),
+//   - a controller owner reference on the CR, so the ConfigMap is garbage-collected with it,
+//   - the canonical labels: app.kubernetes.io/instance (the CR name) and
+//     app.kubernetes.io/managed-by ("operator-go", matching the role-group resources built
+//     by BaseRoleGroupHandler), plus app.kubernetes.io/name when WithDiscoveryProductName
+//     is given and any extra labels/annotations from the options.
+//
+// The PRODUCT owns computing the data map — address aggregation differs per product
+// (Kafka aggregates bootstrap Listener ingress addresses into a KAFKA key, ZooKeeper
+// renders ZOOKEEPER/ZOOKEEPER_HOSTS/... from pod FQDNs or NodePorts, HDFS renders client
+// core-site.xml/hdfs-site.xml) and is passed in as-is. Data is replaced wholesale, so keys
+// removed by the product disappear from the ConfigMap.
+//
+// The ConfigMap lives in the owner's namespace. It lives in pkg/reconciler because this
+// package already owns the framework's apply/ensure path and the canonical label helpers
+// (ClusterLabelKey and friends), and — unlike pkg/common — may depend on them.
+//
+// Intended consumers (each currently hand-rolls this in a ClusterExtension PostReconcile):
+//   - kafka-operator internal/controller/discovery_extension.go
+//   - zookeeper-operator internal/controller/cluster_extension.go (cluster-level discovery)
+//     and its ZookeeperZnode per-znode discovery
+//   - hdfs-operator discovery extension
+func EnsureDiscoveryConfigMap(
+	ctx context.Context,
+	c client.Client,
+	scheme *runtime.Scheme,
+	owner common.ClusterInterface,
+	name string,
+	data map[string]string,
+	opts ...DiscoveryConfigMapOption,
+) error {
+	if name == "" {
+		return fmt.Errorf("discovery configmap name must not be empty")
+	}
+	// SetControllerReference needs a client.Object; every real CR is one, so the runtime
+	// object of a ClusterInterface is expected to be too (same contract the reconciler's
+	// own apply path relies on).
+	ownerObj, ok := owner.GetRuntimeObject().(client.Object)
+	if !ok {
+		return fmt.Errorf("discovery configmap owner %q: runtime object %T is not a client.Object", owner.GetName(), owner.GetRuntimeObject())
+	}
+
+	options := &DiscoveryConfigMapOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	labels := make(map[string]string, len(options.ExtraLabels)+3)
+	for k, v := range options.ExtraLabels {
+		labels[k] = v
+	}
+	// Canonical labels are framework-owned and set last, so extras cannot override them:
+	// consumers select discovery ConfigMaps by these keys.
+	labels["app.kubernetes.io/instance"] = owner.GetName()
+	labels["app.kubernetes.io/managed-by"] = "operator-go"
+	if options.ProductName != "" {
+		labels["app.kubernetes.io/name"] = options.ProductName
+	}
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: owner.GetNamespace(),
+		},
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, c, cm, func() error {
+		cm.Labels = labels
+		for k, v := range options.Annotations {
+			if cm.Annotations == nil {
+				cm.Annotations = make(map[string]string, len(options.Annotations))
+			}
+			cm.Annotations[k] = v
+		}
+		cm.Data = data
+		return controllerutil.SetControllerReference(ownerObj, cm, scheme)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to ensure discovery configmap %s/%s: %w", owner.GetNamespace(), name, err)
+	}
+	return nil
+}

--- a/pkg/reconciler/discovery.go
+++ b/pkg/reconciler/discovery.go
@@ -83,8 +83,9 @@ func WithDiscoveryAnnotations(annotations map[string]string) DiscoveryConfigMapO
 }
 
 // EnsureDiscoveryConfigMap creates or updates a product "discovery ConfigMap": a
-// cluster-scoped ConfigMap, usually named after the CR (optionally suffixed, e.g.
-// "<cluster>-nodeport"), that publishes client connection info for the product.
+// cluster-level ConfigMap (namespaced, written into the CR's namespace), usually named
+// after the CR (optionally suffixed, e.g. "<cluster>-nodeport"), that publishes client
+// connection info for the product.
 //
 // The split of responsibilities is deliberately modest. The framework owns the ensure
 // semantics only:
@@ -126,9 +127,10 @@ func EnsureDiscoveryConfigMap(
 	// SetControllerReference needs a client.Object; every real CR is one, so the runtime
 	// object of a ClusterInterface is expected to be too (same contract the reconciler's
 	// own apply path relies on).
-	ownerObj, ok := owner.GetRuntimeObject().(client.Object)
+	runtimeObj := owner.GetRuntimeObject()
+	ownerObj, ok := runtimeObj.(client.Object)
 	if !ok {
-		return fmt.Errorf("discovery configmap owner %q: runtime object %T is not a client.Object", owner.GetName(), owner.GetRuntimeObject())
+		return fmt.Errorf("discovery configmap owner %q: runtime object %T is not a client.Object", owner.GetName(), runtimeObj)
 	}
 
 	options := &DiscoveryConfigMapOptions{}

--- a/pkg/reconciler/discovery_test.go
+++ b/pkg/reconciler/discovery_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler_test
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/zncdatadev/operator-go/pkg/reconciler"
+	"github.com/zncdatadev/operator-go/pkg/testutil"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("EnsureDiscoveryConfigMap", func() {
+	const namespace = "default"
+
+	var (
+		crName  string
+		mockCR  *testutil.MockCluster
+		owner   *testutil.ClusterWrapper
+		getCM   func(name string) *corev1.ConfigMap
+		cleanup []string
+	)
+
+	BeforeEach(func() {
+		crName = fmt.Sprintf("discovery-cr-%d", time.Now().UnixNano())
+		mockCR = testutil.NewMockCluster(crName, namespace)
+		Expect(k8sClient.Create(ctx, mockCR)).To(Succeed())
+		owner = testutil.WrapMockCluster(mockCR, testScheme)
+		cleanup = nil
+
+		getCM = func(name string) *corev1.ConfigMap {
+			cm := &corev1.ConfigMap{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, cm)).To(Succeed())
+			return cm
+		}
+	})
+
+	AfterEach(func() {
+		// envtest has no GC controller, so owned ConfigMaps are deleted explicitly.
+		for _, name := range cleanup {
+			cm := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace}}
+			_ = k8sClient.Delete(ctx, cm)
+		}
+		_ = k8sClient.Delete(ctx, mockCR)
+	})
+
+	ensure := func(name string, data map[string]string, opts ...reconciler.DiscoveryConfigMapOption) error {
+		cleanup = append(cleanup, name)
+		return reconciler.EnsureDiscoveryConfigMap(ctx, k8sClient, testScheme, owner, name, data, opts...)
+	}
+
+	It("creates the ConfigMap with a controller owner reference and canonical labels", func() {
+		Expect(ensure(crName, map[string]string{"KAFKA": "broker-0:9092"},
+			reconciler.WithDiscoveryProductName("kafka"),
+		)).To(Succeed())
+
+		cm := getCM(crName)
+		Expect(cm.Data).To(Equal(map[string]string{"KAFKA": "broker-0:9092"}))
+		Expect(cm.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "kafka"))
+		Expect(cm.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", crName))
+		Expect(cm.Labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "operator-go"))
+
+		// Controller owner reference -> garbage-collected with the CR.
+		Expect(cm).To(testutil.HaveOwnerReference(crName, "MockCluster"))
+		controllerRef := metav1.GetControllerOf(cm)
+		Expect(controllerRef).NotTo(BeNil())
+		fetchedCR := &testutil.MockCluster{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: crName}, fetchedCR)).To(Succeed())
+		Expect(controllerRef.UID).To(Equal(fetchedCR.UID))
+	})
+
+	It("updates the ConfigMap in place when the data changes", func() {
+		Expect(ensure(crName, map[string]string{"KAFKA": "broker-0:9092", "STALE": "x"})).To(Succeed())
+		created := getCM(crName)
+
+		Expect(ensure(crName, map[string]string{"KAFKA": "broker-0:9092,broker-1:9092"})).To(Succeed())
+
+		updated := getCM(crName)
+		// Same object (updated, not recreated), data replaced wholesale: stale keys pruned.
+		Expect(updated.UID).To(Equal(created.UID))
+		Expect(updated.Data).To(Equal(map[string]string{"KAFKA": "broker-0:9092,broker-1:9092"}))
+	})
+
+	It("is idempotent when nothing changes", func() {
+		data := map[string]string{"ZOOKEEPER": "zk-0:2181/"}
+		Expect(ensure(crName, data)).To(Succeed())
+		created := getCM(crName)
+
+		Expect(ensure(crName, data)).To(Succeed())
+
+		unchanged := getCM(crName)
+		Expect(unchanged.UID).To(Equal(created.UID))
+		Expect(unchanged.ResourceVersion).To(Equal(created.ResourceVersion))
+	})
+
+	It("merges extra labels but keeps the canonical labels authoritative", func() {
+		Expect(ensure(crName, map[string]string{"KAFKA": "broker-0:9092"},
+			reconciler.WithDiscoveryProductName("kafka"),
+			reconciler.WithDiscoveryExtraLabels(map[string]string{
+				reconciler.ClusterLabelKey("kafka.kubedoop.dev"): crName,
+				"app.kubernetes.io/instance":                     "spoofed",
+			}),
+		)).To(Succeed())
+
+		cm := getCM(crName)
+		// Product identity label merged.
+		Expect(cm.Labels).To(HaveKeyWithValue("kafka.kubedoop.dev/cluster", crName))
+		// Canonical label wins over the conflicting extra label.
+		Expect(cm.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", crName))
+	})
+
+	It("merges annotations without pruning foreign keys", func() {
+		Expect(ensure(crName, map[string]string{"KAFKA": "broker-0:9092"},
+			reconciler.WithDiscoveryAnnotations(map[string]string{"kubedoop.dev/note": "v1"}),
+		)).To(Succeed())
+
+		// A foreign controller adds its own annotation.
+		cm := getCM(crName)
+		cm.Annotations["other.io/keep"] = "yes"
+		Expect(k8sClient.Update(ctx, cm)).To(Succeed())
+
+		Expect(ensure(crName, map[string]string{"KAFKA": "broker-0:9092"},
+			reconciler.WithDiscoveryAnnotations(map[string]string{"kubedoop.dev/note": "v2"}),
+		)).To(Succeed())
+
+		cm = getCM(crName)
+		Expect(cm.Annotations).To(HaveKeyWithValue("kubedoop.dev/note", "v2"))
+		Expect(cm.Annotations).To(HaveKeyWithValue("other.io/keep", "yes"))
+	})
+
+	It("supports suffixed ConfigMaps for the same owner (e.g. nodeport variant)", func() {
+		for _, name := range []string{crName, crName + "-nodeport"} {
+			Expect(ensure(name, map[string]string{"KAFKA": "node-0:31234"})).To(Succeed())
+		}
+
+		for _, name := range []string{crName, crName + "-nodeport"} {
+			cm := getCM(name)
+			Expect(cm).To(testutil.HaveOwnerReference(crName, "MockCluster"))
+			Expect(cm.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", crName))
+		}
+	})
+
+	It("rejects an empty ConfigMap name", func() {
+		err := reconciler.EnsureDiscoveryConfigMap(ctx, k8sClient, testScheme, owner, "", nil)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("name must not be empty"))
+	})
+})


### PR DESCRIPTION
## Summary

Every product operator publishes cluster-scoped discovery ConfigMaps and hand-rolls the same ensure boilerplate. Surveyed kafka (`discovery_extension.go`), zookeeper (`internal/common/discovery.go` + cluster extension) and hdfs: the true common denominator is exactly the ensure step — `CreateOrUpdate` + controller owner reference + canonical labels. Address computation stays product-side.

New API in `pkg/reconciler/discovery.go`:

```go
EnsureDiscoveryConfigMap(ctx, c, scheme, owner common.ClusterInterface, name string, data map[string]string, opts...)
WithDiscoveryProductName(name)   // app.kubernetes.io/name
WithDiscoveryExtraLabels(labels) // e.g. product identity labels
WithDiscoveryAnnotations(annotations)
```

Semantics: labels + data replaced wholesale (stale keys pruned, canonical labels win over extras), annotations merged (foreign keys survive), controller owner ref → GC'd with the CR. Placed in `pkg/reconciler` because that package already owns the apply/ensure path and canonical label helpers.

No product migration in this PR; kafka/zk/hdfs call sites are cited in the doc comment as intended consumers (each collapses to a one-liner).

## Test plan
- 7 envtest specs: create with owner ref + canonical labels; in-place update with stale-key pruning; idempotency (ResourceVersion unchanged); extra-label merge with canonical precedence; annotation merge; `-nodeport` variant; empty-name rejection. 300/300 reconciler specs green; lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)