### PR TITLE
docs(example): sync the trino example with the recently merged framework capabilities

### DIFF
--- a/examples/trino-operator/AGENTS.md
+++ b/examples/trino-operator/AGENTS.md
@@ -15,7 +15,7 @@ Complete Trino operator implementation demonstrating the operator-go framework w
 | `internal/controller/` | `TrinoRoleGroupHandler` — embeds the SDK `BaseRoleGroupHandler`; the framework owns resource orchestration |
 | `internal/product/` | `ProductConfig` hook (`product.ComputeConfig`): Trino's `config.properties` (role-branched, derived) computed and returned as data |
 | `internal/config/` | `JVMConfigBuilder` (non-key-value `jvm.config`) and `CatalogConfigBuilder` |
-| `internal/extensions/` | Catalog validation + health (ClusterExtension / RoleExtension) |
+| `internal/extensions/` | Catalog validation + health + discovery ConfigMap (ClusterExtension / RoleExtension; discovery uses `reconciler.EnsureDiscoveryConfigMap`) |
 
 ## Architecture (ProductConfig pattern)
 
@@ -24,6 +24,8 @@ This example demonstrates the SDK's preferred division of labour:
 - **Framework owns the 90%.** `TrinoRoleGroupHandler` embeds `reconciler.BaseRoleGroupHandler`, so the ConfigMap, Services, StatefulSet (with sidecars + `podOverrides` applied), and PDB are built by the SDK. The handler sets `ConfigMountPath` (`/etc/trino`), `MainContainerName` (`trino`), `LoggingContainers` (declarative Log4j2), and per-role ports.
 - **Logging is fully framework-owned.** `LoggingContainers` declares only the container + framework (no output file — the framework derives `<LogDir>/<lowercased container>/<container>.<framework suffix>`, e.g. `.log4j.xml` for log4j/logback). When a role group enables the Vector agent, the SDK's Vector provider is the single owner of the shared log volume (creates it, RW-mounts the producer, mounts it on the agent, which pre-creates the per-container log dirs before exec'ing vector), and — because `TrinoCluster` implements `reconciler.VectorAggregatorProvider` (`VectorAggregatorConfigMapName()` from `spec.clusterConfig`) — the framework also generates `vector.yaml` into the ConfigMap. The product writes no Vector wiring by hand.
 - **Product config flows as data through the merge pipeline.** `product.ComputeConfig` computes `config.properties` and returns it as an `*OverridesSpec`, wired via `GenericReconcilerConfig.ProductConfig` — the lowest merge layer, so any user `configOverrides` in the CRD always win. This is config generation (recomputed every reconcile), not webhook defaulting.
+- **Scheduling and shutdown are declarative.** The framework consumes the role group config's `affinity` (a raw `corev1.Affinity`) and `gracefulShutdownTimeout` (mapped to `terminationGracePeriodSeconds`); user `podOverrides` keep precedence over both. The sample CR demonstrates `gracefulShutdownTimeout`.
+- **Discovery is a one-liner.** `extensions.DiscoveryExtension` (a `ClusterExtension` running PostReconcile) publishes the coordinator URI in a discovery ConfigMap named after the cluster via `reconciler.EnsureDiscoveryConfigMap` — the framework owns CreateOrUpdate + controller owner reference + canonical labels; the product only computes the data map.
 - **Escape hatch for what the pipeline can't model.** `BuildResources` calls the base, then appends the CR-driven image, the non-key-value `jvm.config`, and coordinator-only catalog files. There is no hand-built `StatefulSet`.
 
 ## Working Instructions

