### PR TITLE
feat(reconciler): per-CR ServiceAccount naming (shared-name SA breaks multi-cluster namespaces)

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -74,6 +74,7 @@ This layer focuses on how the Operator constructs the Kubernetes Pods and Resour
 Every specific Product Cluster managed by the SDK operates with its own distinct identity.
 
 - **Automated Provisioning**: The SDK automatically creates a dedicated `ServiceAccount` for each Cluster instance (or specific RoleGroup, depending on configuration).
+- **Per-CR Naming (recommended)**: Products should configure `GenericReconcilerConfig.ServiceAccountNameFunc` to derive the SA name from the CR (e.g. `"<product>-<cluster name>"`). Resolution order is: per-CR func result > static `ServiceAccountName` > empty (SA management skipped). A static name shared by two clusters of the same product in one namespace breaks isolation and reconciliation: the second cluster can never take controller ownership of the shared SA (the SDK surfaces a clear error naming both owners), and deleting the first cluster garbage-collects the SA out from under the second cluster's running pods.
 - **Scope**: Pods run as this ServiceAccount, meaning any audit logs in Kubernetes will reflect the specific application identity rather than a generic "default" account.
 - **Customization**: Users can override the generated ServiceAccount name in the CR Spec if integration with external IAM (like AWS IRSA or Google Workload Identity) is required.
 

--- a/pkg/reconciler/AGENTS.md
+++ b/pkg/reconciler/AGENTS.md
@@ -21,3 +21,11 @@ GenericReconciler framework for operator reconciliation logic and state manageme
 1. **Implementing a reconciler:** Extend GenericReconciler with custom logic
 2. **Status updates:** Use status utilities for consistent status management
 3. **Finalizers:** Use finalizer helpers for cleanup operations
+4. **ServiceAccounts:** Prefer per-CR naming via `GenericReconcilerConfig.ServiceAccountNameFunc`
+   (e.g. `"<product>-" + cr.GetName()`). The reconciler resolves the SA name per CR (func result >
+   static `ServiceAccountName` > "" = skip), ensures the SA with the CR as controller owner
+   (`ensureServiceAccount`), and propagates the resolved name through
+   `RoleGroupBuildContext.ServiceAccountName` to the STS pod template. A static name shared by two
+   clusters in one namespace permanently fails the second cluster's reconcile (AlreadyOwnedError,
+   surfaced as a clear both-owners error) and GC-deletes the SA under the survivor when the owner
+   cluster is deleted.

