### PR TITLE
fix(reconciler): reconcile all resources when stopped, scaling pods to 0

### DIFF
--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -518,11 +518,23 @@ func (h *BaseRoleGroupHandler[CR]) buildStatefulSet(
 	// Use the builder pattern from the existing codebase
 	stsBuilder := builder.NewStatefulSetBuilder(buildCtx.ResourceName, buildCtx.ClusterNamespace)
 
+	// Effective replica count. Normally the role group's declared replicas, but when the cluster
+	// is stopped (ClusterOperation.stopped) it is forced to 0: stopping a cluster means "run zero
+	// pods while every resource — ConfigMap, Service, StatefulSet, PDB, ServiceAccount, PVCs — is
+	// still reconciled and preserved so the cluster can be resumed". Only the pod count changes;
+	// the full resource set is created/updated (and spec/config changes are applied) as usual.
+	replicas := buildCtx.RoleGroupSpec.GetReplicas()
+	if buildCtx.ClusterSpec != nil &&
+		buildCtx.ClusterSpec.ClusterOperation != nil &&
+		buildCtx.ClusterSpec.ClusterOperation.Stopped {
+		replicas = int32(0)
+	}
+
 	// Set basic properties
 	stsBuilder.WithLabels(labels).
 		WithSelectorLabels(h.buildSelectorLabels(buildCtx)).
 		WithAnnotations(h.buildAnnotations(buildCtx)).
-		WithReplicas(buildCtx.RoleGroupSpec.GetReplicas()).
+		WithReplicas(replicas).
 		WithImage(h.containerImage(buildCtx.RoleName), h.ImagePullPolicy).
 		WithConfig(buildCtx.MergedConfig).
 		WithPorts(h.containerPorts(buildCtx.RoleName, buildCtx.RoleGroupName))

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -464,6 +464,33 @@ var _ = Describe("StatefulSet building", func() {
 		Expect(*resources.StatefulSet.Spec.Replicas).To(Equal(int32(3)))
 	})
 
+	It("forces replicas to 0 when the cluster is stopped, still building the StatefulSet", func() {
+		// Stopped scales pods to 0 while all resources are reconciled/preserved: the StatefulSet is
+		// still built (with the declared image, config volume, etc.), only its replica count is 0.
+		buildCtx.ClusterSpec = &v1alpha1.GenericClusterSpec{
+			ClusterOperation: &v1alpha1.ClusterOperationSpec{Stopped: true},
+		}
+
+		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.StatefulSet).NotTo(BeNil())
+		Expect(resources.StatefulSet.Spec.Replicas).NotTo(BeNil())
+		Expect(*resources.StatefulSet.Spec.Replicas).To(Equal(int32(0)))
+	})
+
+	It("keeps the declared replicas when ClusterOperation is set but not stopped", func() {
+		// A non-stopped ClusterOperation (e.g. only reconciliationPaused set elsewhere) must not
+		// affect the replica count.
+		buildCtx.ClusterSpec = &v1alpha1.GenericClusterSpec{
+			ClusterOperation: &v1alpha1.ClusterOperationSpec{Stopped: false},
+		}
+
+		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.StatefulSet.Spec.Replicas).NotTo(BeNil())
+		Expect(*resources.StatefulSet.Spec.Replicas).To(Equal(int32(3)))
+	})
+
 	It("should set image correctly", func() {
 		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -150,8 +150,10 @@ type GenericReconcilerConfig[CR common.ClusterInterface] struct {
 //  2. Panic recovery wrapper
 //  3. Execute reconcile():
 //     a. ClusterOperation gate (evaluated first, before any mutation)
-//     - Handle ReconciliationPaused -> return early
-//     - Handle Stopped -> scale to 0
+//     - Handle ReconciliationPaused -> return early (full freeze)
+//     - Stopped is NOT short-circuited here: it falls through to the normal reconcile
+//     so all resources are created/preserved, with StatefulSet replicas forced to 0
+//     downstream (see BaseRoleGroupHandler.buildStatefulSet)
 //     b. PreReconcile Extensions (Hook)
 //     c. Validate Dependencies
 //     d. For Each Role:
@@ -333,18 +335,22 @@ func (r *GenericReconciler[CR]) reconcile(ctx context.Context, cr CR) (ctrl.Resu
 
 	// ClusterOperation gate — evaluated FIRST, before any resource mutation (ServiceAccount
 	// provisioning, PreReconcile extensions, role reconciliation). reconciliationPaused must fully
-	// freeze reconciliation per the documented contract (docs/architecture.md), and stopped scales
-	// workloads to zero; neither should be preceded by mutating steps.
+	// freeze reconciliation per the documented contract (docs/architecture.md), so it returns here
+	// before any mutating step.
+	//
+	// Note: `stopped` is deliberately NOT gated here. Stopping a cluster means "keep every resource
+	// (ConfigMap, Service, StatefulSet, PDB, ServiceAccount, PVCs) created and up to date, but run
+	// zero pods", so it must fall through to the full normal reconcile. The StatefulSet replica
+	// count is forced to 0 downstream (see BaseRoleGroupHandler.buildStatefulSet), which is what
+	// scales the workload down while all resources are still reconciled/preserved and any spec or
+	// config change applied while stopped is honored. The stopped status is reported by the health
+	// step at the end of the normal reconcile (see health.go).
 	if op := spec.ClusterOperation; op != nil {
 		if op.ReconciliationPaused {
 			logger.Info("Reconciliation is paused")
 			status.SetDegraded(true, v1alpha1.ReasonReconciliationPaused, "Reconciliation is paused")
 			_ = r.updateStatus(ctx, cr) //nolint:errcheck
 			return ctrl.Result{}, nil
-		}
-		if op.Stopped {
-			logger.Info("Cluster is stopped, scaling to zero")
-			return r.handleStoppedCluster(ctx, cr)
 		}
 	}
 
@@ -779,51 +785,6 @@ func (r *GenericReconciler[CR]) applyResource(ctx context.Context, owner client.
 		r.eventManager.EmitUpdateEvent(owner.GetName(), obj)
 	}
 	return nil
-}
-
-// handleStoppedCluster handles the case when a cluster is stopped.
-func (r *GenericReconciler[CR]) handleStoppedCluster(ctx context.Context, cr CR) (ctrl.Result, error) {
-	logger := log.FromContext(ctx)
-	spec := cr.GetSpec()
-	status := cr.GetStatus()
-
-	// Scale all role groups to 0
-	for roleName, roleSpec := range spec.Roles {
-		for groupName := range roleSpec.GetRoleGroups() {
-			resourceName := RoleGroupResourceName(cr.GetName(), roleName, groupName)
-			if err := r.scaleToZero(ctx, cr.GetNamespace(), resourceName); err != nil {
-				logger.Error(err, "Failed to scale role group to zero", "role", roleName, "group", groupName)
-				// Continue with other groups
-			}
-		}
-	}
-
-	status.SetUnavailable(v1alpha1.ReasonStopped, "Cluster is stopped")
-	status.SetDegraded(false, v1alpha1.ReasonStopped, "Cluster is intentionally stopped")
-
-	if err := r.updateStatus(ctx, cr); err != nil {
-		return ctrl.Result{}, err
-	}
-
-	return ctrl.Result{}, nil
-}
-
-// scaleToZero scales a StatefulSet to zero replicas.
-func (r *GenericReconciler[CR]) scaleToZero(ctx context.Context, namespace, name string) error {
-	sts := &appsv1.StatefulSet{}
-	key := types.NamespacedName{Namespace: namespace, Name: name}
-
-	if err := r.client.Get(ctx, key, sts); err != nil {
-		if errors.IsNotFound(err) {
-			return nil // StatefulSet doesn't exist, nothing to scale
-		}
-		return err
-	}
-
-	zero := int32(0)
-	sts.Spec.Replicas = &zero
-
-	return r.client.Update(ctx, sts)
 }
 
 // executeErrorHooks executes error hooks when reconciliation fails.

--- a/pkg/reconciler/generic_reconciler_test.go
+++ b/pkg/reconciler/generic_reconciler_test.go
@@ -737,7 +737,10 @@ var _ = Describe("GenericReconciler Integration Tests", func() {
 			Expect(k8sClient.Delete(ctx, stoppedCR)).To(Succeed())
 		})
 
-		It("should handle stopped cluster", func() {
+		It("should reconcile all resources with the StatefulSet scaled to zero when stopped", func() {
+			// A cluster created directly with stopped=true (no prior StatefulSet to scale) must
+			// still get its full resource set — the shortcut design left such a cluster with
+			// nothing. The new design runs the normal reconcile and forces replicas to 0.
 			req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: crName}}
 
 			result, err := r.Reconcile(ctx, req)
@@ -745,9 +748,28 @@ var _ = Describe("GenericReconciler Integration Tests", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(ctrl.Result{}))
 
-			// Verify status shows unavailable due to stopped
+			resName := reconciler.RoleGroupResourceName(crName, "test-role", "default")
+
+			// The ConfigMap and Service are provisioned even though the cluster is stopped.
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: resName}, &corev1.ConfigMap{})).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: resName}, &corev1.Service{})).To(Succeed())
+
+			// The StatefulSet is CREATED (not merely scaled) with 0 replicas so it can be resumed.
+			sts := &appsv1.StatefulSet{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: resName}, sts)).To(Succeed())
+			Expect(sts.Spec.Replicas).NotTo(BeNil())
+			Expect(*sts.Spec.Replicas).To(Equal(int32(0)))
+
+			// The health step must report Stopped at the end of the reconcile: the Available
+			// condition is False with Reason == ReasonStopped. Asserting the reason (not merely
+			// "conditions are non-empty") is what discriminates the new behavior from a cluster
+			// that is merely Creating/Not-all-replicas-available.
 			fetchedCR := &testutil.MockCluster{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: crName}, fetchedCR)).To(Succeed())
