### PR TITLE
fix(listener): omit the class annotation for by-name volume registrations

### DIFF
--- a/pkg/listener/provisioner.go
+++ b/pkg/listener/provisioner.go
@@ -63,6 +63,9 @@ func (p *ListenerProvisioner) WithMountBasePath(basePath string) *ListenerProvis
 // registration gives the CSI provisioner nothing to provision from.
 func (p *ListenerProvisioner) RegisterVolume(registrations ...*VolumeRegistration) *ListenerProvisioner {
 	for _, reg := range registrations {
+		if reg == nil {
+			panic("listener volume registration must not be nil")
+		}
 		if _, exists := p.volumeNames[reg.volumeName]; exists {
 			panic(fmt.Sprintf("listener volume %q is already registered", reg.volumeName))
 		}

--- a/pkg/listener/provisioner.go
+++ b/pkg/listener/provisioner.go
@@ -58,11 +58,16 @@ func (p *ListenerProvisioner) WithMountBasePath(basePath string) *ListenerProvis
 }
 
 // RegisterVolume adds CSI volume declarations to the provisioner.
-// Panics if a volume with the same name is already registered.
+// Panics if a volume with the same name is already registered, or if a
+// registration has neither a listener class nor a listener name — such a
+// registration gives the CSI provisioner nothing to provision from.
 func (p *ListenerProvisioner) RegisterVolume(registrations ...*VolumeRegistration) *ListenerProvisioner {
 	for _, reg := range registrations {
 		if _, exists := p.volumeNames[reg.volumeName]; exists {
 			panic(fmt.Sprintf("listener volume %q is already registered", reg.volumeName))
+		}
+		if reg.listenerClass == "" && reg.listenerName == "" {
+			panic(fmt.Sprintf("listener volume %q must set a listener class or a listener name", reg.volumeName))
 		}
 		p.volumeNames[reg.volumeName] = struct{}{}
 		p.volumeRegs = append(p.volumeRegs, reg)

--- a/pkg/listener/provisioner_test.go
+++ b/pkg/listener/provisioner_test.go
@@ -87,6 +87,34 @@ var _ = Describe("ListenerProvisioner", func() {
 			))
 		})
 
+		It("should set both annotations when class and listener name are given", func() {
+			provisioner.RegisterVolume(
+				listener.NewVolume("listener", listener.ListenerClassClusterInternal).
+					WithListenerName("my-listener"),
+			)
+			volumes := provisioner.Volumes()
+			annotations := volumes[0].Ephemeral.VolumeClaimTemplate.Annotations
+			Expect(annotations).To(HaveKeyWithValue(
+				listener.ListenerClassAnnotation, "cluster-internal",
+			))
+			Expect(annotations).To(HaveKeyWithValue(
+				listener.AnnotationListenerName, "my-listener",
+			))
+		})
+
+		It("should omit class annotation for by-name registrations", func() {
+			provisioner.RegisterVolume(
+				listener.NewVolume("listener", "").
+					WithListenerName("my-listener"),
+			)
+			volumes := provisioner.Volumes()
+			annotations := volumes[0].Ephemeral.VolumeClaimTemplate.Annotations
+			Expect(annotations).NotTo(HaveKey(listener.ListenerClassAnnotation))
+			Expect(annotations).To(HaveKeyWithValue(
+				listener.AnnotationListenerName, "my-listener",
+			))
+		})
+
 		It("should use EphemeralVolumeSource with correct PVC spec", func() {
 			provisioner.RegisterVolume(
 				listener.NewVolume("listener", listener.ListenerClassClusterInternal),
@@ -128,6 +156,14 @@ var _ = Describe("ListenerProvisioner", func() {
 					listener.NewVolume("vol", listener.ListenerClassExternalStable),
 				)
 			}).To(Panic())
+		})
+
+		It("should panic when neither class nor listener name is set", func() {
+			Expect(func() {
+				provisioner.RegisterVolume(
+					listener.NewVolume("vol", ""),
+				)
+			}).To(PanicWith(ContainSubstring("must set a listener class or a listener name")))
 		})
 
 		It("should return empty volumes when none registered", func() {

--- a/pkg/listener/provisioner_test.go
+++ b/pkg/listener/provisioner_test.go
@@ -166,6 +166,12 @@ var _ = Describe("ListenerProvisioner", func() {
 			}).To(PanicWith(ContainSubstring("must set a listener class or a listener name")))
 		})
 
+		It("should panic on a nil registration with a clear message", func() {
+			Expect(func() {
+				provisioner.RegisterVolume(nil)
+			}).To(PanicWith(ContainSubstring("must not be nil")))
+		})
+
 		It("should return empty volumes when none registered", func() {
 			Expect(provisioner.Volumes()).To(BeEmpty())
 		})

--- a/pkg/listener/registration.go
+++ b/pkg/listener/registration.go
@@ -32,6 +32,9 @@ type VolumeRegistration struct {
 }
 
 // NewVolume creates a VolumeRegistration with the given volume name and listener class.
+// The class may be empty when the volume references a pre-created Listener by name
+// via WithListenerName; a registration with neither a class nor a listener name is
+// rejected by ListenerProvisioner.RegisterVolume.
 func NewVolume(name string, class ListenerClass) *VolumeRegistration {
 	return &VolumeRegistration{
 		volumeName:    name,
@@ -52,9 +55,14 @@ func (r *VolumeRegistration) WithListenerName(name string) *VolumeRegistration {
 }
 
 // buildAnnotations constructs the PVC template annotations for this registration.
+// The class annotation is omitted when the listener class is empty (by-name
+// registrations): an empty class would at best be noise and at worst confuse
+// the listener-operator CSI provisioner.
 func (r *VolumeRegistration) buildAnnotations() map[string]string {
-	annotations := map[string]string{
-		ListenerClassAnnotation: string(r.listenerClass),
+	annotations := map[string]string{}
+
+	if r.listenerClass != "" {
+		annotations[ListenerClassAnnotation] = string(r.listenerClass)
 	}
 
 	if r.scope != nil {


### PR DESCRIPTION
## Summary

`VolumeRegistration.buildAnnotations` always wrote `listeners.kubedoop.dev/class`, even when the class is empty — the by-name case (`WithListenerName`, e.g. kafka's bootstrap listener volume). An empty class annotation is at best noise and at worst confuses the listener-operator CSI provisioner.

- Omit the class annotation when the class is empty.
- Guard in `RegisterVolume` (the package's established panic site for registration errors): a registration with neither class nor listener name now panics with a clear message — such a volume gives the provisioner nothing to provision from.

## Test plan
- Specs: class-only → class annotation; name-only → listener-name annotation, no class key; both → both; neither → panic. Build/test/lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)