--- a/examples/trino-operator/cmd/main.go
+++ b/examples/trino-operator/cmd/main.go
@@ -94,6 +94,12 @@ func main() {
 	healthExt := extensions.NewHealthExtension()
 	common.GetExtensionRegistry().RegisterRoleExtension(healthExt)
 
+	// Register Discovery extension (demonstrates ClusterExtension PostReconcile +
+	// reconciler.EnsureDiscoveryConfigMap): publishes the coordinator URI in a discovery
+	// ConfigMap named after the cluster, the kubedoop pattern every product follows.
+	discoveryExt := extensions.NewDiscoveryExtension(mgr.GetScheme())
+	common.GetExtensionRegistry().RegisterClusterExtension(discoveryExt)
+
 	// ==================== Create GenericReconciler ====================
 	// Use operator-go SDK's GenericReconciler instead of traditional Controller
 

--- a/examples/trino-operator/config/samples/trino_v1alpha1_trinocluster.yaml
+++ b/examples/trino-operator/config/samples/trino_v1alpha1_trinocluster.yaml
@@ -17,6 +17,10 @@ spec:
       default:
         replicas: 1
         config:
+          # Consumed by the framework (podOverrides take precedence when both are set):
+          # gracefulShutdownTimeout maps to the pod's terminationGracePeriodSeconds, and an
+          # `affinity:` block here (a full corev1.Affinity) lands on the pod spec as-is.
+          gracefulShutdownTimeout: "30s"
           resources:
             cpu:
               min: "500m"

--- a/examples/trino-operator/internal/extensions/discovery_extension.go
+++ b/examples/trino-operator/internal/extensions/discovery_extension.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extensions
+
+import (
+	"context"
+	"fmt"
+
+	trinov1alpha1 "github.com/zncdatadev/operator-go/examples/trino-operator/api/v1alpha1"
+	"github.com/zncdatadev/operator-go/examples/trino-operator/internal/product"
+	"github.com/zncdatadev/operator-go/pkg/common"
+	"github.com/zncdatadev/operator-go/pkg/reconciler"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// TrinoDiscoveryKey is the key carrying the coordinator URI in the discovery ConfigMap.
+const TrinoDiscoveryKey = "TRINO"
+
+// DiscoveryExtension is a ClusterExtension that publishes the cluster's client connection
+// info as a "discovery ConfigMap" named after the CR — the kubedoop pattern every product
+// operator follows (clients and dependent operators read the connection info from it).
+//
+// It demonstrates two SDK pieces working together:
+//   - the ClusterExtension PostReconcile hook (runs after all role groups are reconciled,
+//     so the coordinator Service exists), and
+//   - reconciler.EnsureDiscoveryConfigMap, which owns the ensure semantics (idempotent
+//     CreateOrUpdate, controller owner reference, canonical labels) while the product only
+//     computes the data map.
+type DiscoveryExtension struct {
+	common.BaseExtension
+	scheme *runtime.Scheme
+}
+
+// NewDiscoveryExtension creates a new DiscoveryExtension.
+func NewDiscoveryExtension(scheme *runtime.Scheme) *DiscoveryExtension {
+	return &DiscoveryExtension{
+		BaseExtension: common.NewBaseExtension("discovery-extension"),
+		scheme:        scheme,
+	}
+}
+
+var _ common.ClusterExtension[common.ClusterInterface] = &DiscoveryExtension{}
+
+// PreReconcile is a no-op: the coordinator Service the URI points at does not exist yet.
+func (e *DiscoveryExtension) PreReconcile(_ context.Context, _ client.Client, _ common.ClusterInterface) error {
+	return nil
+}
+
+// PostReconcile publishes the discovery ConfigMap once the role groups (and therefore the
+// coordinator Service) have been reconciled.
+func (e *DiscoveryExtension) PostReconcile(ctx context.Context, c client.Client, cr common.ClusterInterface) error {
+	trinoCR, ok := cr.(*trinov1alpha1.TrinoCluster)
+	if !ok {
+		// The extension registry is shared by every controller in the process; skip
+		// clusters of other products.
+		return nil
+	}
+
+	if err := reconciler.EnsureDiscoveryConfigMap(ctx, c, e.scheme, trinoCR, trinoCR.Name,
+		map[string]string{TrinoDiscoveryKey: product.DiscoveryURI(trinoCR)},
+		reconciler.WithDiscoveryProductName("trino"),
+	); err != nil {
+		return fmt.Errorf("failed to ensure discovery configmap %s/%s: %w", trinoCR.Namespace, trinoCR.Name, err)
+	}
+
+	log.FromContext(ctx).V(1).Info("ensured discovery configmap",
+		"cluster", trinoCR.Name, "uri", product.DiscoveryURI(trinoCR))
+	return nil
+}
+
+// OnReconcileError is a no-op.
+func (e *DiscoveryExtension) OnReconcileError(_ context.Context, _ client.Client, _ common.ClusterInterface, _ error) error {
+	return nil
+}

--- a/examples/trino-operator/internal/extensions/discovery_extension_test.go
+++ b/examples/trino-operator/internal/extensions/discovery_extension_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package extensions_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	trinov1alpha1 "github.com/zncdatadev/operator-go/examples/trino-operator/api/v1alpha1"
+	"github.com/zncdatadev/operator-go/examples/trino-operator/internal/extensions"
+	commonsv1alpha1 "github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("DiscoveryExtension", func() {
+	var scheme *runtime.Scheme
+	var cr *trinov1alpha1.TrinoCluster
+
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
+		Expect(trinov1alpha1.AddToScheme(scheme)).To(Succeed())
+
+		cr = &trinov1alpha1.TrinoCluster{
+			ObjectMeta: metav1.ObjectMeta{Name: "trino-sample", Namespace: "default"},
+			Spec: trinov1alpha1.TrinoClusterSpec{
+				Coordinators: &trinov1alpha1.CoordinatorsSpec{
+					RoleSpec: commonsv1alpha1.RoleSpec{
+						RoleGroups: map[string]commonsv1alpha1.RoleGroupSpec{
+							"default": {},
+						},
+					},
+				},
+			},
+		}
+	})
+
+	It("publishes the discovery ConfigMap with the coordinator URI and owner reference", func() {
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cr).Build()
+		ext := extensions.NewDiscoveryExtension(scheme)
+
+		Expect(ext.PostReconcile(context.Background(), c, cr)).To(Succeed())
+
+		cm := &corev1.ConfigMap{}
+		Expect(c.Get(context.Background(),
+			types.NamespacedName{Namespace: "default", Name: "trino-sample"}, cm)).To(Succeed())
+		Expect(cm.Data).To(HaveKeyWithValue(extensions.TrinoDiscoveryKey,
+			"http://trino-sample-coordinators-default:8080"))
+		Expect(cm.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", "trino"))
+		Expect(cm.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", "trino-sample"))
+		Expect(cm.OwnerReferences).To(HaveLen(1))
+		Expect(cm.OwnerReferences[0].Kind).To(Equal("TrinoCluster"))
+		Expect(*cm.OwnerReferences[0].Controller).To(BeTrue())
+	})
+
+	It("is idempotent and refreshes the data on repeated reconciles", func() {
+		c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(cr).Build()
+		ext := extensions.NewDiscoveryExtension(scheme)
+
+		Expect(ext.PostReconcile(context.Background(), c, cr)).To(Succeed())
+		Expect(ext.PostReconcile(context.Background(), c, cr)).To(Succeed())
+
+		cm := &corev1.ConfigMap{}
+		Expect(c.Get(context.Background(),
+			types.NamespacedName{Namespace: "default", Name: "trino-sample"}, cm)).To(Succeed())
+		Expect(cm.Data).To(HaveKey(extensions.TrinoDiscoveryKey))
+	})
+
+	It("skips clusters of other products without error", func() {
+		c := fake.NewClientBuilder().WithScheme(scheme).Build()
+		ext := extensions.NewDiscoveryExtension(scheme)
+		Expect(ext.PostReconcile(context.Background(), c, nil)).To(Succeed())
+	})
+})

