### PR TITLE
feat(builder): opt-in named targetPort for the metrics Service

### DIFF
--- a/pkg/builder/AGENTS.md
+++ b/pkg/builder/AGENTS.md
@@ -15,6 +15,7 @@ Kubernetes resource builders for StatefulSet, Service, ConfigMap, PDB, RBAC, and
 | `pdb_builder.go` | PodDisruptionBudget builder |
 | `rbac_builder.go` | RBAC (Role, RoleBinding) builder |
 | `serviceaccount_builder.go` | ServiceAccount builder |
+| `metrics_service_builder.go` | Metrics headless Service builder (Prometheus scrape annotations; targetPort defaults to the numeric port, `WithTargetPortName` opts into a named targetPort) |
 
 ## Working Instructions
 

--- a/pkg/builder/metrics_service_builder.go
+++ b/pkg/builder/metrics_service_builder.go
@@ -35,14 +35,15 @@ import (
 //
 // Override defaults with WithScheme() and WithPath().
 type MetricsServiceBuilder struct {
-	resourceName string
-	namespace    string
-	port         int32
-	portName     string
-	labels       map[string]string
-	selector     map[string]string
-	scheme       string
-	path         string
+	resourceName   string
+	namespace      string
+	port           int32
+	portName       string
+	targetPortName string
+	labels         map[string]string
+	selector       map[string]string
+	scheme         string
+	path           string
 }
 
 // NewMetricsServiceBuilder creates a builder for a metrics headless service.
@@ -79,6 +80,15 @@ func (b *MetricsServiceBuilder) WithPortName(name string) *MetricsServiceBuilder
 	return b
 }
 
+// WithTargetPortName targets the container port by name instead of by number.
+// By default the Service targets the numeric port; opting into a named
+// targetPort keeps the Service valid if the container port number changes,
+// as long as the container declares a port with the given name.
+func (b *MetricsServiceBuilder) WithTargetPortName(name string) *MetricsServiceBuilder {
+	b.targetPortName = name
+	return b
+}
+
 // WithSelector sets a dedicated pod selector (default: the labels). Use this to decouple the
 // selector from the descriptive labels.
 func (b *MetricsServiceBuilder) WithSelector(selector map[string]string) *MetricsServiceBuilder {
@@ -112,6 +122,11 @@ func (b *MetricsServiceBuilder) Build() *corev1.Service {
 		selector = map[string]string{}
 	}
 
+	targetPort := intstr.FromInt(int(b.port))
+	if b.targetPortName != "" {
+		targetPort = intstr.FromString(b.targetPortName)
+	}
+
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        b.resourceName + "-metrics",
@@ -126,7 +141,7 @@ func (b *MetricsServiceBuilder) Build() *corev1.Service {
 				{
 					Name:       b.portName,
 					Port:       b.port,
-					TargetPort: intstr.FromInt(int(b.port)),
+					TargetPort: targetPort,
 				},
 			},
 		},

--- a/pkg/builder/metrics_service_builder_test.go
+++ b/pkg/builder/metrics_service_builder_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/zncdatadev/operator-go/pkg/builder"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 var _ = Describe("MetricsServiceBuilder", func() {
@@ -73,6 +74,7 @@ var _ = Describe("MetricsServiceBuilder", func() {
 			Expect(svc.Spec.Ports).To(HaveLen(1))
 			Expect(svc.Spec.Ports[0].Name).To(Equal("metrics"))
 			Expect(svc.Spec.Ports[0].Port).To(Equal(port))
+			Expect(svc.Spec.Ports[0].TargetPort).To(Equal(intstr.FromInt(int(port))))
 		})
 
 		It("should not mutate the original labels map", func() {
@@ -116,6 +118,44 @@ var _ = Describe("MetricsServiceBuilder", func() {
 				Build()
 
 			Expect(svc.Spec.Ports[0].Name).To(Equal("jmx-metrics"))
+		})
+
+		It("should not change the numeric targetPort", func() {
+			svc := builder.NewMetricsServiceBuilder(resourceName, namespace, port, labels).
+				WithPortName("jmx-metrics").
+				Build()
+
+			Expect(svc.Spec.Ports[0].TargetPort).To(Equal(intstr.FromInt(int(port))))
+		})
+	})
+
+	Describe("WithTargetPortName", func() {
+		It("should target the container port by name", func() {
+			svc := builder.NewMetricsServiceBuilder(resourceName, namespace, port, labels).
+				WithTargetPortName("metrics").
+				Build()
+
+			Expect(svc.Spec.Ports[0].TargetPort).To(Equal(intstr.FromString("metrics")))
+		})
+
+		It("should keep the numeric port and default port name", func() {
+			svc := builder.NewMetricsServiceBuilder(resourceName, namespace, port, labels).
+				WithTargetPortName("metrics").
+				Build()
+
+			Expect(svc.Spec.Ports[0].Name).To(Equal("metrics"))
+			Expect(svc.Spec.Ports[0].Port).To(Equal(port))
+			Expect(svc.Annotations).To(HaveKeyWithValue("prometheus.io/port", "9505"))
+		})
+
+		It("should combine with WithPortName independently", func() {
+			svc := builder.NewMetricsServiceBuilder(resourceName, namespace, port, labels).
+				WithPortName("jmx-metrics").
+				WithTargetPortName("jmx").
+				Build()
+
+			Expect(svc.Spec.Ports[0].Name).To(Equal("jmx-metrics"))
+			Expect(svc.Spec.Ports[0].TargetPort).To(Equal(intstr.FromString("jmx")))
 		})
 	})
 })


### PR DESCRIPTION
## Summary

`MetricsServiceBuilder` always renders a numeric `targetPort`. Named target ports are more robust when the container declares named ports (renumbering doesn't break the Service), and pre-framework operators (kafka) used them.

Adds opt-in `WithTargetPortName(name)` → `targetPort: <name>`. **Default behavior unchanged** (existing adopters assert numeric targetPort in e2e).

## Test plan
- New specs: default numeric unchanged; named targetPort rendered; `WithPortName` independence/interplay. Build/test/lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)