### PR TITLE
fix(reconciler): emit the PodDisruptionBudget once per role, not per role group

### DIFF
--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
 	"github.com/zncdatadev/operator-go/pkg/builder"
 	"github.com/zncdatadev/operator-go/pkg/common"
 	"github.com/zncdatadev/operator-go/pkg/config"
@@ -36,10 +37,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+// managedByValue is the app.kubernetes.io/managed-by value stamped on framework-built resources.
+const managedByValue = "operator-go"
 
 // BaseRoleGroupHandler provides a base implementation of RoleGroupHandler.
 // Product operators can embed this struct and override methods as needed.
@@ -223,7 +226,11 @@ func (h *BaseRoleGroupHandler[CR]) resolveSecurityContext() (*corev1.SecurityCon
 // - Headless Service for StatefulSet
 // - Service (if ports are defined)
 // - StatefulSet with standard configuration
-// - PodDisruptionBudget (if configured in RoleConfig)
+//
+// The PodDisruptionBudget is intentionally NOT built here: it is a role-level resource
+// (roleConfig.podDisruptionBudget covers all pods of a role across every role group), so the
+// generic reconciler builds exactly one per role via BuildRolePodDisruptionBudget. Building it
+// per role group here would emit one PDB per group and split the role's disruption budget.
 func (h *BaseRoleGroupHandler[CR]) BuildResources(
 	ctx context.Context,
 	k8sClient client.Client,
@@ -260,12 +267,6 @@ func (h *BaseRoleGroupHandler[CR]) BuildResources(
 		return nil, fmt.Errorf("failed to build StatefulSet: %w", err)
 	}
 	resources.StatefulSet = sts
-
-	// Build PodDisruptionBudget
-	pdb := h.buildPodDisruptionBudget(buildCtx, labels)
-	if pdb != nil {
-		resources.PodDisruptionBudget = pdb
-	}
 
 	logger.V(1).Info("Built role group resources",
 		"role", buildCtx.RoleName,
@@ -347,7 +348,7 @@ func (h *BaseRoleGroupHandler[CR]) buildLabels(buildCtx *RoleGroupBuildContext) 
 	// Add standard labels
 	labels["app.kubernetes.io/instance"] = buildCtx.ClusterName
 	labels["app.kubernetes.io/component"] = buildCtx.RoleName
-	labels["app.kubernetes.io/managed-by"] = "operator-go"
+	labels["app.kubernetes.io/managed-by"] = managedByValue
 
 	// Role group label
 	labels[buildCtx.ClusterName+"-"+buildCtx.RoleGroupName] = "true"
@@ -682,45 +683,86 @@ func (h *BaseRoleGroupHandler[CR]) buildStatefulSet(
 	return sts, nil
 }
 
-// buildPodDisruptionBudget creates the PDB for the role group.
-func (h *BaseRoleGroupHandler[CR]) buildPodDisruptionBudget(buildCtx *RoleGroupBuildContext, labels map[string]string) *policyv1.PodDisruptionBudget {
-	// Check if PDB is configured in RoleConfig
-	roleConfig := buildCtx.RoleSpec.GetRoleConfig()
+// BuildRolePodDisruptionBudget builds the role-level PodDisruptionBudget from
+// roleConfig.podDisruptionBudget. A role's PDB covers every pod of the role across all of its
+// role groups (name "<cluster>-<role>", selector on the cluster+role identity labels), so
+// exactly one is emitted per role. Returns nil when the PDB is unset or explicitly disabled.
+func (h *BaseRoleGroupHandler[CR]) BuildRolePodDisruptionBudget(
+	clusterName, namespace, roleName string,
+	clusterLabels map[string]string,
+	roleSpec *v1alpha1.RoleSpec,
+) *policyv1.PodDisruptionBudget {
+	roleConfig := roleSpec.GetRoleConfig()
 	if roleConfig == nil || roleConfig.PodDisruptionBudget == nil {
 		return nil
 	}
 
-	pdbSpec := roleConfig.PodDisruptionBudget
+	b := builder.NewPDBBuilder(RoleResourceName(clusterName, roleName), namespace).
+		WithLabels(h.buildRoleLabels(clusterName, roleName, clusterLabels)).
+		WithAnnotations(h.ExtraAnnotations).
+		WithSelector(h.buildRoleSelectorLabels(clusterName, roleName)).
+		WithSpec(roleConfig.PodDisruptionBudget)
 
-	// Check if PDB is enabled (default is true if Enabled is not set)
-	if !pdbSpec.Enabled {
+	// Enabled defaults to true in the CRD; honor an explicit disable.
+	if !b.IsEnabled() {
 		return nil
 	}
 
-	// Build PDB spec
-	pdb := &policyv1.PodDisruptionBudget{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        buildCtx.ResourceName,
-			Namespace:   buildCtx.ClusterNamespace,
-			Labels:      labels,
-			Annotations: h.buildAnnotations(buildCtx),
-		},
-		Spec: policyv1.PodDisruptionBudgetSpec{
-			Selector: &metav1.LabelSelector{
-				MatchLabels: h.buildSelectorLabels(buildCtx),
-			},
-		},
-	}
+	return b.Build()
+}
 
-	// Set max unavailable (only option available in PodDisruptionBudgetSpec)
-	if pdbSpec.MaxUnavailable != nil {
-		pdb.Spec.MaxUnavailable = &intstr.IntOrString{
-			Type:   intstr.Int,
-			IntVal: *pdbSpec.MaxUnavailable,
+// roleIdentityLabels are the product-owned labels that identify a role (cluster + role, without
+// a role group). They are a subset of every pod's identity labels, so a selector built from them
+// matches all of a role's pods across role groups. Empty when the handler has no LabelDomain.
+func (h *BaseRoleGroupHandler[CR]) roleIdentityLabels(clusterName, roleName string) map[string]string {
+	if h.LabelDomain == "" {
+		return nil
+	}
+	return map[string]string{
+		ClusterLabelKey(h.LabelDomain): clusterName,
+		RoleLabelKey(h.LabelDomain):    roleName,
+	}
+}
+
+// buildRoleSelectorLabels is the role-scoped analogue of buildSelectorLabels: it must match all
+// pods of the role across every role group, so it omits the role group marker/identity label.
+func (h *BaseRoleGroupHandler[CR]) buildRoleSelectorLabels(clusterName, roleName string) map[string]string {
+	if h.LabelDomain == "" {
+		// Without product identity labels the selector falls back to the recommended labels.
+		// Include managed-by (framework pods always carry it) so the PDB stays scoped to
+		// operator-go-managed pods and cannot accidentally match another operator's workloads
+		// that reuse the same instance/component labels.
+		return map[string]string{
+			"app.kubernetes.io/instance":   clusterName,
+			"app.kubernetes.io/component":  roleName,
+			"app.kubernetes.io/managed-by": managedByValue,
 		}
 	}
+	return h.roleIdentityLabels(clusterName, roleName)
+}
 
-	return pdb
+// buildRoleLabels is the role-scoped analogue of buildLabels for metadata on role-level
+// resources: the standard recommended labels plus cluster/extra labels, but no role group marker.
+func (h *BaseRoleGroupHandler[CR]) buildRoleLabels(clusterName, roleName string, clusterLabels map[string]string) map[string]string {
+	labels := make(map[string]string)
+
+	for k, v := range clusterLabels {
+		labels[k] = v
+	}
+
+	labels["app.kubernetes.io/instance"] = clusterName
+	labels["app.kubernetes.io/component"] = roleName
+	labels["app.kubernetes.io/managed-by"] = managedByValue
+
+	for k, v := range h.roleIdentityLabels(clusterName, roleName) {
+		labels[k] = v
+	}
+
+	for k, v := range h.ExtraLabels {
+		labels[k] = v
+	}
+
+	return labels
 }
 
 // SetRoleImage sets the image for a specific role.

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/zncdatadev/operator-go/pkg/vector"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
@@ -189,37 +190,16 @@ var _ = Describe("BaseRoleGroupHandler", func() {
 			Expect(resources.StatefulSet.Namespace).To(Equal("default"))
 		})
 
-		It("should not build PDB when not configured", func() {
-			resources, err := handler.BuildResources(ctx, k8sClient, mockCR, buildCtx)
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(resources.PodDisruptionBudget).To(BeNil())
-		})
-
-		It("should build PDB when configured", func() {
+		It("should never set a role-group PDB (the PDB is a role-level resource)", func() {
+			// Even with roleConfig.podDisruptionBudget configured, BuildResources must not emit
+			// a per-group PDB: the framework builds exactly one PDB per role via
+			// BuildRolePodDisruptionBudget (covered in the "PodDisruptionBudget building" suite).
 			maxUnavailable := int32(1)
 			buildCtx.RoleSpec = &v1alpha1.RoleSpec{
 				RoleConfig: &v1alpha1.RoleConfigSpec{
 					PodDisruptionBudget: &v1alpha1.PodDisruptionBudgetSpec{
 						Enabled:        true,
 						MaxUnavailable: &maxUnavailable,
-					},
-				},
-			}
-
-			resources, err := handler.BuildResources(ctx, k8sClient, mockCR, buildCtx)
-
-			Expect(err).NotTo(HaveOccurred())
-			Expect(resources.PodDisruptionBudget).NotTo(BeNil())
-			Expect(resources.PodDisruptionBudget.Name).To(Equal("test-cluster-default"))
-		})
-
-		It("should not build PDB when disabled", func() {
-			enabled := false
-			buildCtx.RoleSpec = &v1alpha1.RoleSpec{
-				RoleConfig: &v1alpha1.RoleConfigSpec{
-					PodDisruptionBudget: &v1alpha1.PodDisruptionBudgetSpec{
-						Enabled: enabled,
 					},
 				},
 			}
@@ -391,50 +371,56 @@ var _ = Describe("RoleGroupHandlerFuncs", func() {
 
 var _ = Describe("PodDisruptionBudget building", func() {
 	var handler *reconciler.BaseRoleGroupHandler[common.ClusterInterface]
-	var buildCtx *reconciler.RoleGroupBuildContext
 
 	BeforeEach(func() {
 		handler = reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("test-image:latest", testScheme)
-		buildCtx = &reconciler.RoleGroupBuildContext{
-			ClusterName:      "test-cluster",
-			ClusterNamespace: "default",
-			ClusterLabels:    map[string]string{},
-			RoleName:         "test-role",
-			RoleSpec:         &v1alpha1.RoleSpec{},
-			RoleGroupName:    "default",
-			RoleGroupSpec:    v1alpha1.RoleGroupSpec{},
-			MergedConfig:     &config.MergedConfig{},
-			ResourceName:     "test-cluster-default",
-		}
+	})
+
+	roleWithPDB := func(spec *v1alpha1.PodDisruptionBudgetSpec) *v1alpha1.RoleSpec {
+		return &v1alpha1.RoleSpec{RoleConfig: &v1alpha1.RoleConfigSpec{PodDisruptionBudget: spec}}
+	}
+
+	It("should name the PDB at role level (<cluster>-<role>), not per role group", func() {
+		roleSpec := roleWithPDB(&v1alpha1.PodDisruptionBudgetSpec{Enabled: true})
+
+		pdb := handler.BuildRolePodDisruptionBudget("test-cluster", "default", "test-role", nil, roleSpec)
+		Expect(pdb).NotTo(BeNil())
+		Expect(pdb.Name).To(Equal("test-cluster-test-role"))
+		Expect(pdb.Namespace).To(Equal("default"))
 	})
 
 	It("should set maxUnavailable correctly", func() {
 		maxUnavailable := int32(2)
-		buildCtx.RoleSpec.RoleConfig = &v1alpha1.RoleConfigSpec{
-			PodDisruptionBudget: &v1alpha1.PodDisruptionBudgetSpec{
-				Enabled:        true,
-				MaxUnavailable: &maxUnavailable,
-			},
-		}
+		roleSpec := roleWithPDB(&v1alpha1.PodDisruptionBudgetSpec{Enabled: true, MaxUnavailable: &maxUnavailable})
 
-		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(resources.PodDisruptionBudget).NotTo(BeNil())
-		Expect(resources.PodDisruptionBudget.Spec.MaxUnavailable.IntVal).To(Equal(int32(2)))
+		pdb := handler.BuildRolePodDisruptionBudget("test-cluster", "default", "test-role", nil, roleSpec)
+		Expect(pdb).NotTo(BeNil())
+		Expect(pdb.Spec.MaxUnavailable.IntVal).To(Equal(int32(2)))
 	})
 
-	It("should set selector with correct labels", func() {
-		buildCtx.RoleSpec.RoleConfig = &v1alpha1.RoleConfigSpec{
-			PodDisruptionBudget: &v1alpha1.PodDisruptionBudgetSpec{
-				Enabled: true,
-			},
-		}
-		buildCtx.ClusterLabels["app"] = "test"
+	It("should build a role-scoped selector without the role group label", func() {
+		roleSpec := roleWithPDB(&v1alpha1.PodDisruptionBudgetSpec{Enabled: true})
 
-		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(resources.PodDisruptionBudget.Spec.Selector).NotTo(BeNil())
-		Expect(resources.PodDisruptionBudget.Spec.Selector.MatchLabels).NotTo(BeEmpty())
+		pdb := handler.BuildRolePodDisruptionBudget("test-cluster", "default", "test-role",
+			map[string]string{"app": "test"}, roleSpec)
+		Expect(pdb.Spec.Selector).NotTo(BeNil())
+		Expect(pdb.Spec.Selector.MatchLabels).To(HaveKeyWithValue("app.kubernetes.io/instance", "test-cluster"))
+		Expect(pdb.Spec.Selector.MatchLabels).To(HaveKeyWithValue("app.kubernetes.io/component", "test-role"))
+		// The selector must match all of the role's pods across role groups, so it must not
+		// carry the role group marker "<cluster>-<group>" that scopes a single group.
+		Expect(pdb.Spec.Selector.MatchLabels).NotTo(HaveKey("test-cluster-default"))
+	})
+
+	It("should return nil when disabled", func() {
+		roleSpec := roleWithPDB(&v1alpha1.PodDisruptionBudgetSpec{Enabled: false})
+		Expect(handler.BuildRolePodDisruptionBudget("test-cluster", "default", "test-role", nil, roleSpec)).To(BeNil())
+	})
+
+	It("should return nil when PodDisruptionBudget or RoleConfig is unset", func() {
+		Expect(handler.BuildRolePodDisruptionBudget("test-cluster", "default", "test-role", nil,
+			roleWithPDB(nil))).To(BeNil())
+		Expect(handler.BuildRolePodDisruptionBudget("test-cluster", "default", "test-role", nil,
+			&v1alpha1.RoleSpec{})).To(BeNil())
 	})
 })
 
@@ -1101,76 +1087,35 @@ var _ = Describe("BaseRoleGroupHandler extra labels and annotations", func() {
 
 var _ = Describe("BaseRoleGroupHandler with PDB", func() {
 	var handler *reconciler.BaseRoleGroupHandler[common.ClusterInterface]
-	var buildCtx *reconciler.RoleGroupBuildContext
 
 	BeforeEach(func() {
 		handler = reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("test-image:latest", testScheme)
-		buildCtx = &reconciler.RoleGroupBuildContext{
-			ClusterName:      "test-cluster",
-			ClusterNamespace: "default",
-			ClusterLabels:    map[string]string{},
-			RoleName:         "test-role",
-			RoleSpec:         &v1alpha1.RoleSpec{},
-			RoleGroupName:    "default",
-			RoleGroupSpec:    v1alpha1.RoleGroupSpec{Replicas: ptr.To(int32(3))},
-			MergedConfig:     &config.MergedConfig{},
-			ResourceName:     "test-cluster-default",
-		}
 	})
+
+	buildRolePDB := func(spec *v1alpha1.PodDisruptionBudgetSpec) *policyv1.PodDisruptionBudget {
+		roleSpec := &v1alpha1.RoleSpec{RoleConfig: &v1alpha1.RoleConfigSpec{PodDisruptionBudget: spec}}
+		return handler.BuildRolePodDisruptionBudget("test-cluster", "default", "test-role", nil, roleSpec)
+	}
 
 	It("should create PDB when MaxUnavailable is set and Enabled is true", func() {
 		maxUnavailable := int32(1)
-		buildCtx.RoleSpec = &v1alpha1.RoleSpec{
-			RoleConfig: &v1alpha1.RoleConfigSpec{
-				PodDisruptionBudget: &v1alpha1.PodDisruptionBudgetSpec{
-					Enabled:        true,
-					MaxUnavailable: &maxUnavailable,
-				},
-			},
-		}
-
-		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(resources.PodDisruptionBudget).NotTo(BeNil())
-		Expect(resources.PodDisruptionBudget.Spec.MaxUnavailable).NotTo(BeNil())
+		pdb := buildRolePDB(&v1alpha1.PodDisruptionBudgetSpec{Enabled: true, MaxUnavailable: &maxUnavailable})
+		Expect(pdb).NotTo(BeNil())
+		Expect(pdb.Spec.MaxUnavailable).NotTo(BeNil())
 	})
 
 	It("should not create PDB when Enabled is false", func() {
 		maxUnavailable := int32(1)
-		buildCtx.RoleSpec = &v1alpha1.RoleSpec{
-			RoleConfig: &v1alpha1.RoleConfigSpec{
-				PodDisruptionBudget: &v1alpha1.PodDisruptionBudgetSpec{
-					Enabled:        false,
-					MaxUnavailable: &maxUnavailable,
-				},
-			},
-		}
-
-		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(resources.PodDisruptionBudget).To(BeNil())
+		Expect(buildRolePDB(&v1alpha1.PodDisruptionBudgetSpec{Enabled: false, MaxUnavailable: &maxUnavailable})).To(BeNil())
 	})
 
 	It("should not create PDB when PodDisruptionBudget is nil", func() {
-		buildCtx.RoleSpec = &v1alpha1.RoleSpec{
-			RoleConfig: &v1alpha1.RoleConfigSpec{
-				PodDisruptionBudget: nil,
-			},
-		}
-
-		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(resources.PodDisruptionBudget).To(BeNil())
+		Expect(buildRolePDB(nil)).To(BeNil())
 	})
 
 	It("should not create PDB when RoleConfig is nil", func() {
-		buildCtx.RoleSpec = &v1alpha1.RoleSpec{
-			RoleConfig: nil,
-		}
-
-		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(resources.PodDisruptionBudget).To(BeNil())
+		Expect(handler.BuildRolePodDisruptionBudget("test-cluster", "default", "test-role", nil,
+			&v1alpha1.RoleSpec{})).To(BeNil())
 	})
 })
 

--- a/pkg/reconciler/discovery.go
+++ b/pkg/reconciler/discovery.go
@@ -145,7 +145,7 @@ func EnsureDiscoveryConfigMap(
 	// Canonical labels are framework-owned and set last, so extras cannot override them:
 	// consumers select discovery ConfigMaps by these keys.
 	labels["app.kubernetes.io/instance"] = owner.GetName()
-	labels["app.kubernetes.io/managed-by"] = "operator-go"
+	labels["app.kubernetes.io/managed-by"] = managedByValue
 	if options.ProductName != "" {
 		labels["app.kubernetes.io/name"] = options.ProductName
 	}

--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -431,12 +431,55 @@ func (r *GenericReconciler[CR]) reconcileRole(ctx context.Context, cr CR, roleNa
 		}
 	}
 
+	// Reconcile the role-level PodDisruptionBudget (one per role, covering all its role groups).
+	if err := r.reconcileRolePodDisruptionBudget(ctx, cr, roleName, roleSpec); err != nil {
+		return err
+	}
+
 	// Execute role PostReconcile extensions
 	if err := r.extensionRegistry.ExecuteRolePostReconcile(ctx, r.client, cr, roleName); err != nil {
 		return NewReconcileError("RolePostReconcile", fmt.Sprintf("role %s extension hook failed", roleName), err)
 	}
 
 	logger.V(1).Info("Role reconciled", "role", roleName)
+	return nil
+}
+
+// rolePodDisruptionBudgetBuilder is satisfied by BaseRoleGroupHandler (and any handler that
+// embeds it, via the promoted method). Asserting on this method-set interface — rather than the
+// concrete *BaseRoleGroupHandler[CR] — is what lets product handlers that embed the base handler
+// (e.g. *ZkRoleGroupHandler) still get a role-level PDB. The method signature does not depend on
+// CR, so the interface is non-generic.
+type rolePodDisruptionBudgetBuilder interface {
+	BuildRolePodDisruptionBudget(clusterName, namespace, roleName string, clusterLabels map[string]string, roleSpec *v1alpha1.RoleSpec) *policyv1.PodDisruptionBudget
+}
+
+// reconcileRolePodDisruptionBudget builds and applies the role's single PodDisruptionBudget.
+// The PDB is a role-level resource (roleConfig.podDisruptionBudget covers all pods of a role
+// across every role group), so it is reconciled here rather than per role group. When the PDB
+// is unset or disabled, any previously-created role PDB is deleted so toggling it off takes
+// effect. Handlers that neither are nor embed BaseRoleGroupHandler manage their own PDBs.
+func (r *GenericReconciler[CR]) reconcileRolePodDisruptionBudget(ctx context.Context, cr CR, roleName string, roleSpec *v1alpha1.RoleSpec) error {
+	handler, ok := r.roleGroupHandler.(rolePodDisruptionBudgetBuilder)
+	if !ok {
+		return nil
+	}
+
+	owner := r.getAsClientObject(cr)
+	name := RoleResourceName(cr.GetName(), roleName)
+
+	pdb := handler.BuildRolePodDisruptionBudget(cr.GetName(), cr.GetNamespace(), roleName, cr.GetLabels(), roleSpec)
+	if pdb == nil {
+		// PDB unset or disabled: remove any role PDB we previously created (ownership-checked).
+		if err := r.cleaner.deletePDB(ctx, cr.GetNamespace(), name, owner.GetUID()); err != nil {
+			return NewResourceApplyError("PodDisruptionBudget", cr.GetNamespace(), name, "failed to delete disabled PDB", err)
+		}
+		return nil
+	}
+
+	if err := r.applyResource(ctx, owner, pdb); err != nil {
+		return NewResourceApplyError("PodDisruptionBudget", cr.GetNamespace(), name, "failed to apply", err)
+	}
 	return nil
 }
 
@@ -514,6 +557,14 @@ func RoleGroupResourceName(clusterName, roleName, groupName string) string {
 	suffix := hex.EncodeToString(sum[:])[:8]
 	head := strings.TrimRight(name[:maxRoleGroupNameLen-len(suffix)-1], "-")
 	return head + "-" + suffix
+}
+
+// RoleResourceName returns the canonical resource name for a role-level resource:
+// "<cluster>-<role>". Used for resources that span all of a role's role groups, e.g. the
+// role's PodDisruptionBudget. It is always shorter than the corresponding role group name,
+// so no truncation is needed to stay within DNS limits.
+func RoleResourceName(clusterName, roleName string) string {
+	return fmt.Sprintf("%s-%s", clusterName, roleName)
 }
 
 // buildRoleGroupContext creates the build context for a role group.
@@ -709,11 +760,18 @@ func (r *GenericReconciler[CR]) applyResources(ctx context.Context, cr CR, resou
 		}
 	}
 
-	// 6. Apply PodDisruptionBudget
+	// 6. Apply the custom per-group PodDisruptionBudget (escape hatch), or reclaim the legacy
+	// per-role-group PDB. The framework's own PDB is now role-level (reconcileRolePodDisruptionBudget);
+	// a product may still ship a custom per-group PDB via RoleGroupResources.PodDisruptionBudget.
+	// When it does not, delete any PDB named "<cluster>-<role>-<group>" left behind by older
+	// framework versions (ownership-checked, no-op if absent) so upgraded clusters converge to
+	// exactly one role-level PDB instead of retaining stale per-group constraints.
 	if resources.PodDisruptionBudget != nil {
 		if err := r.applyResource(ctx, owner, resources.PodDisruptionBudget); err != nil {
 			return NewResourceApplyError("PodDisruptionBudget", buildCtx.ClusterNamespace, buildCtx.ResourceName, "failed to apply", err)
 		}
+	} else if err := r.cleaner.deletePDB(ctx, buildCtx.ClusterNamespace, buildCtx.ResourceName, owner.GetUID()); err != nil {
+		return NewResourceApplyError("PodDisruptionBudget", buildCtx.ClusterNamespace, buildCtx.ResourceName, "failed to delete legacy per-group PDB", err)
 	}
 
 	// 7. Apply MetricsService

--- a/pkg/reconciler/generic_reconciler_test.go
+++ b/pkg/reconciler/generic_reconciler_test.go
@@ -2223,3 +2223,108 @@ var _ = Describe("GenericReconciler update propagation (issue #526)", func() {
 		Expect(sts.Spec.Template.Labels).To(HaveKeyWithValue("version", "v2"))
 	})
 })
+
+// embeddingRoleGroupHandler mirrors how product operators (e.g. ZkRoleGroupHandler) consume the
+// framework: it EMBEDS *BaseRoleGroupHandler rather than being it exactly. It is the regression
+// guard for the role-level PDB — the reconciler must still emit it for an embedding handler,
+// which it does by asserting on the promoted method set (rolePodDisruptionBudgetBuilder) instead
+// of the concrete *BaseRoleGroupHandler type.
+type embeddingRoleGroupHandler struct {
+	*reconciler.BaseRoleGroupHandler[*testutil.ClusterWrapper]
+}
+
+var _ = Describe("GenericReconciler role PodDisruptionBudget", func() {
+	var r *reconciler.GenericReconciler[*testutil.ClusterWrapper]
+	var namespace string
+	var crName string
+	var mockCR *testutil.MockCluster
+
+	BeforeEach(func() {
+		namespace = testNamespace
+		crName = fmt.Sprintf("pdb-role-%d", time.Now().UnixNano())
+
+		handler := &embeddingRoleGroupHandler{
+			BaseRoleGroupHandler: reconciler.NewBaseRoleGroupHandler[*testutil.ClusterWrapper]("test-image:latest", testScheme),
+		}
+
+		cfg := &reconciler.GenericReconcilerConfig[*testutil.ClusterWrapper]{
+			Client:           k8sClient,
+			Scheme:           testScheme,
+			Recorder:         recorder,
+			RoleGroupHandler: handler,
+			Prototype:        testutil.WrapMockCluster(testutil.NewMockCluster(crName, namespace)),
+		}
+		var err error
+		r, err = reconciler.NewGenericReconciler(cfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		maxUnavailable := int32(2)
+		mockCR = testutil.NewMockCluster(crName, namespace).WithRoles(map[string]v1alpha1.RoleSpec{
+			"server": {
+				RoleConfig: &v1alpha1.RoleConfigSpec{
+					PodDisruptionBudget: &v1alpha1.PodDisruptionBudgetSpec{Enabled: true, MaxUnavailable: &maxUnavailable},
+				},
+				RoleGroups: map[string]v1alpha1.RoleGroupSpec{
+					"default":   {Replicas: ptr.To(int32(2))},
+					"secondary": {Replicas: ptr.To(int32(1))},
+				},
+			},
+		})
+		Expect(k8sClient.Create(ctx, mockCR)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		_ = k8sClient.Delete(ctx, mockCR)
+	})
+
+	It("emits exactly one role-level PDB across role groups for an embedding handler", func() {
+		req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: crName}}
+		_, err := r.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+
+		// One role-level PDB named "<cluster>-<role>" (not "<cluster>-<role>-<group>").
+		rolePDB := &policyv1.PodDisruptionBudget{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: reconciler.RoleResourceName(crName, "server")}, rolePDB)).To(Succeed())
+		Expect(rolePDB.Spec.MaxUnavailable.IntVal).To(Equal(int32(2)))
+
+		// No per-group PDBs: the role PDB's selector spans every group.
+		for _, group := range []string{"default", "secondary"} {
+			perGroup := &policyv1.PodDisruptionBudget{}
+			getErr := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: reconciler.RoleGroupResourceName(crName, "server", group)}, perGroup)
+			Expect(k8serrors.IsNotFound(getErr)).To(BeTrue(), "no per-group PDB should exist for group %q", group)
+		}
+	})
+
+	It("reclaims a legacy per-role-group PDB left by an older framework version", func() {
+		// Simulate an upgrade: a per-group PDB "<cluster>-server-default", owned by the CR, was
+		// written by an older framework version and still lingers.
+		legacyName := reconciler.RoleGroupResourceName(crName, "server", "default")
+		legacy := &policyv1.PodDisruptionBudget{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      legacyName,
+				Namespace: namespace,
+				OwnerReferences: []metav1.OwnerReference{{
+					APIVersion: "test.zncdata.dev/v1alpha1",
+					Kind:       "MockCluster",
+					Name:       crName,
+					UID:        mockCR.GetUID(),
+					Controller: ptr.To(true),
+				}},
+			},
+			Spec: policyv1.PodDisruptionBudgetSpec{
+				Selector:       &metav1.LabelSelector{MatchLabels: map[string]string{"legacy": "true"}},
+				MaxUnavailable: func() *intstr.IntOrString { v := intstr.FromInt(1); return &v }(),
+			},
+		}
+		Expect(k8sClient.Create(ctx, legacy)).To(Succeed())
+
+		req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: crName}}
+		_, err := r.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+
+		// The legacy per-group PDB is reclaimed; exactly the role-level PDB remains.
+		getErr := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: legacyName}, &policyv1.PodDisruptionBudget{})
+		Expect(k8serrors.IsNotFound(getErr)).To(BeTrue(), "legacy per-group PDB should have been deleted")
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: reconciler.RoleResourceName(crName, "server")}, &policyv1.PodDisruptionBudget{})).To(Succeed())
+	})
+})