--- a/examples/trino-operator/internal/product/config.go
+++ b/examples/trino-operator/internal/product/config.go
@@ -98,3 +98,10 @@ func coordinatorServiceName(cr *trinov1alpha1.TrinoCluster) string {
 func discoveryURI(cr *trinov1alpha1.TrinoCluster, port int32) string {
 	return fmt.Sprintf("http://%s:%d", coordinatorServiceName(cr), port)
 }
+
+// DiscoveryURI returns the client-facing coordinator URI. It backs both the workers'
+// discovery.uri in config.properties and the cluster discovery ConfigMap published by
+// extensions.DiscoveryExtension.
+func DiscoveryURI(cr *trinov1alpha1.TrinoCluster) string {
+	return discoveryURI(cr, CoordinatorPort(cr))
+}


### PR DESCRIPTION
## Summary

Brings the canonical `examples/trino-operator` in line with the five recently merged framework PRs (#517 #518 #519 #520 #523). Baseline first: the example builds and tests green against main (it tracks the framework via `replace => ../..`), so this is about the example fulfilling its teaching role, not fixing breakage.

### Per-PR assessment → action taken

| PR | Assessment | Action |
|----|-----------|--------|
| #523 vector stable pipeline | AGENTS.md was already synced in that PR; `LoggingContainers` declaration is already the canonical usage | none needed |
| #517 affinity/gracefulShutdown | Example never hand-parsed them (no code to delete), but nothing showcased the capability | AGENTS.md bullet (framework consumes both, podOverrides win) + `gracefulShutdownTimeout: "30s"` demonstrated in the sample CR |
| #518 discovery helper | **Biggest gap**: every real product publishes a discovery ConfigMap; the example had none | new `extensions.DiscoveryExtension` (ClusterExtension PostReconcile) publishing the coordinator URI via `reconciler.EnsureDiscoveryConfigMap`; registered in main.go; `product.DiscoveryURI` exported to back both config.properties and the ConfigMap; 3 specs (owner ref + canonical labels + URI, idempotency, other-product skip) |
| #519 named targetPort | Example builds no metrics Service; staging one would add surface without teaching value | intentionally skipped; kafka-operator#291 is the real-world reference |
| #520 listener by-name registration | Example uses no listener volumes (pure ClusterIP demo) | intentionally skipped; same reference |

## Test plan
- `make test` in the example: all packages green (extensions coverage 66.7%, controller 95.2%); golangci-lint 0 issues.
- The new spec pins the published URI shape (`http://trino-sample-coordinators-default:8080`) against the SDK's role-group naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)