+			availableCond := fetchedCR.Status.GetCondition(v1alpha1.ConditionAvailable)
+			Expect(availableCond).NotTo(BeNil())
+			Expect(availableCond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(availableCond.Reason).To(Equal(v1alpha1.ReasonStopped))
 		})
 	})
 
@@ -1005,24 +1027,19 @@ var _ = Describe("GenericReconciler ClusterOperation gate ordering (issue #511)"
 			})
 		})
 
-		It("scales an existing StatefulSet to zero without provisioning the ServiceAccount first", func() {
-			// Pre-create a StatefulSet with replicas > 0 that the stopped path should scale down.
-			replicas := int32(3)
+		It("reconciles the full resource set — provisioning the ServiceAccount and creating the StatefulSet with zero replicas", func() {
+			// New design (was inverted under the shortcut): stopped is NOT a short-circuit. It runs
+			// the normal reconcile so every resource — including the ServiceAccount — is created and
+			// kept up to date, with the StatefulSet's replicas forced to 0. The old behavior (scale
+			// only pre-existing StatefulSets, never provision the SA) left a directly-stopped cluster
+			// with no resources at all.
 			stsName := reconciler.RoleGroupResourceName(crName, "test-role", "default")
-			sts := &appsv1.StatefulSet{
-				ObjectMeta: metav1.ObjectMeta{Name: stsName, Namespace: namespace},
-				Spec: appsv1.StatefulSetSpec{
-					Replicas: &replicas,
-					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": crName}},
-					Template: corev1.PodTemplateSpec{
-						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": crName}},
-						Spec: corev1.PodSpec{
-							Containers: []corev1.Container{{Name: "test", Image: "test-image"}},
-						},
-					},
-				},
-			}
-			Expect(k8sClient.Create(ctx, sts)).To(Succeed())
+
+			// Guards: neither the SA nor the StatefulSet pre-exists.
+			Expect(k8serrors.IsNotFound(saLookup())).To(BeTrue())
+			Expect(k8serrors.IsNotFound(
+				k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: stsName}, &appsv1.StatefulSet{}),
+			)).To(BeTrue())
 
 			r := newReconciler(testutil.WrapMockCluster(stoppedCR))
 			req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: crName}}