--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -93,12 +93,32 @@ type GenericReconcilerConfig[CR common.ClusterInterface] struct {
 	// +optional
 	GrayDeleteGracePeriod time.Duration
 
-	// ServiceAccountName is the name of the ServiceAccount to create for the workload.
-	// When set, the GenericReconciler automatically creates (or updates) a ServiceAccount
-	// with this name in the CR's namespace at the start of each reconciliation.
-	// Products can then reference this SA in their StatefulSetBuilder via WithServiceAccount().
+	// ServiceAccountName is the static name of the ServiceAccount to create for the workload.
+	// When set (and ServiceAccountNameFunc is nil or returns ""), the GenericReconciler
+	// automatically creates (or updates) a ServiceAccount with this name in the CR's namespace
+	// at the start of each reconciliation and propagates it to the workload pod template via
+	// RoleGroupBuildContext.ServiceAccountName.
+	//
+	// WARNING: a static name is shared by every CR of the product in a namespace. With two
+	// clusters in one namespace, the second cluster can never take controller ownership of the
+	// shared SA (its reconcile fails permanently), and deleting the first cluster garbage-collects
+	// the SA out from under the second cluster's running pods. Prefer ServiceAccountNameFunc for
+	// per-CR naming; keep this field only as a fallback or for single-cluster-per-namespace use.
 	// +optional
 	ServiceAccountName string
+
+	// ServiceAccountNameFunc computes the ServiceAccount name per CR at reconcile time.
+	// When set and returning a non-empty string, its result takes precedence over the static
+	// ServiceAccountName. When it returns "", the static ServiceAccountName is used as fallback;
+	// if that is also empty, ServiceAccount management is skipped entirely.
+	//
+	// RECOMMENDED for multi-cluster namespaces: derive the name from the CR, e.g.
+	// "<product>-<cr name>" ("kafka-" + cr.GetName()), so each cluster owns its own SA. This
+	// avoids the shared-SA failure mode described on ServiceAccountName (permanent ownership
+	// conflict for the second cluster, and SA garbage collection when the first cluster is
+	// deleted).
+	// +optional
+	ServiceAccountNameFunc func(cr CR) string
 
 	// ProductConfig, when set, computes the product's configuration contribution for a role
 	// group at reconcile time, returned as an *v1alpha1.OverridesSpec (the same shape users
@@ -163,7 +183,10 @@ type GenericReconciler[CR common.ClusterInterface] struct {
 	prototype           CR
 	rateLimitRetryAfter time.Duration
 	serviceAccountName  string
-	productConfig       func(cr CR, roleName, roleGroupName string) *v1alpha1.OverridesSpec
+	// serviceAccountNameFunc, when set, resolves a per-CR SA name that takes precedence over
+	// the static serviceAccountName (see resolveServiceAccountName).
+	serviceAccountNameFunc func(cr CR) string
+	productConfig          func(cr CR, roleName, roleGroupName string) *v1alpha1.OverridesSpec
 }
 
 // NewGenericReconciler creates a new GenericReconciler.
@@ -209,20 +232,21 @@ func NewGenericReconciler[CR common.ClusterInterface](cfg *GenericReconcilerConf
 	}
 
 	return &GenericReconciler[CR]{
-		client:              cfg.Client,
-		scheme:              cfg.Scheme,
-		k8sUtil:             util.NewK8sUtil(cfg.Client, cfg.Scheme),
-		healthManager:       healthManager,
-		dependencyResolver:  NewDependencyResolver(cfg.Client),
-		cleaner:             cleaner,
-		eventManager:        NewEventManager(cfg.Recorder),
-		configMerger:        config.NewConfigMerger(),
-		roleGroupHandler:    cfg.RoleGroupHandler,
-		extensionRegistry:   common.GetExtensionRegistry(),
-		prototype:           cfg.Prototype,
-		rateLimitRetryAfter: rateLimitRetryAfter,
-		serviceAccountName:  cfg.ServiceAccountName,
-		productConfig:       cfg.ProductConfig,
+		client:                 cfg.Client,
+		scheme:                 cfg.Scheme,
+		k8sUtil:                util.NewK8sUtil(cfg.Client, cfg.Scheme),
+		healthManager:          healthManager,
+		dependencyResolver:     NewDependencyResolver(cfg.Client),
+		cleaner:                cleaner,
+		eventManager:           NewEventManager(cfg.Recorder),
+		configMerger:           config.NewConfigMerger(),
+		roleGroupHandler:       cfg.RoleGroupHandler,
+		extensionRegistry:      common.GetExtensionRegistry(),
+		prototype:              cfg.Prototype,
+		rateLimitRetryAfter:    rateLimitRetryAfter,
+		serviceAccountName:     cfg.ServiceAccountName,
+		serviceAccountNameFunc: cfg.ServiceAccountNameFunc,
+		productConfig:          cfg.ProductConfig,
 	}, nil
 }
 
@@ -324,9 +348,11 @@ func (r *GenericReconciler[CR]) reconcile(ctx context.Context, cr CR) (ctrl.Resu
 		}
 	}
 
