### PR TITLE
fix(reconciler): propagate desired state on update in applyResource

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,8 @@ The `GenericReconciler` provides a fixed reconciliation flow with customizable e
 8. PostReconcile Extensions
 9. Final Status Update
 
+Each "Apply" is create-OR-UPDATE (issue #526): when the resource already exists, the live object is updated to the handler-built desired state every reconcile — labels are replaced wholesale, annotations are merged (foreign annotations survive), and spec/data is copied per kind while preserving Kubernetes immutable/allocated fields (StatefulSet `selector`/`serviceName`/`volumeClaimTemplates`/`podManagementPolicy`; Service `clusterIP(s)`/`ipFamilies` and allocated NodePorts). Arbitrary-GVK extras get a generic top-level field copy. See `copyDesiredState` in `pkg/reconciler/apply.go`. Changing an immutable field for an existing cluster requires a manual delete/recreate migration.
+
 ### 3. RoleGroupHandler and BaseRoleGroupHandler
 Product operators implement `RoleGroupHandler` to define resource building logic:
 ```go

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -771,6 +771,14 @@ The rationale follows Kubernetes resource dependency rules:
 
 This creation order is the inverse of the deletion order used during orphaned resource cleanup (see §4.4.2).
 
+**Resource Application Semantics (create-or-update)**
+
+Applying a resource is not create-only: when the resource already exists, `applyResource` updates the live object to the handler-built desired state on every reconcile, so CR spec changes (replicas, config overrides, ports, ...) propagate to existing resources (issue #526). The update rules live in `copyDesiredState` (`pkg/reconciler/apply.go`):
+
+- **Labels** are framework-owned and replaced wholesale; **annotations** are merged, so foreign annotations (e.g. `kubectl.kubernetes.io/last-applied-configuration`) survive.
+- **Typed kinds** copy their spec/data from the desired object while preserving Kubernetes immutable/allocated fields: StatefulSet `selector`, `serviceName`, `volumeClaimTemplates` and `podManagementPolicy` keep their live values (changing them requires a manual delete/recreate migration); Service `clusterIP(s)`/`ipFamilies` are never touched, and NodePorts already allocated by the API server are carried over; ConfigMap data is replaced wholesale (removed keys disappear).
+- **Arbitrary GVKs** (`ExtraResources`) get a generic copy of every top-level field except `apiVersion`/`kind`/`metadata`/`status` via unstructured conversion.
+
 ### 5.3.4 Benefits
 
 - **Consistency**: All products follow the same reconciliation structure.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -758,7 +758,7 @@ The Template Method Pattern defines the skeleton of an algorithm in a base class
 Within step 3, resources are applied in a strict dependency order:
 
 ```
-ConfigMap → HeadlessService → Service → StatefulSet → PDB
+ConfigMap → HeadlessService → Service → ExtraResources → StatefulSet → PDB → MetricsService
 ```
 
 The rationale follows Kubernetes resource dependency rules:
@@ -766,8 +766,10 @@ The rationale follows Kubernetes resource dependency rules:
 1. **ConfigMap**: Applied first because Pods reference ConfigMaps as volume mounts or environment sources. The configuration data must exist before any Pod starts.
 2. **HeadlessService**: A StatefulSet requires a `serviceName` pointing to a headless Service. Kubernetes uses it to create stable, predictable DNS entries (`pod-0.svc.ns.svc.cluster.local`) for inter-pod communication. It must exist before the StatefulSet is created.
 3. **Service** (client-facing): Created before the StatefulSet so that client endpoints are available as soon as Pods become ready.
-4. **StatefulSet**: Applied after all its dependencies (configs, DNS) are in place. The StatefulSet controller then creates Pods in ordinal order.
-5. **PDB** (PodDisruptionBudget): Applied last, as it references existing Pods. It enforces availability guarantees during voluntary disruptions once the workload is running.
+4. **ExtraResources** (product-specific objects): Applied before the StatefulSet because they are typically pod-scheduling prerequisites — e.g. a Listener CR that the pods reference through an ephemeral CSI volume (see `RoleGroupResources.ExtraResources`).
+5. **StatefulSet**: Applied after all its dependencies (configs, DNS, extras) are in place. The StatefulSet controller then creates Pods in ordinal order.
+6. **PDB** (PodDisruptionBudget): Applied after the workload, as it references existing Pods. It enforces availability guarantees during voluntary disruptions once the workload is running.
+7. **MetricsService**: Applied last; it only exposes already-running Pods to Prometheus discovery and nothing depends on it.
 
 This creation order is the inverse of the deletion order used during orphaned resource cleanup (see §4.4.2).
 

--- a/pkg/reconciler/AGENTS.md
+++ b/pkg/reconciler/AGENTS.md
@@ -10,6 +10,7 @@ GenericReconciler framework for operator reconciliation logic and state manageme
 | File | Purpose |
 |------|---------|
 | `generic_reconciler.go` | Core reconciliation framework |
+| `apply.go` | `copyDesiredState` — update semantics of the apply path (issue #526): labels replaced wholesale, annotations merged, per-kind spec/data copy that preserves Kubernetes immutable fields (StatefulSet selector/serviceName/volumeClaimTemplates/podManagementPolicy; Service clusterIP/allocated NodePorts), unstructured top-level copy for arbitrary-GVK extras |
 | `reconciler.go` | Reconciler interface definitions |
 | `status.go` | Status management utilities |
 | `finalizer.go` | Finalizer handling |

--- a/pkg/reconciler/apply.go
+++ b/pkg/reconciler/apply.go
@@ -1,0 +1,265 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// copyDesiredState copies the handler-built desired state onto the live object inside a
+// controllerutil.CreateOrUpdate mutate func. controller-runtime's CreateOrUpdate overwrites
+// the passed object with LIVE cluster state on Get before running the mutate func, so without
+// this copy the desired spec/data never reaches an existing object and the apply path is
+// create-only (issue #526).
+//
+// Copy rules, in order:
+//
+//   - Labels are framework-owned and replaced WHOLESALE (consistent with
+//     EnsureDiscoveryConfigMap): labels removed from the desired object disappear from the
+//     live object, and foreign labels added out-of-band do not survive a reconcile.
+//   - Annotations are MERGED (desired wins per key): foreign annotations such as
+//     kubectl.kubernetes.io/last-applied-configuration survive reconciles.
+//   - Known kinds get a typed copy that respects Kubernetes immutable/system-managed fields
+//     (see copyStatefulSetState / copyServiceState and the per-kind cases below).
+//   - Any other kind (RoleGroupResources.ExtraResources with arbitrary GVKs, e.g. a
+//     listeners.kubedoop.dev Listener) falls back to a generic top-level field copy via
+//     unstructured conversion (see copyGenericState).
+//
+// The desired object must be a deep copy taken BEFORE CreateOrUpdate (the object passed to
+// CreateOrUpdate is clobbered with live state on Get) and must have the same concrete type as
+// live. On the create path CreateOrUpdate runs the mutate func against the not-yet-created
+// object, i.e. live == desired state already; every rule below is a no-op in that case, which
+// is exactly why desired-only-at-create fields (e.g. Service.Spec.ClusterIP) need no special
+// handling here.
+func copyDesiredState(desired, live client.Object) error {
+	// Labels: framework-owned, replaced wholesale.
+	live.SetLabels(desired.GetLabels())
+
+	// Annotations: merge desired into live so foreign annotations survive.
+	if desiredAnnotations := desired.GetAnnotations(); len(desiredAnnotations) > 0 {
+		annotations := live.GetAnnotations()
+		if annotations == nil {
+			annotations = make(map[string]string, len(desiredAnnotations))
+		}
+		for k, v := range desiredAnnotations {
+			annotations[k] = v
+		}
+		live.SetAnnotations(annotations)
+	}
+
+	switch liveObj := live.(type) {
+	case *appsv1.StatefulSet:
+		desiredObj, err := desiredAs[*appsv1.StatefulSet](desired, live)
+		if err != nil {
+			return err
+		}
+		copyStatefulSetState(desiredObj, liveObj)
+		return nil
+	case *corev1.ConfigMap:
+		desiredObj, err := desiredAs[*corev1.ConfigMap](desired, live)
+		if err != nil {
+			return err
+		}
+		// Data and BinaryData are replaced wholesale: keys removed by the product disappear
+		// from the live ConfigMap.
+		liveObj.Data = desiredObj.Data
+		liveObj.BinaryData = desiredObj.BinaryData
+		return nil
+	case *corev1.Service:
+		desiredObj, err := desiredAs[*corev1.Service](desired, live)
+		if err != nil {
+			return err
+		}
+		copyServiceState(desiredObj, liveObj)
+		return nil
+	case *corev1.ServiceAccount:
+		// A ServiceAccount has no spec the framework owns; labels/annotations (above) and the
+		// controller owner reference (set by the caller) are the whole desired state. Never
+		// touch Secrets/ImagePullSecrets — the token controller manages them.
+		return nil
+	case *policyv1.PodDisruptionBudget:
+		desiredObj, err := desiredAs[*policyv1.PodDisruptionBudget](desired, live)
+		if err != nil {
+			return err
+		}
+		liveObj.Spec = desiredObj.Spec
+		return nil
+	default:
+		return copyGenericState(desired, live)
+	}
+}
+
+// desiredAs asserts that desired has the same concrete type as live. It always does in
+// practice — applyResource deep-copies the live object's original — so this only guards
+// against future misuse with a clear error instead of a panic.
+func desiredAs[T client.Object](desired, live client.Object) (T, error) {
+	typed, ok := desired.(T)
+	if !ok {
+		return typed, fmt.Errorf("desired object type %T does not match live object type %T", desired, live)
+	}
+	return typed, nil
+}
+
+// copyStatefulSetState copies the desired StatefulSet spec onto the live one, preserving the
+// fields the Kubernetes API declares immutable after creation:
+//
+//   - Spec.Selector
+//   - Spec.ServiceName
+//   - Spec.VolumeClaimTemplates
+//   - Spec.PodManagementPolicy
+//
+// These keep their LIVE values, so a handler that starts producing different values for them
+// (e.g. a new label-selector layout after an operator upgrade) does not make every subsequent
+// Update fail against the API server. Changing them for an existing cluster requires a manual
+// migration (delete/recreate of the StatefulSet), documented as part of the upgrade path in
+// issue #526. Everything else — Replicas, Template, UpdateStrategy, MinReadySeconds,
+// PersistentVolumeClaimRetentionPolicy, ... — comes from desired.
+func copyStatefulSetState(desired, live *appsv1.StatefulSet) {
+	selector := live.Spec.Selector
+	serviceName := live.Spec.ServiceName
+	volumeClaimTemplates := live.Spec.VolumeClaimTemplates
+	podManagementPolicy := live.Spec.PodManagementPolicy
+
+	live.Spec = desired.Spec
+
+	live.Spec.Selector = selector
+	live.Spec.ServiceName = serviceName
+	live.Spec.VolumeClaimTemplates = volumeClaimTemplates
+	live.Spec.PodManagementPolicy = podManagementPolicy
+}
+
+// copyServiceState copies the desired Service spec onto the live one:
+//
+//   - Mutable framework-owned fields come from desired: Type, Selector, Ports,
+//     PublishNotReadyAddresses, SessionAffinity(+Config), External/InternalTrafficPolicy,
+//     ExternalName, ExternalIPs, LoadBalancerSourceRanges.
+//   - Ports are replaced with desired's, but for every desired port with NodePort == 0 the
+//     live port's allocated NodePort is carried over (matched by port name, falling back to
+//     port number), so NodePort/LoadBalancer services keep their stable allocated node ports
+//     across reconciles (same precedent as zookeeper-operator's cluster_extension.go).
+//   - ClusterIP, ClusterIPs, IPFamilies and IPFamilyPolicy are NEVER touched: they are
+//     immutable/allocated by the API server. The desired ClusterIP ("None" for headless
+//     services) only matters at CREATE time, where the mutate func runs against the desired
+//     object itself and the value is already in place.
+func copyServiceState(desired, live *corev1.Service) {
+	livePorts := live.Spec.Ports
+
+	live.Spec.Type = desired.Spec.Type
+	live.Spec.Selector = desired.Spec.Selector
+	live.Spec.PublishNotReadyAddresses = desired.Spec.PublishNotReadyAddresses
+	live.Spec.SessionAffinity = desired.Spec.SessionAffinity
+	live.Spec.SessionAffinityConfig = desired.Spec.SessionAffinityConfig
+	live.Spec.ExternalTrafficPolicy = desired.Spec.ExternalTrafficPolicy
+	live.Spec.InternalTrafficPolicy = desired.Spec.InternalTrafficPolicy
+	live.Spec.ExternalName = desired.Spec.ExternalName
+	live.Spec.ExternalIPs = desired.Spec.ExternalIPs
+	live.Spec.LoadBalancerSourceRanges = desired.Spec.LoadBalancerSourceRanges
+
+	ports := make([]corev1.ServicePort, len(desired.Spec.Ports))
+	copy(ports, desired.Spec.Ports)
+	for i := range ports {
+		if ports[i].NodePort != 0 {
+			continue // the handler pinned an explicit NodePort; take it as-is
+		}
+		if allocated := findServicePort(livePorts, ports[i]); allocated != nil {
+			ports[i].NodePort = allocated.NodePort
+		}
+	}
+	live.Spec.Ports = ports
+}
+
+// findServicePort finds the live port corresponding to a desired port: by name when the
+// desired port is named, falling back to the port number. Returns nil when no live port
+// matches (a genuinely new port — the API server will allocate its NodePort if needed).
+func findServicePort(livePorts []corev1.ServicePort, desired corev1.ServicePort) *corev1.ServicePort {
+	if desired.Name != "" {
+		for i := range livePorts {
+			if livePorts[i].Name == desired.Name {
+				return &livePorts[i]
+			}
+		}
+	}
+	for i := range livePorts {
+		if livePorts[i].Port == desired.Port {
+			return &livePorts[i]
+		}
+	}
+	return nil
+}
+
+// copyGenericState is the fallback for kinds without a typed rule (arbitrary-GVK
+// ExtraResources such as a listeners.kubedoop.dev Listener). Both objects are converted to
+// unstructured maps, every top-level field of desired EXCEPT apiVersion, kind, metadata and
+// status is copied onto live (that covers spec, data, stringData, ... — whatever payload the
+// kind defines), and the result is converted back into the live object. Metadata is handled
+// by copyDesiredState (labels/annotations) and the caller (owner reference); status belongs
+// to the resource's own controller. Top-level fields present only on live are kept — they are
+// typically server-managed (deliberately conservative; a product that needs to REMOVE a
+// top-level payload field of an extra resource should set it to its empty value instead).
+func copyGenericState(desired, live client.Object) error {
+	desiredMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(desired)
+	if err != nil {
+		return fmt.Errorf("failed to convert desired object %T to unstructured: %w", desired, err)
+	}
+
+	// When the live object already is unstructured (extras built as
+	// *unstructured.Unstructured), mutate its content map directly — the reflection-based
+	// FromUnstructured below only fills typed structs.
+	if liveUnstructured, ok := live.(*unstructured.Unstructured); ok {
+		for field, value := range desiredMap {
+			if isReservedTopLevelField(field) {
+				continue
+			}
+			liveUnstructured.Object[field] = value
+		}
+		return nil
+	}
+
+	liveMap, err := runtime.DefaultUnstructuredConverter.ToUnstructured(live)
+	if err != nil {
+		return fmt.Errorf("failed to convert live object %T to unstructured: %w", live, err)
+	}
+
+	for field, value := range desiredMap {
+		if isReservedTopLevelField(field) {
+			continue
+		}
+		liveMap[field] = value
+	}
+
+	if err := runtime.DefaultUnstructuredConverter.FromUnstructured(liveMap, live); err != nil {
+		return fmt.Errorf("failed to convert merged state back into live object %T: %w", live, err)
+	}
+	return nil
+}
+
+// isReservedTopLevelField reports whether a top-level unstructured field is identity,
+// metadata or controller-owned state that copyGenericState must never overwrite.
+func isReservedTopLevelField(field string) bool {
+	switch field {
+	case "apiVersion", "kind", "metadata", "status":
+		return true
+	}
+	return false
+}

--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -629,6 +629,8 @@ func (r *GenericReconciler[CR]) resolveVectorAggregatorAddress(ctx context.Conte
 // Order: ConfigMap -> Headless Service -> Service -> ExtraResources -> StatefulSet -> PDB -> MetricsService
 // ExtraResources are applied before the StatefulSet because they are typically prerequisites
 // for pod scheduling (e.g. a Listener CR referenced by an ephemeral CSI volume).
+// Each resource is created when absent and updated to the handler-built desired state when it
+// already exists (see applyResource / copyDesiredState for the exact update semantics).
 func (r *GenericReconciler[CR]) applyResources(ctx context.Context, cr CR, resources *RoleGroupResources, buildCtx *RoleGroupBuildContext) error {
 	owner := r.getAsClientObject(cr)
 
@@ -701,16 +703,40 @@ func (r *GenericReconciler[CR]) resourceKind(obj client.Object) string {
 	return fmt.Sprintf("%T", obj)
 }
 
-// applyResource applies a single resource using CreateOrUpdate.
+// applyResource applies a single resource using CreateOrUpdate: it creates the object when
+// absent and otherwise UPDATES the live object to the handler-built desired state, so CR spec
+// changes (replicas, config, ports, ...) propagate to existing resources on every reconcile
+// (issue #526).
+//
+// controllerutil.CreateOrUpdate overwrites the passed object with live cluster state on Get
+// before running the mutate func, so the desired state is deep-copied up front and copied
+// back onto the live object inside the mutate func. The copy semantics — wholesale labels,
+// merged annotations, per-kind spec/data rules that respect Kubernetes immutable fields
+// (StatefulSet selector/serviceName/volumeClaimTemplates/podManagementPolicy, Service
+// clusterIP/allocated NodePorts), and a generic top-level field copy for arbitrary GVKs —
+// are documented on copyDesiredState in apply.go.
+//
 // After the operation, emits a Create or Update event based on the result.
 // If the Kubernetes API returns 429 Too Many Requests, a RateLimitError is returned.
+//
+// Note: handler-built objects usually omit server-defaulted fields, so a steady-state
+// reconcile may still issue an Update whose server-side result is identical to the stored
+// object; the API server short-circuits such writes (no resourceVersion bump, no watch
+// event), so this cannot cause a reconcile loop.
 func (r *GenericReconciler[CR]) applyResource(ctx context.Context, owner client.Object, obj client.Object) error {
+	// Capture the desired state before CreateOrUpdate clobbers obj with live state on Get.
+	desired, ok := obj.DeepCopyObject().(client.Object)
+	if !ok {
+		return fmt.Errorf("failed to deep copy desired object %T: copy is not a client.Object", obj)
+	}
 	result, err := r.k8sUtil.CreateOrUpdate(ctx, obj, func() error {
 		// Set ownership
 		if err := controllerutil.SetControllerReference(owner, obj, r.scheme); err != nil {
 			return err
 		}
-		return nil
+		// Copy the desired state onto the live object; without this the apply path is
+		// create-only (see the doc comment above and copyDesiredState).
+		return copyDesiredState(desired, obj)
 	})
 	if err != nil {
 		if errors.IsTooManyRequests(err) {

--- a/pkg/reconciler/generic_reconciler_test.go
+++ b/pkg/reconciler/generic_reconciler_test.go
@@ -35,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -1662,5 +1663,272 @@ var _ = Describe("GenericReconciler ProductConfig", func() {
 		props := captured.ConfigFiles["config.properties"]
 		Expect(props).To(HaveKeyWithValue("shared", "from-crd"))
 		Expect(props).NotTo(HaveKey("product-only"))
+	})
+})
+
+// Regression coverage for issue #526: applyResource was create-only — the CreateOrUpdate
+// mutate func only set the owner reference, so after initial creation no CR change ever
+// reached the StatefulSet/ConfigMap/Service/extras. These specs drive two reconciles with a
+// handler whose desired output changes in between and assert the change propagates, plus the
+// copy rules of copyDesiredState: wholesale labels, merged (foreign-preserving) annotations,
+// immutable StatefulSet fields kept from live, and allocated Service NodePorts carried over.
+var _ = Describe("GenericReconciler update propagation (issue #526)", func() {
+	var (
+		namespace    string
+		crName       string
+		resourceName string
+		mockCR       *testutil.MockCluster
+		fakeRecorder *record.FakeRecorder
+	)
+
+	BeforeEach(func() {
+		namespace = testNamespace
+		crName = fmt.Sprintf("update-prop-cr-%d", time.Now().UnixNano())
+		resourceName = reconciler.RoleGroupResourceName(crName, "broker", "default")
+		mockCR = testutil.NewMockCluster(crName, namespace).
+			WithRoles(map[string]v1alpha1.RoleSpec{
+				"broker": {
+					RoleGroups: map[string]v1alpha1.RoleGroupSpec{
+						"default": {Replicas: ptr.To(int32(1))},
+					},
+				},
+			})
+		Expect(k8sClient.Create(ctx, mockCR)).To(Succeed())
+		// Dedicated recorder so event assertions don't race with other specs sharing the
+		// suite-level recorder.
+		fakeRecorder = record.NewFakeRecorder(100)
+	})
+
+	AfterEach(func() {
+		_ = k8sClient.Delete(ctx, mockCR)
+		// envtest runs no garbage collector, so reclaim the owned resources by name.
+		meta := metav1.ObjectMeta{Name: resourceName, Namespace: namespace}
+		_ = k8sClient.Delete(ctx, &appsv1.StatefulSet{ObjectMeta: meta})
+		_ = k8sClient.Delete(ctx, &corev1.ConfigMap{ObjectMeta: meta})
+		_ = k8sClient.Delete(ctx, &corev1.Service{ObjectMeta: meta})
+		_ = k8sClient.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: resourceName + "-extra", Namespace: namespace}})
+	})
+
+	// newReconciler wires a GenericReconciler whose handler defers to build, so specs can
+	// change the desired output between reconciles by mutating captured variables.
+	newReconciler := func(build func(buildCtx *reconciler.RoleGroupBuildContext) *reconciler.RoleGroupResources) *reconciler.GenericReconciler[*testutil.ClusterWrapper] {
+		handler := &reconciler.RoleGroupHandlerFuncs[*testutil.ClusterWrapper]{
+			BuildResourcesFunc: func(_ context.Context, _ client.Client, _ *testutil.ClusterWrapper, buildCtx *reconciler.RoleGroupBuildContext) (*reconciler.RoleGroupResources, error) {
+				return build(buildCtx), nil
+			},
+		}
+		cfg := &reconciler.GenericReconcilerConfig[*testutil.ClusterWrapper]{
+			Client:           k8sClient,
+			Scheme:           testScheme,
+			Recorder:         fakeRecorder,
+			RoleGroupHandler: handler,
+			Prototype:        testutil.WrapMockCluster(testutil.NewMockCluster("proto", namespace)),
+		}
+		r, err := reconciler.NewGenericReconciler(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		return r
+	}
+
+	reconcile := func(r *reconciler.GenericReconciler[*testutil.ClusterWrapper]) {
+		req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: crName}}
+		_, err := r.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	drainEvents := func() []string {
+		var events []string
+		for {
+			select {
+			case e := <-fakeRecorder.Events:
+				events = append(events, e)
+			default:
+				return events
+			}
+		}
+	}
+
+	It("propagates StatefulSet replicas and template changes and emits an Update event", func() {
+		replicas := int32(1)
+		envValue := "v1"
+		r := newReconciler(func(buildCtx *reconciler.RoleGroupBuildContext) *reconciler.RoleGroupResources {
+			sts := testutil.NewTestStatefulSet(buildCtx.ResourceName, buildCtx.ClusterNamespace)
+			sts.Spec.Replicas = ptr.To(replicas)
+			sts.Spec.Template.Spec.Containers[0].Env = []corev1.EnvVar{{Name: "PROPAGATION_PROBE", Value: envValue}}
+			return &reconciler.RoleGroupResources{StatefulSet: sts}
+		})
+
+		reconcile(r)
+		sts := &appsv1.StatefulSet{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: resourceName}, sts)).To(Succeed())
+		Expect(*sts.Spec.Replicas).To(Equal(int32(1)))
+
+		// The CR changed (e.g. kubectl patch replicas 1 -> 3): the handler now builds
+		// different desired state, and the second reconcile must propagate it.
+		replicas = 3
+		envValue = "v2"
+		Expect(drainEvents()).To(ContainElement(ContainSubstring("Created")))
+		reconcile(r)
+
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: resourceName}, sts)).To(Succeed())
+		Expect(*sts.Spec.Replicas).To(Equal(int32(3)), "replicas change must reach the live StatefulSet")
+		Expect(sts.Spec.Template.Spec.Containers[0].Env).To(ContainElement(corev1.EnvVar{Name: "PROPAGATION_PROBE", Value: "v2"}), "template change must reach the live StatefulSet")
+
+		// OperationResultUpdated surfaced through the event plumbing.
+		Expect(drainEvents()).To(ContainElement(SatisfyAll(
+			ContainSubstring("Updated"),
+			ContainSubstring(resourceName),
+		)))
+	})
+
+	It("propagates ConfigMap data changes, including removed keys", func() {
+		data := map[string]string{"keep": "one", "remove": "two"}
+		r := newReconciler(func(buildCtx *reconciler.RoleGroupBuildContext) *reconciler.RoleGroupResources {
+			return &reconciler.RoleGroupResources{
+				ConfigMap: testutil.NewTestConfigMapWithData(buildCtx.ResourceName, buildCtx.ClusterNamespace, data),
+			}
+		})
+
+		reconcile(r)
+		cm := &corev1.ConfigMap{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: resourceName}, cm)).To(Succeed())
+		Expect(cm.Data).To(HaveKeyWithValue("remove", "two"))
+
+		data = map[string]string{"keep": "changed"}
+		reconcile(r)
+
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: resourceName}, cm)).To(Succeed())
+		// Data is replaced wholesale: the changed value propagates AND the removed key
+		// disappears from the live ConfigMap.
+		Expect(cm.Data).To(Equal(map[string]string{"keep": "changed"}))
+	})
+
+	It("propagates Service port changes while preserving the allocated NodePort", func() {
+		port := int32(9092)
+		r := newReconciler(func(buildCtx *reconciler.RoleGroupBuildContext) *reconciler.RoleGroupResources {
+			svc := testutil.NewTestService(buildCtx.ResourceName, buildCtx.ClusterNamespace)
+			svc.Spec.Type = corev1.ServiceTypeNodePort
+			svc.Spec.Ports = []corev1.ServicePort{{
+				Name:       "client",
+				Port:       port,
+				TargetPort: intstr.FromInt(9092),
+				Protocol:   corev1.ProtocolTCP,
+				// NodePort deliberately unset: the API server allocates it on create and the
+				// apply path must carry the allocation over on updates.
+			}}
+			return &reconciler.RoleGroupResources{Service: svc}
+		})
+
+		reconcile(r)
+		svc := &corev1.Service{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: resourceName}, svc)).To(Succeed())
+		Expect(svc.Spec.Ports).To(HaveLen(1))
+		allocatedNodePort := svc.Spec.Ports[0].NodePort
+		Expect(allocatedNodePort).NotTo(BeZero())
+		clusterIP := svc.Spec.ClusterIP
+		Expect(clusterIP).NotTo(BeEmpty())
+
+		port = 9093
+		reconcile(r)
+
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: resourceName}, svc)).To(Succeed())
+		Expect(svc.Spec.Ports).To(HaveLen(1))
+		Expect(svc.Spec.Ports[0].Port).To(Equal(int32(9093)), "port change must reach the live Service")
+		Expect(svc.Spec.Ports[0].NodePort).To(Equal(allocatedNodePort), "allocated NodePort must survive the update")
+		Expect(svc.Spec.ClusterIP).To(Equal(clusterIP), "allocated ClusterIP must never be touched")
+	})
+
+	It("propagates data and label changes of extra resources via the generic fallback", func() {
+		payload := "v1"
+		labelValue := "v1"
+		r := newReconciler(func(buildCtx *reconciler.RoleGroupBuildContext) *reconciler.RoleGroupResources {
+			// A Secret has no typed rule in copyDesiredState, so it exercises the
+			// unstructured top-level-field fallback used for arbitrary-GVK extras.
+			extra := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      buildCtx.ResourceName + "-extra",
+					Namespace: buildCtx.ClusterNamespace,
+					Labels:    map[string]string{"app.kubernetes.io/version": labelValue},
+				},
+				Data: map[string][]byte{"payload": []byte(payload)},
+			}
+			return &reconciler.RoleGroupResources{ExtraResources: []client.Object{extra}}
+		})
+
+		reconcile(r)
+		secret := &corev1.Secret{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: resourceName + "-extra"}, secret)).To(Succeed())
+		Expect(secret.Data).To(HaveKeyWithValue("payload", []byte("v1")))
+
+		payload = "v2"
+		labelValue = "v2"
+		reconcile(r)
+
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: resourceName + "-extra"}, secret)).To(Succeed())
+		Expect(secret.Data).To(HaveKeyWithValue("payload", []byte("v2")), "extra resource data must propagate")
+		Expect(secret.Labels).To(HaveKeyWithValue("app.kubernetes.io/version", "v2"), "extra resource labels must propagate")
+	})
+
+	It("keeps foreign annotations but replaces labels wholesale", func() {
+		r := newReconciler(func(buildCtx *reconciler.RoleGroupBuildContext) *reconciler.RoleGroupResources {
+			return &reconciler.RoleGroupResources{
+				ConfigMap: testutil.NewTestConfigMap(buildCtx.ResourceName, buildCtx.ClusterNamespace),
+			}
+		})
+
+		reconcile(r)
+		cm := &corev1.ConfigMap{}
+		key := types.NamespacedName{Namespace: namespace, Name: resourceName}
+		Expect(k8sClient.Get(ctx, key, cm)).To(Succeed())
+
+		// Out-of-band actor (e.g. kubectl apply) decorates the live object.
+		if cm.Annotations == nil {
+			cm.Annotations = map[string]string{}
+		}
+		cm.Annotations["kubectl.kubernetes.io/last-applied-configuration"] = "{}"
+		cm.Labels["foreign-label"] = "added-out-of-band"
+		Expect(k8sClient.Update(ctx, cm)).To(Succeed())
+
+		reconcile(r)
+
+		Expect(k8sClient.Get(ctx, key, cm)).To(Succeed())
+		// Annotations are merged, so the foreign annotation survives the reconcile...
+		Expect(cm.Annotations).To(HaveKeyWithValue("kubectl.kubernetes.io/last-applied-configuration", "{}"))
+		// ...but labels are framework-owned and replaced wholesale.
+		Expect(cm.Labels).NotTo(HaveKey("foreign-label"))
+		Expect(cm.Labels).To(HaveKeyWithValue("app.kubernetes.io/name", resourceName))
+	})
+
+	It("preserves the live StatefulSet's immutable fields when the handler's selector changes", func() {
+		selectorVersion := ""
+		r := newReconciler(func(buildCtx *reconciler.RoleGroupBuildContext) *reconciler.RoleGroupResources {
+			sts := testutil.NewTestStatefulSet(buildCtx.ResourceName, buildCtx.ClusterNamespace)
+			if selectorVersion != "" {
+				// The handler starts producing a different selector layout (e.g. after an
+				// operator upgrade). Template labels stay a superset of the live selector,
+				// which the API server requires.
+				sts.Spec.Selector.MatchLabels["version"] = selectorVersion
+				sts.Spec.Template.Labels["version"] = selectorVersion
+			}
+			return &reconciler.RoleGroupResources{StatefulSet: sts}
+		})
+
+		reconcile(r)
+		sts := &appsv1.StatefulSet{}
+		key := types.NamespacedName{Namespace: namespace, Name: resourceName}
+		Expect(k8sClient.Get(ctx, key, sts)).To(Succeed())
+		originalSelector := sts.Spec.Selector.DeepCopy()
+		originalServiceName := sts.Spec.ServiceName
+
+		selectorVersion = "v2"
+		// The reconcile must NOT fail with an immutable-field error...
+		reconcile(r)
+
+		Expect(k8sClient.Get(ctx, key, sts)).To(Succeed())
+		// ...because the live selector/serviceName are preserved (changing them requires a
+		// manual delete/recreate migration, see copyStatefulSetState).
+		Expect(sts.Spec.Selector).To(Equal(originalSelector))
+		Expect(sts.Spec.ServiceName).To(Equal(originalServiceName))
+		// The mutable template change still propagates.
+		Expect(sts.Spec.Template.Labels).To(HaveKeyWithValue("version", "v2"))
 	})
 })


### PR DESCRIPTION
Fixes #526 (CRITICAL).

## Problem

`applyResource` called `controllerutil.CreateOrUpdate` with a mutate func that only set the controller ownerRef. `CreateOrUpdate` overwrites the passed desired object with live state on Get, so after initial creation **no CR change ever reached any framework-applied resource** — scaling, TLS enablement, configOverrides, image bumps were all silent no-ops with `ReconcileComplete=true`. Empirically reproduced on kind (replicas patch 1→3 left the StatefulSet at 1). Affects every adopter of the redesigned framework; no e2e caught it because all suites only fresh-install.

## Fix

`applyResource` deep-copies the desired object before `CreateOrUpdate` and, inside the mutate func, copies desired state onto the live object via the new `copyDesiredState` (pkg/reconciler/apply.go) — the same pattern `EnsureDiscoveryConfigMap` already used:

- **Labels** replaced wholesale (framework-owned); **annotations** merged (foreign keys survive).
- **StatefulSet**: spec from desired, except live's immutable `selector`/`serviceName`/`volumeClaimTemplates`/`podManagementPolicy` are preserved (changing those requires a documented manual migration — see #526's upgrade note).
- **ConfigMap**: Data/BinaryData replaced wholesale (key removals propagate).
- **Service**: mutable spec fields from desired; ports replaced but allocated NodePorts carried over (name, then port-number match); `clusterIP(s)/ipFamilies/ipFamilyPolicy` never touched.
- **ServiceAccount**: metadata only. **PDB**: spec replaced.
- **Arbitrary GVKs** (ExtraResources, e.g. Listener CRs): unstructured copy of every top-level field except apiVersion/kind/metadata/status.

## Validation

- 6 new envtest specs ("update propagation (issue #526)"): STS replicas+template, CM data change+key removal, Service port change with NodePort/ClusterIP preservation, extra-resource propagation via the generic fallback, foreign-annotation survival vs foreign-label replacement, immutable-selector no-op safety. Full reconciler suite 315 specs green; `make test` all packages; lint 0 issues.
- **Empirical end-to-end on kind** (kafka-operator refactor branch pinned to this branch): the original reproduction now passes — replicas 1→3 propagates to the StatefulSet, and a live configOverrides patch (`log.retention.hours=42`) lands in the rendered server.properties ConfigMap.

Downstream after merge: kafka-operator#291 re-pin; recommend an e2e step that mutates a CR post-install to lock this in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)