@@ -1031,13 +1048,14 @@ var _ = Describe("GenericReconciler ClusterOperation gate ordering (issue #511)"
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(ctrl.Result{}))
 
-			// StatefulSet scaled to zero.
+			// The ServiceAccount IS provisioned (stopped runs the full reconcile).
+			Expect(saLookup()).To(Succeed(), "ServiceAccount should be created for a stopped cluster under the new design")
+
+			// The StatefulSet is CREATED with 0 replicas so the cluster can be resumed.
 			fetched := &appsv1.StatefulSet{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: stsName}, fetched)).To(Succeed())
+			Expect(fetched.Spec.Replicas).NotTo(BeNil())
 			Expect(*fetched.Spec.Replicas).To(Equal(int32(0)))
-
-			// Stopped path handled by the gate before ensureServiceAccount, so no SA was provisioned.
-			Expect(k8serrors.IsNotFound(saLookup())).To(BeTrue(), "ServiceAccount should not be created for a stopped cluster")
 		})
 	})
 })
@@ -1284,7 +1302,7 @@ var _ = Describe("GenericReconciler per-CR ServiceAccount naming", func() {
 	})
 })
 
-var _ = Describe("GenericReconciler scaleToZero", func() {
+var _ = Describe("GenericReconciler stopped scales the StatefulSet to zero", func() {
 	var r *reconciler.GenericReconciler[*testutil.ClusterWrapper]
 	var mockHandler *testutil.MockRoleGroupHandler
 	var namespace string
@@ -1316,6 +1334,14 @@ var _ = Describe("GenericReconciler scaleToZero", func() {
 
 	AfterEach(func() {
 		Expect(k8sClient.Delete(ctx, customCR)).To(Succeed())
+		// envtest has no garbage collector, so explicitly remove the reconciled StatefulSet to
+		// keep the two specs in this block independent regardless of execution order.
+		_ = k8sClient.Delete(ctx, &appsv1.StatefulSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      reconciler.RoleGroupResourceName(crName, "test-role", "default"),
+				Namespace: namespace,
+			},
+		})
 	})
 
 	JustBeforeEach(func() {
@@ -1332,22 +1358,27 @@ var _ = Describe("GenericReconciler scaleToZero", func() {
 		Expect(r).NotTo(BeNil())
 	})
 
-	It("should scale StatefulSet to zero when cluster is stopped", func() {
-		// Create StatefulSet with replicas > 0
+	It("updates an existing StatefulSet's replicas to zero while reconciling it", func() {
+		// Pre-create a StatefulSet with replicas > 0. The normal reconcile now UPDATES it to the
+		// handler-built desired state, whose replicas are forced to 0 because the cluster is stopped.
+		// The selector/template labels must match those the mock handler builds
+		// (app.kubernetes.io/name = resource name) so the update keeps the immutable selector valid.
 		replicas := int32(3)
+		stsName := reconciler.RoleGroupResourceName(crName, "test-role", "default")
+		stsLabels := map[string]string{"app.kubernetes.io/name": stsName}
 		sts := &appsv1.StatefulSet{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      reconciler.RoleGroupResourceName(crName, "test-role", "default"),
+				Name:      stsName,
 				Namespace: namespace,
 			},
 			Spec: appsv1.StatefulSetSpec{
 				Replicas: &replicas,
 				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"app": crName},
+					MatchLabels: stsLabels,
 				},
 				Template: corev1.PodTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{"app": crName},
+						Labels: stsLabels,
 					},
 					Spec: corev1.PodSpec{
 						Containers: []corev1.Container{
@@ -1363,13 +1394,30 @@ var _ = Describe("GenericReconciler scaleToZero", func() {
 		result, err := r.Reconcile(ctx, req)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(ctrl.Result{}))
+
+		fetched := &appsv1.StatefulSet{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: stsName}, fetched)).To(Succeed())
+		Expect(fetched.Spec.Replicas).NotTo(BeNil())
+		Expect(*fetched.Spec.Replicas).To(Equal(int32(0)))
 	})
 
-	It("should handle StatefulSet not existing when scaling to zero", func() {
+	It("creates the StatefulSet with zero replicas when none exists yet", func() {
+		// A cluster stopped from the start has no StatefulSet to scale; the reconcile must CREATE
+		// it (with 0 replicas) rather than do nothing.
+		stsName := reconciler.RoleGroupResourceName(crName, "test-role", "default")
+		Expect(k8serrors.IsNotFound(
+			k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: stsName}, &appsv1.StatefulSet{}),
+		)).To(BeTrue())
+
 		req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: crName}}
 		result, err := r.Reconcile(ctx, req)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).To(Equal(ctrl.Result{}))
+
+		fetched := &appsv1.StatefulSet{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: stsName}, fetched)).To(Succeed())
+		Expect(fetched.Spec.Replicas).NotTo(BeNil())
+		Expect(*fetched.Spec.Replicas).To(Equal(int32(0)))
 	})
 })
 