-	// 0. Auto-create ServiceAccount if configured
-	if r.serviceAccountName != "" {
-		if err := r.ensureServiceAccount(ctx, cr); err != nil {
+	// 0. Auto-create ServiceAccount if configured. The name is resolved per CR (per-CR func
+	// wins over the static name; empty means SA management is disabled) so that two clusters
+	// of the same product in one namespace each own their own SA.
+	if saName := r.resolveServiceAccountName(cr); saName != "" {
+		if err := r.ensureServiceAccount(ctx, cr, saName); err != nil {
 			return ctrl.Result{}, NewReconcileError("ServiceAccount", "failed to ensure service account", err)
 		}
 	}
@@ -512,8 +538,9 @@ func (r *GenericReconciler[CR]) buildRoleGroupContext(cr CR, roleName string, ro
 		MergedConfig:     mergedConfig,
 		ResourceName:     resourceName,
 		// Propagate the reconciler-managed ServiceAccount so the workload pods actually run as
-		// the SA the reconciler creates. Empty when no SA is configured (backward compatible).
-		ServiceAccountName: r.serviceAccountName,
+		// the SA the reconciler creates. Resolved per CR (per-CR func over static name), and
+		// empty when no SA is configured (backward compatible).
+		ServiceAccountName: r.resolveServiceAccountName(cr),
 	}
 }
 
@@ -828,16 +855,50 @@ func (r *GenericReconciler[CR]) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-// ensureServiceAccount creates or updates the ServiceAccount for the cluster workload.
-func (r *GenericReconciler[CR]) ensureServiceAccount(ctx context.Context, cr CR) error {
+// resolveServiceAccountName resolves the ServiceAccount name for a CR.
+// Precedence: ServiceAccountNameFunc (when set and returning non-empty) > static
+// ServiceAccountName > "" (SA management skipped). Per-CR naming is what keeps two clusters
+// of the same product in one namespace from fighting over a single shared SA.
+func (r *GenericReconciler[CR]) resolveServiceAccountName(cr CR) string {
+	if r.serviceAccountNameFunc != nil {
+		if name := r.serviceAccountNameFunc(cr); name != "" {
+			return name
+		}
+	}
+	return r.serviceAccountName
+}
+
+// ensureServiceAccount creates or updates the ServiceAccount for the cluster workload and sets
+// the CR as its controller owner.
+//
+// Guard rail: if an SA with this name already exists but is controlled by a DIFFERENT owner,
+// SetControllerReference refuses to steal it; that raw AlreadyOwnedError is wrapped in an
+// explicit error naming both owners, because it almost always means two CRs were configured to
+// share one static ServiceAccountName — the fix is per-CR naming via ServiceAccountNameFunc.
+func (r *GenericReconciler[CR]) ensureServiceAccount(ctx context.Context, cr CR, name string) error {
 	owner := r.getAsClientObject(cr)
 	sa := &corev1.ServiceAccount{}
-	sa.Name = r.serviceAccountName
+	sa.Name = name
 	sa.Namespace = cr.GetNamespace()
 
 	_, err := r.k8sUtil.CreateOrUpdate(ctx, sa, func() error {
 		sa.Labels = cr.GetLabels()
-		return controllerutil.SetControllerReference(owner, sa, r.scheme)
+		if err := controllerutil.SetControllerReference(owner, sa, r.scheme); err != nil {
+			var alreadyOwned *controllerutil.AlreadyOwnedError
+			if stderrors.As(err, &alreadyOwned) {
+				return fmt.Errorf(
+					"ServiceAccount %s/%s is already controlled by %s %q and cannot be adopted by %s %q: "+
+						"multiple clusters appear to share one ServiceAccount name; "+
+						"use per-CR naming (GenericReconcilerConfig.ServiceAccountNameFunc, e.g. \"<product>-<cluster>\"): %w",
+					sa.Namespace, sa.Name,
+					alreadyOwned.Owner.Kind, alreadyOwned.Owner.Name,
+					r.resourceKind(owner), owner.GetName(),
+					err,
+				)
+			}
+			return err
+		}
+		return nil
 	})
 	return err
 }

--- a/pkg/reconciler/generic_reconciler_test.go
+++ b/pkg/reconciler/generic_reconciler_test.go
@@ -39,6 +39,7 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 var _ = Describe("GenericReconciler", func() {
@@ -1038,6 +1039,248 @@ var _ = Describe("GenericReconciler ClusterOperation gate ordering (issue #511)"
 			// Stopped path handled by the gate before ensureServiceAccount, so no SA was provisioned.
 			Expect(k8serrors.IsNotFound(saLookup())).To(BeTrue(), "ServiceAccount should not be created for a stopped cluster")
 		})
+	})
+})
+
+// saCapturingHandler wraps the mock handler and records the ServiceAccountName each
+// RoleGroupBuildContext carries, so tests can assert the resolved SA name is propagated to
+// resource building (the base handler's pod-template binding is covered in
+// base_role_group_handler_test.go).
+type saCapturingHandler struct {
+	inner       reconciler.RoleGroupHandler[*testutil.ClusterWrapper]
+	seenSANames []string
+}
+
+func (h *saCapturingHandler) BuildResources(ctx context.Context, k8sClient client.Client, cr *testutil.ClusterWrapper, buildCtx *reconciler.RoleGroupBuildContext) (*reconciler.RoleGroupResources, error) {
+	h.seenSANames = append(h.seenSANames, buildCtx.ServiceAccountName)
+	return h.inner.BuildResources(ctx, k8sClient, cr, buildCtx)
+}
+
+// Coverage for per-CR ServiceAccount naming: a static ServiceAccountName is shared by every CR
+// of a product in a namespace, so the second cluster hits AlreadyOwnedError forever and deleting
+// the first cluster garbage-collects the SA out from under the second. ServiceAccountNameFunc
+// resolves a per-CR name (precedence: func result > static name > "" = skip SA management).
+var _ = Describe("GenericReconciler per-CR ServiceAccount naming", func() {
+	var (
+		mockHandler *testutil.MockRoleGroupHandler
+		capturing   *saCapturingHandler
+		namespace   string
+		testID      string
+	)
+
+	newReconciler := func(prototype *testutil.ClusterWrapper, staticName string, nameFunc func(cr *testutil.ClusterWrapper) string) *reconciler.GenericReconciler[*testutil.ClusterWrapper] {
+		cfg := &reconciler.GenericReconcilerConfig[*testutil.ClusterWrapper]{
+			Client:                 k8sClient,
+			Scheme:                 testScheme,
+			Recorder:               recorder,
+			RoleGroupHandler:       capturing,
+			Prototype:              prototype,
+			ServiceAccountName:     staticName,
+			ServiceAccountNameFunc: nameFunc,
+		}
+		r, err := reconciler.NewGenericReconciler(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		return r
+	}
+
+	newCR := func(name string) *testutil.MockCluster {
+		cr := testutil.NewMockCluster(name, namespace).
+			WithRoles(map[string]v1alpha1.RoleSpec{
+				"test-role": {
+					RoleGroups: map[string]v1alpha1.RoleGroupSpec{
+						"default": {Replicas: ptr.To(int32(1))},
+					},
+				},
+			})
+		Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+		return cr
+	}
+
+	getSA := func(name string) (*corev1.ServiceAccount, error) {
+		sa := &corev1.ServiceAccount{}
+		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, sa)
+		return sa, err
+	}
+
+	deleteSA := func(name string) {
+		_ = k8sClient.Delete(ctx, &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		})
+	}
+
+	reconcileReq := func(r *reconciler.GenericReconciler[*testutil.ClusterWrapper], crName string) (ctrl.Result, error) {
+		return r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: crName}})
+	}
+
+	BeforeEach(func() {
+		namespace = testNamespace
+		mockHandler = testutil.NewMockRoleGroupHandler()
+		capturing = &saCapturingHandler{inner: &handlerAdapter{handler: mockHandler}}
+		testID = fmt.Sprintf("%d", time.Now().UnixNano())
+	})
+
+	It("uses the per-CR func over the static name and wires it into the build context", func() {
+		crName := "sa-func-" + testID
+		staticName := "sa-static-" + testID
+		perCRName := "sa-per-cr-" + crName
+		cr := newCR(crName)
+		defer func() {
+			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+			deleteSA(perCRName)
+			deleteSA(staticName)
+		}()
+
+		r := newReconciler(testutil.WrapMockCluster(cr), staticName, func(c *testutil.ClusterWrapper) string {
+			return "sa-per-cr-" + c.GetName()
+		})
+
+		_, err := reconcileReq(r, crName)
+		Expect(err).NotTo(HaveOccurred())
+
+		// The per-CR named SA exists and is controller-owned by this CR.
+		sa, err := getSA(perCRName)
+		Expect(err).NotTo(HaveOccurred())
+		ownerRef := metav1.GetControllerOf(sa)
+		Expect(ownerRef).NotTo(BeNil())
+		Expect(ownerRef.Name).To(Equal(crName))
+		Expect(ownerRef.Kind).To(Equal("MockCluster"))
+
+		// The static-named SA is never created when the func resolves a name.
+		_, err = getSA(staticName)
+		Expect(k8serrors.IsNotFound(err)).To(BeTrue(), "static SA must not be created when the per-CR func resolves")
+
+		// The resolved name flows through RoleGroupBuildContext to resource building (the base
+		// handler binds it to the pod template; see base_role_group_handler_test.go).
+		Expect(capturing.seenSANames).NotTo(BeEmpty())
+		for _, seen := range capturing.seenSANames {
+			Expect(seen).To(Equal(perCRName))
+		}
+	})
+
+	It("falls back to the static name when the func is nil", func() {
+		crName := "sa-nilfunc-" + testID
+		staticName := "sa-static-nil-" + testID
+		cr := newCR(crName)
+		defer func() {
+			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+			deleteSA(staticName)
+		}()
+
+		r := newReconciler(testutil.WrapMockCluster(cr), staticName, nil)
+
+		_, err := reconcileReq(r, crName)
+		Expect(err).NotTo(HaveOccurred())
+
+		sa, err := getSA(staticName)
+		Expect(err).NotTo(HaveOccurred())
+		ownerRef := metav1.GetControllerOf(sa)
+		Expect(ownerRef).NotTo(BeNil())
+		Expect(ownerRef.Name).To(Equal(crName))
+	})
+
+	It("falls back to the static name when the func returns empty", func() {
+		crName := "sa-emptyfunc-" + testID
+		staticName := "sa-static-empty-" + testID
+		cr := newCR(crName)
+		defer func() {
+			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+			deleteSA(staticName)
+		}()
+
+		r := newReconciler(testutil.WrapMockCluster(cr), staticName, func(*testutil.ClusterWrapper) string {
+			return ""
+		})
+
+		_, err := reconcileReq(r, crName)
+		Expect(err).NotTo(HaveOccurred())
+
+		sa, err := getSA(staticName)
+		Expect(err).NotTo(HaveOccurred())
+		ownerRef := metav1.GetControllerOf(sa)
+		Expect(ownerRef).NotTo(BeNil())
+		Expect(ownerRef.Name).To(Equal(crName))
+	})
+
+	It("lets two clusters in one namespace each reconcile and own their own SA", func() {
+		// This is the multi-cluster scenario a shared static name breaks: the second cluster's
+		// SetControllerReference on the shared SA fails with AlreadyOwnedError forever.
+		crNameA := "sa-multi-a-" + testID
+		crNameB := "sa-multi-b-" + testID
+		crA := newCR(crNameA)
+		crB := newCR(crNameB)
+		defer func() {
+			Expect(k8sClient.Delete(ctx, crA)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, crB)).To(Succeed())
+			deleteSA("sa-per-cr-" + crNameA)
+			deleteSA("sa-per-cr-" + crNameB)
+		}()
+
+		nameFunc := func(c *testutil.ClusterWrapper) string { return "sa-per-cr-" + c.GetName() }
+		rA := newReconciler(testutil.WrapMockCluster(crA), "", nameFunc)
+		rB := newReconciler(testutil.WrapMockCluster(crB), "", nameFunc)
+
+		_, err := reconcileReq(rA, crNameA)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = reconcileReq(rB, crNameB)
+		Expect(err).NotTo(HaveOccurred(), "second cluster in the namespace must reconcile cleanly with per-CR SA naming")
+
+		// Reconcile both again: steady state must stay clean (no AlreadyOwnedError on re-reconcile).
+		_, err = reconcileReq(rA, crNameA)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = reconcileReq(rB, crNameB)
+		Expect(err).NotTo(HaveOccurred())
+
+		saA, err := getSA("sa-per-cr-" + crNameA)
+		Expect(err).NotTo(HaveOccurred())
+		saB, err := getSA("sa-per-cr-" + crNameB)
+		Expect(err).NotTo(HaveOccurred())
+
+		refA := metav1.GetControllerOf(saA)
+		Expect(refA).NotTo(BeNil())
+		Expect(refA.Name).To(Equal(crNameA))
+		refB := metav1.GetControllerOf(saB)
+		Expect(refB).NotTo(BeNil())
+		Expect(refB.Name).To(Equal(crNameB))
+	})
+
+	It("reports a clear error naming both owners when the SA is owned by a different owner", func() {
+		crName := "sa-victim-" + testID
+		otherName := "sa-squatter-" + testID
+		sharedSAName := "sa-shared-" + testID
+
+		// The "other" cluster that already controller-owns the shared SA.
+		otherCR := newCR(otherName)
+		cr := newCR(crName)
+		defer func() {
+			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, otherCR)).To(Succeed())
+			deleteSA(sharedSAName)
+		}()
+
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: sharedSAName, Namespace: namespace},
+		}
+		Expect(controllerutil.SetControllerReference(otherCR, sa, testScheme)).To(Succeed())
+		Expect(k8sClient.Create(ctx, sa)).To(Succeed())
+
+		r := newReconciler(testutil.WrapMockCluster(cr), sharedSAName, nil)
+
+		_, err := reconcileReq(r, crName)
+		Expect(err).To(HaveOccurred())
+		// The error must diagnose the shared-name misconfiguration, naming both owners and the
+		// per-CR naming fix, instead of surfacing the raw AlreadyOwnedError.
+		Expect(err.Error()).To(ContainSubstring(sharedSAName))
+		Expect(err.Error()).To(ContainSubstring("already controlled by"))
+		Expect(err.Error()).To(ContainSubstring(otherName), "error should name the existing owner")
+		Expect(err.Error()).To(ContainSubstring(crName), "error should name the owner that failed to adopt")
+		Expect(err.Error()).To(ContainSubstring("ServiceAccountNameFunc"), "error should point at the per-CR naming fix")
+
+		// The squatter's ownership is untouched.
+		fetched, err := getSA(sharedSAName)
+		Expect(err).NotTo(HaveOccurred())
+		ref := metav1.GetControllerOf(fetched)
+		Expect(ref).NotTo(BeNil())
+		Expect(ref.Name).To(Equal(otherName))
 	})
 })
 

