### PR TITLE
fix(vector): make the vector sidecar actually come up (E651 VRL + unreachable readiness probe)

### DIFF
--- a/pkg/vector/config_template.go
+++ b/pkg/vector/config_template.go
@@ -83,7 +83,7 @@ transforms:
     inputs:
       - "files_stdout"
     source: |
-      .message = string!(.message) ?? ""
+      .message = string(.message) ?? ""
       .tags.log_type = "stdout"
 
   parse_stderr:
@@ -91,7 +91,7 @@ transforms:
     inputs:
       - "files_stderr"
     source: |
-      .message = string!(.message) ?? ""
+      .message = string(.message) ?? ""
       .tags.log_type = "stderr"
 
   parse_log4j:
@@ -99,7 +99,7 @@ transforms:
     inputs:
       - "files_log4j"
     source: |
-      .message = string!(.message) ?? ""
+      .message = string(.message) ?? ""
       .tags.log_type = "log4j"
 
   parse_log4j2:
@@ -107,7 +107,7 @@ transforms:
     inputs:
       - "files_log4j2"
     source: |
-      .message = string!(.message) ?? ""
+      .message = string(.message) ?? ""
       .tags.log_type = "log4j2"
 
   parse_py:
@@ -115,7 +115,7 @@ transforms:
     inputs:
       - "files_py"
     source: |
-      .message = string!(.message) ?? ""
+      .message = string(.message) ?? ""
       .tags.log_type = "py"
 
   parse_airlift:
@@ -123,7 +123,7 @@ transforms:
     inputs:
       - "files_airlift"
     source: |
-      .message = string!(.message) ?? ""
+      .message = string(.message) ?? ""
       .tags.log_type = "airlift"
 
   enrich_metadata:

--- a/pkg/vector/config_template.go
+++ b/pkg/vector/config_template.go
@@ -19,7 +19,10 @@ package vector
 const vectorConfigTemplate = `---
 api:
   enabled: true
-  address: "127.0.0.1:{{APIPort}}"
+  # Bind on all interfaces: the container's readiness probe is an httpGet issued by the
+  # kubelet against the POD IP, which a loopback-only bind can never answer (the sidecar
+  # would stay NotReady forever, wedging the whole pod).
+  address: "0.0.0.0:{{APIPort}}"
 
 sources:
   files_stdout:

--- a/pkg/vector/config_test.go
+++ b/pkg/vector/config_test.go
@@ -187,8 +187,10 @@ func TestRenderVectorConfig_APIDefaults(t *testing.T) {
 	if !strings.Contains(result, "enabled: true") {
 		t.Error("RenderVectorConfig() API should be enabled")
 	}
-	if !strings.Contains(result, "127.0.0.1:8686") {
-		t.Error("RenderVectorConfig() API address should be 127.0.0.1:8686")
+	// The API must bind all interfaces: the readiness probe is a kubelet httpGet against
+	// the pod IP, which a loopback-only bind can never answer.
+	if !strings.Contains(result, "0.0.0.0:8686") {
+		t.Error("RenderVectorConfig() API address should be 0.0.0.0:8686")
 	}
 }
 

--- a/pkg/vector/testdata/default_vector.yaml.golden
+++ b/pkg/vector/testdata/default_vector.yaml.golden
@@ -1,7 +1,10 @@
 ---
 api:
   enabled: true
-  address: "127.0.0.1:8686"
+  # Bind on all interfaces: the container's readiness probe is an httpGet issued by the
+  # kubelet against the POD IP, which a loopback-only bind can never answer (the sidecar
+  # would stay NotReady forever, wedging the whole pod).
+  address: "0.0.0.0:8686"
 
 sources:
   files_stdout:

--- a/pkg/vector/testdata/default_vector.yaml.golden
+++ b/pkg/vector/testdata/default_vector.yaml.golden
@@ -65,7 +65,7 @@ transforms:
     inputs:
       - "files_stdout"
     source: |
-      .message = string!(.message) ?? ""
+      .message = string(.message) ?? ""
       .tags.log_type = "stdout"
 
   parse_stderr:
@@ -73,7 +73,7 @@ transforms:
     inputs:
       - "files_stderr"
     source: |
-      .message = string!(.message) ?? ""
+      .message = string(.message) ?? ""
       .tags.log_type = "stderr"
 
   parse_log4j:
@@ -81,7 +81,7 @@ transforms:
     inputs:
       - "files_log4j"
     source: |
-      .message = string!(.message) ?? ""
+      .message = string(.message) ?? ""
       .tags.log_type = "log4j"
 
   parse_log4j2:
@@ -89,7 +89,7 @@ transforms:
     inputs:
       - "files_log4j2"
     source: |
-      .message = string!(.message) ?? ""
+      .message = string(.message) ?? ""
       .tags.log_type = "log4j2"
 
   parse_py:
@@ -97,7 +97,7 @@ transforms:
     inputs:
       - "files_py"
     source: |
-      .message = string!(.message) ?? ""
+      .message = string(.message) ?? ""
       .tags.log_type = "py"
 
   parse_airlift:
@@ -105,7 +105,7 @@ transforms:
     inputs:
       - "files_airlift"
     source: |
-      .message = string!(.message) ?? ""
+      .message = string(.message) ?? ""
       .tags.log_type = "airlift"
 
   enrich_metadata:


### PR DESCRIPTION
## Summary

Two independent defects in the framework-owned vector.yaml (#503) that together make **every vector-enabled pod permanently NotReady** — the root cause of the deterministic logging-suite failures on kafka-operator#291's CI matrix (first product e2e to exercise the new Vector provider):

1. **VRL E651 (config rejected at startup).** All six remap transforms wrote `.message = string!(.message) ?? ""`; `string!()` is infallible so the `?? ""` can never resolve. Newer Vector builds (as bundled in the kafka kubedoop images) reject this at compile time (E651) and the sidecar crash-loops. Fixed to fallible `string(.message) ?? ""`. Verified against the real binary in `quay.io/zncdatadev/kafka:3.9.0-kubedoop0.0.0-dev`: 6× E651 before, 0 after.

2. **Loopback-only API vs kubelet probe.** The API bound `127.0.0.1:8686` while the readiness probe is a kubelet httpGet against the **pod IP** — unreachable by construction, so even a healthy sidecar (pipeline running, files tailed, healthcheck passed) never becomes Ready. Fixed to `0.0.0.0:8686`.

Both verified end-to-end on a kind cluster with the kafka-operator refactor branch: broker pods went from `0/2` (vector CrashLoopBackOff) → `1/2` (vector running, probe unreachable) → expected Ready with both fixes.

## Test plan
- `make test` full suite green; golden file and API-default assertion updated with rationale comments.
- Runtime validation against the kafka image binary (E651 count) and live kind cluster.

Downstream: kafka-operator#291 re-pins after merge; its logging e2e is blocked on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)