--- a/pkg/testutil/mocks.go
+++ b/pkg/testutil/mocks.go
@@ -246,11 +246,23 @@ func (h *MockRoleGroupHandler) BuildResources(ctx context.Context, k8sClient cli
 		return h.BuildResourcesFunc(ctx, k8sClient, cr, buildCtx)
 	}
 
+	// Effective replica count, mirroring the real BaseRoleGroupHandler: the role group's declared
+	// replicas, but forced to 0 when the cluster is stopped (ClusterOperation.stopped). Stopping
+	// runs zero pods while all resources are still built/preserved, so the mock must produce the
+	// StatefulSet with replicas 0 rather than short-circuiting resource creation.
+	replicas := buildCtx.RoleGroupSpec.GetReplicas()
+	if buildCtx.ClusterSpec != nil &&
+		buildCtx.ClusterSpec.ClusterOperation != nil &&
+		buildCtx.ClusterSpec.ClusterOperation.Stopped {
+		replicas = int32(0)
+	}
+
 	// Return default resources
 	return &reconciler.RoleGroupResources{
 		ConfigMap: NewTestConfigMap(buildCtx.ResourceName, buildCtx.ClusterNamespace),
 		Service:   NewTestService(buildCtx.ResourceName, buildCtx.ClusterNamespace),
 		StatefulSet: NewTestStatefulSetBuilder(buildCtx.ResourceName, buildCtx.ClusterNamespace).
+			WithReplicas(replicas).
 			WithImage(h.Image, corev1.PullIfNotPresent).
 			Build(),
 	}, nil