--- a/pkg/reconciler/role_group_handler.go
+++ b/pkg/reconciler/role_group_handler.go
@@ -48,7 +48,11 @@ type RoleGroupResources struct {
 	// HeadlessService is the headless service for StatefulSet network identity.
 	HeadlessService *corev1.Service
 
-	// PodDisruptionBudget controls pod eviction (optional).
+	// PodDisruptionBudget is an optional escape hatch for a custom, role-group-scoped PDB.
+	// The framework's own PDB (from roleConfig.podDisruptionBudget) is a role-level resource
+	// covering all of a role's groups and is emitted once per role by the generic reconciler
+	// (see BaseRoleGroupHandler.BuildRolePodDisruptionBudget); it is NOT set here. Leave this
+	// nil unless a product deliberately needs an extra per-group PDB.
 	PodDisruptionBudget *policyv1.PodDisruptionBudget
 
 	// MetricsService is a headless service with Prometheus scrape annotations (optional).


### PR DESCRIPTION
## Problem

`roleConfig.podDisruptionBudget` is a **role-level** concept — the API models it on `RoleConfigSpec` and its docs say the PDB *"covers all Pods across all RoleGroups"* of a role. But the framework built it inside `BaseRoleGroupHandler.BuildResources`, which runs once **per role group**, so it emitted one PDB per group named `<cluster>-<role>-<group>` whose selector only matched that single group.

For a `server` role with groups `default(2)` + `secondary(1)` and `roleConfig.maxUnavailable=2` this produced:

| | design / intent | old framework |
|---|---|---|
| PDB count | 1 | 2 |
| name | `<cluster>-server` | `<cluster>-server-default` + `<cluster>-server-secondary` |
| coverage | all 3 pods | 2 and 1, per group |
| `maxUnavailable=2` meaning | ≤2 unavailable across the role | ≤2 **per group** (up to 4 across the role); on the 1-pod group `maxUnavailable≥replicas` → zero protection |

The role's disruption budget was effectively defeated.

## Fix

Make the PDB a role-level resource:

- `BaseRoleGroupHandler.BuildResources` no longer builds a PDB.
- New `BaseRoleGroupHandler.BuildRolePodDisruptionBudget` builds **one PDB per role**, named `<cluster>-<role>` (`RoleResourceName`) with a **role-scoped selector** (cluster+role identity labels, no role-group marker) so it covers every group. It reuses `builder.PDBBuilder`.
- `GenericReconciler.reconcileRole` builds and applies it once per role, and deletes any previously-created role PDB when the config is unset or disabled.

The reconciler selects the builder via the `rolePodDisruptionBudgetBuilder` **method-set interface**, not the concrete `*BaseRoleGroupHandler[CR]` type, so product handlers that **embed** the base handler (e.g. `*ZkRoleGroupHandler`) still get a role PDB through the promoted method. A concrete type assertion would silently skip the PDB for every real product operator (caught during e2e — see below).

`RoleGroupResources.PodDisruptionBudget` is kept as an escape hatch for a custom per-group PDB (still applied by `applyResources`) but is no longer populated by the base handler; its doc is updated accordingly.

## Tests

- Building tests moved from the removed per-group builder to `BuildRolePodDisruptionBudget` (role-level name, role-scoped selector without the group marker, `maxUnavailable`, disabled/unset cases).
- A reconcile-level **regression test with a handler that embeds `BaseRoleGroupHandler`** asserts exactly one role PDB (`<cluster>-<role>`, no per-group PDBs) is created across two role groups. Verified it fails if the builder is selected by concrete type instead of the interface.
- Full suite + `golangci-lint` green.

## Validation

Validated end-to-end against zookeeper-operator's `tls-override-pdb` chainsaw e2e (`server` role, groups `default(2)` + `secondary(1)`, `roleConfig.maxUnavailable=2`). The `test pdb` step **passes**: exactly one `test-zk-server` PDB with `maxUnavailable=2`, `expectedPods=3`, `currentHealthy=3`, `disruptionsAllowed=2` — one role PDB spanning both groups.

Builds on #529.

🤖 Generated with [Claude Code](https://claude.com/claude-code)