--- a/pkg/reconciler/role_group_handler.go
+++ b/pkg/reconciler/role_group_handler.go
@@ -130,7 +130,8 @@ type RoleGroupBuildContext struct {
 	ResourceName string
 
 	// ServiceAccountName is the name of the ServiceAccount the workload pods should run as.
-	// It is populated by GenericReconciler from its configured ServiceAccountName (the SA the
+	// It is populated by GenericReconciler with the resolved SA name — the per-CR
+	// ServiceAccountNameFunc result when set, else the static ServiceAccountName (the SA the
 	// reconciler auto-creates). When non-empty, the base StatefulSet builder binds it to the
 	// pod template via WithServiceAccount, so the created SA is actually used. Empty means no
 	// binding — pods fall back to the namespace default SA (backward compatible).


### PR DESCRIPTION
## Problem (found in kafka-operator#291 adversarial review)

`GenericReconcilerConfig.ServiceAccountName` is a single static string and `ensureServiceAccount` sets a controller ownerRef on it. Two clusters of one product in one namespace ⇒ the second hits `AlreadyOwnedError` on every reconcile and never progresses; deleting cluster A garbage-collects the SA out from under cluster B's running pods.

## API

```go
// GenericReconcilerConfig
ServiceAccountNameFunc func(cr CR) string   // optional, per-CR
```

Resolution: func (non-empty result) → static `ServiceAccountName` → both empty = SA management skipped (exact current behavior; fully backward compatible). The resolved name flows to both usages (ensureServiceAccount + RoleGroupBuildContext.ServiceAccountName → STS pod template). Doc comments recommend `"<product>-<cluster>"`.

Guard rail: an `AlreadyOwnedError` is wrapped with a message naming both owners and pointing at `ServiceAccountNameFunc` — the shared-name misconfiguration becomes self-diagnosing.

## Test plan
5 new envtest specs: per-CR precedence + build-context propagation, nil-func fallback, empty-func fallback, two CRs in one namespace reconciling cleanly with their own SAs, different-owner guard message. Reconciler suite 320/320; make test green; lint 0 issues.

Downstream: kafka-operator#291 will adopt `func(cr) { return "kafka-" + cr.Name }` after merge (zookeeper refactor branch should too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)