### PR DESCRIPTION
## Problem

`ClusterOperation.stopped` was a **reconcile short-circuit**: `reconcile()` called `handleStoppedCluster`, which only scaled *existing* StatefulSets to zero and returned before the normal reconcile (ServiceAccount, PreReconcile extensions, role reconciliation, cleanup, health).

That was functionally incomplete:
- a cluster created directly with `stopped=true` got **no resources at all** (nothing to scale);
- config/spec changes made while stopped were **never applied**;
- only StatefulSets — not the full resource set — were touched.

## Fix

Make `stopped` a **replica modifier** instead of a short-circuit. Stopping now means *"run zero pods while every resource (ConfigMap, Service, StatefulSet, PDB, ServiceAccount, PVCs) is still reconciled and preserved so the cluster can be resumed"*.

- `reconcile()` no longer branches on `stopped`; it falls through to the full normal reconcile.
- `BaseRoleGroupHandler.buildStatefulSet` forces the StatefulSet replica count to `0` when `spec.clusterOperation.stopped` is set.
- The health step already reports the `Stopped` status (and returns) at the end of the reconcile.
- Removed the now-unused `handleStoppedCluster` and `scaleToZero` methods.
- The `reconciliationPaused` freeze is **unchanged**: it still returns early before any mutating step (from #512).

## Behavior change to note

Because stopped no longer short-circuits, the normal reconcile's earlier steps now run **while a cluster is stopped** — in particular dependency validation and `PreReconcile` extension hooks. This is intended (a stopped cluster is fully reconciled, just at 0 replicas), but it is a visible change from the previous "touch nothing but the STS" behavior.

## Tests

- Updated the mock handler to mirror the effective-replica logic.
- Inverted/added `generic_reconciler_test.go` cases: stopped now asserts SA created + STS at replicas 0 + ConfigMap/Service created, and `Available=False / Reason=Stopped`. The paused test still asserts no SA is created.
- Added `base_role_group_handler_test.go` coverage for the replica-forcing.

## Validation

Validated end-to-end against zookeeper-operator's `cluster-operation` chainsaw e2e (install→1, stop→0, restart→1, pause+stop stays 1, unpause→0): **PASS**.

Relates to the stopped/paused functional-design review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)