### PR TITLE
feat(reconciler): per-role MainContainerName and LoggingContainers

### DIFF
--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -107,7 +107,15 @@ type BaseRoleGroupHandler[CR common.ClusterInterface] struct {
 	// Products use this when the container name is significant — e.g. it must match the
 	// per-container logging key (logging.containers.<name>) declared in LoggingContainers.
 	// Defaults to the resource name (set by the StatefulSet builder) when empty.
+	//
+	// Products whose primary container name differs per role (e.g. HDFS: namenode / datanode /
+	// journalnode) set it per role via SetRoleMainContainerName; the per-role value wins over
+	// this global default.
 	MainContainerName string
+
+	// RoleMainContainerName maps role names to a role-specific primary container name, overriding
+	// MainContainerName for that role. Symmetric with RoleContainerPorts.
+	RoleMainContainerName map[string]string
 
 	// PublishNotReadyAddresses, when true, sets the same flag on the headless Service so
 	// peers can resolve each other's DNS before readiness (required by quorum systems).
@@ -135,7 +143,14 @@ type BaseRoleGroupHandler[CR common.ClusterInterface] struct {
 	// and mounts it on itself (pre-creating each producer's per-container log directory before
 	// exec'ing vector). When Vector is disabled, no shared volume exists and no file
 	// appender is emitted (console-only).
+	//
+	// Products whose primary container name (and therefore its logging key) differs per role set
+	// this per role via SetRoleLoggingContainers; the per-role value wins over this global list.
 	LoggingContainers []productlogging.ContainerLogging
+
+	// RoleLoggingContainers maps role names to a role-specific logging-producer list, overriding
+	// LoggingContainers for that role. Symmetric with RoleContainerPorts.
+	RoleLoggingContainers map[string][]productlogging.ContainerLogging
 
 	// LogVolumeSize overrides the SizeLimit of the shared log emptyDir. Empty uses
 	// vector.DefaultLogVolumeSize. The GenericReconciler forwards it to the Vector provider,
@@ -168,14 +183,16 @@ type BaseRoleGroupHandler[CR common.ClusterInterface] struct {
 // NewBaseRoleGroupHandler creates a new BaseRoleGroupHandler with defaults.
 func NewBaseRoleGroupHandler[CR common.ClusterInterface](image string, scheme *runtime.Scheme) *BaseRoleGroupHandler[CR] {
 	return &BaseRoleGroupHandler[CR]{
-		Image:              image,
-		ImagePullPolicy:    corev1.PullIfNotPresent,
-		RoleImages:         make(map[string]string),
-		RoleContainerPorts: make(map[string][]corev1.ContainerPort),
-		RoleServicePorts:   make(map[string][]corev1.ServicePort),
-		Scheme:             scheme,
-		ExtraLabels:        make(map[string]string),
-		ExtraAnnotations:   make(map[string]string),
+		Image:                 image,
+		ImagePullPolicy:       corev1.PullIfNotPresent,
+		RoleImages:            make(map[string]string),
+		RoleContainerPorts:    make(map[string][]corev1.ContainerPort),
+		RoleServicePorts:      make(map[string][]corev1.ServicePort),
+		RoleMainContainerName: make(map[string]string),
+		RoleLoggingContainers: make(map[string][]productlogging.ContainerLogging),
+		Scheme:                scheme,
+		ExtraLabels:           make(map[string]string),
+		ExtraAnnotations:      make(map[string]string),
 	}
 }
 
@@ -288,11 +305,48 @@ func vectorEnabledFor(buildCtx *RoleGroupBuildContext) bool {
 	return vector.IsAgentEnabled(buildCtx.MergedConfig.Logging)
 }
 
-// LoggingProducers implements LoggingProducerProvider: it exposes the handler's declared
+// LoggingProducers implements LoggingProducerProvider: it exposes the role's declared
 // log-producer containers so the GenericReconciler can configure the Vector sidecar (the single
-// owner of the shared log volume) without reaching into handler internals.
-func (h *BaseRoleGroupHandler[CR]) LoggingProducers() []productlogging.ContainerLogging {
+// owner of the shared log volume) without reaching into handler internals. The per-role list set
+// via SetRoleLoggingContainers wins over the global LoggingContainers.
+func (h *BaseRoleGroupHandler[CR]) LoggingProducers(roleName string) []productlogging.ContainerLogging {
+	return h.loggingContainersFor(roleName)
+}
+
+// loggingContainersFor returns the role-specific logging-producer list when set, else the global
+// LoggingContainers.
+func (h *BaseRoleGroupHandler[CR]) loggingContainersFor(roleName string) []productlogging.ContainerLogging {
+	if lc, ok := h.RoleLoggingContainers[roleName]; ok {
+		return lc
+	}
 	return h.LoggingContainers
+}
+
+// mainContainerNameFor returns the role-specific primary container name when set, else the global
+// MainContainerName.
+func (h *BaseRoleGroupHandler[CR]) mainContainerNameFor(roleName string) string {
+	if name, ok := h.RoleMainContainerName[roleName]; ok {
+		return name
+	}
+	return h.MainContainerName
+}
+
+// SetRoleLoggingContainers sets the logging-producer list for a specific role, overriding the
+// global LoggingContainers for that role. Symmetric with SetRoleContainerPorts.
+func (h *BaseRoleGroupHandler[CR]) SetRoleLoggingContainers(roleName string, containers []productlogging.ContainerLogging) {
+	if h.RoleLoggingContainers == nil {
+		h.RoleLoggingContainers = make(map[string][]productlogging.ContainerLogging)
+	}
+	h.RoleLoggingContainers[roleName] = containers
+}
+
+// SetRoleMainContainerName sets the primary container name for a specific role, overriding the
+// global MainContainerName for that role. Symmetric with SetRoleContainerPorts.
+func (h *BaseRoleGroupHandler[CR]) SetRoleMainContainerName(roleName, name string) {
+	if h.RoleMainContainerName == nil {
+		h.RoleMainContainerName = make(map[string]string)
+	}
+	h.RoleMainContainerName[roleName] = name
 }
 
 // LogVolumeSizeLimit implements LoggingProducerProvider: the shared log volume SizeLimit override
@@ -443,7 +497,7 @@ func (h *BaseRoleGroupHandler[CR]) buildConfigMap(buildCtx *RoleGroupBuildContex
 	// vector.yaml when the Vector agent is enabled (RenderLoggingConfigMapData owns the file
 	// appender and vector.yaml gating). Fail fast on a key collision rather than silently
 	// overwriting a file the product already produced (e.g. via MergedConfig.ConfigFiles).
-	loggingData, err := RenderLoggingConfigMapData(buildCtx, h.LoggingContainers)
+	loggingData, err := RenderLoggingConfigMapData(buildCtx, h.loggingContainersFor(buildCtx.RoleName))
 	if err != nil {
 		return nil, err
 	}
@@ -665,8 +719,8 @@ func (h *BaseRoleGroupHandler[CR]) buildStatefulSet(
 	// its per-container logging key). The builder makes the primary container index 0. This runs
 	// before sidecar injection so the Vector provider (which RW-mounts the shared log volume on
 	// the producer containers by name) sees the final container names.
-	if h.MainContainerName != "" && len(sts.Spec.Template.Spec.Containers) > 0 {
-		sts.Spec.Template.Spec.Containers[0].Name = h.MainContainerName
+	if mainName := h.mainContainerNameFor(buildCtx.RoleName); mainName != "" && len(sts.Spec.Template.Spec.Containers) > 0 {
+		sts.Spec.Template.Spec.Containers[0].Name = mainName
 	}
 
 	// Inject sidecars: prefer buildCtx (SDK auto-created), fallback to instance field

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -128,6 +128,32 @@ var _ = Describe("BaseRoleGroupHandler", func() {
 		})
 	})
 
+	Describe("per-role logging and main container name", func() {
+		It("SetRoleLoggingContainers wins over the global LoggingContainers for that role", func() {
+			global := []productlogging.ContainerLogging{{Container: "app", Framework: productlogging.LoggingFrameworkLogback}}
+			perRole := []productlogging.ContainerLogging{{Container: "namenode", Framework: productlogging.LoggingFrameworkLog4j}}
+			handler.LoggingContainers = global
+			handler.SetRoleLoggingContainers("namenode", perRole)
+
+			Expect(handler.LoggingProducers("namenode")).To(Equal(perRole))
+			Expect(handler.LoggingProducers("datanode")).To(Equal(global), "roles without an override fall back to global")
+		})
+
+		It("SetRoleMainContainerName records a per-role override", func() {
+			handler.MainContainerName = "app"
+			handler.SetRoleMainContainerName("namenode", "namenode")
+			Expect(handler.RoleMainContainerName["namenode"]).To(Equal("namenode"))
+		})
+
+		It("initializes the per-role maps when nil", func() {
+			nilHandler := &reconciler.BaseRoleGroupHandler[common.ClusterInterface]{}
+			nilHandler.SetRoleMainContainerName("r", "c")
+			nilHandler.SetRoleLoggingContainers("r", []productlogging.ContainerLogging{{Container: "c"}})
+			Expect(nilHandler.RoleMainContainerName).NotTo(BeNil())
+			Expect(nilHandler.RoleLoggingContainers).NotTo(BeNil())
+		})
+	})
+
 	Describe("SetRoleServicePorts", func() {
 		It("should set ports for a role", func() {
 			testPorts := []corev1.ServicePort{{Name: "http", Port: 80}}

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -1728,6 +1728,20 @@ var _ = Describe("VolumeProvider injection", func() {
 		Expect(sts.Spec.Template.Spec.InitContainers).To(ContainElement(HaveField("Name", "init-config")))
 	})
 
+	It("applies the per-role MainContainerName over the global one when building the StatefulSet", func() {
+		// buildCtx.RoleName is "test-role"; the per-role override must win over the global name in
+		// the actual built StatefulSet, exercising the mainContainerNameFor wiring end-to-end.
+		handler.MainContainerName = "global-main"
+		handler.SetRoleMainContainerName(buildCtx.RoleName, "per-role-main")
+
+		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
+		Expect(err).NotTo(HaveOccurred())
+
+		sts := resources.StatefulSet
+		Expect(sts.Spec.Template.Spec.Containers).NotTo(BeEmpty())
+		Expect(sts.Spec.Template.Spec.Containers[0].Name).To(Equal("per-role-main"))
+	})
+
 	It("supports multiple providers, injecting every volume + mount", func() {
 		second := &fakeVolumeProvider{
 			volume: corev1.Volume{

--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -625,7 +625,7 @@ func (r *GenericReconciler[CR]) buildSidecarManager(ctx context.Context, buildCt
 	var producers []productlogging.ContainerLogging
 	var logVolumeSize string
 	if lp, ok := r.roleGroupHandler.(LoggingProducerProvider); ok {
-		producers = lp.LoggingProducers()
+		producers = lp.LoggingProducers(buildCtx.RoleName)
 		logVolumeSize = lp.LogVolumeSizeLimit()
 	}
 
@@ -674,9 +674,9 @@ func producerContainerNames(producers []productlogging.ContainerLogging) []strin
 // LoggingProducerProvider (nil otherwise). Both Vector sidecar registration and aggregator-address
 // resolution gate on "≥1 producer" so they stay consistent: the framework only wires Vector — and
 // only resolves/generates its config — when there is actually something to collect.
-func (r *GenericReconciler[CR]) loggingProducers() []productlogging.ContainerLogging {
+func (r *GenericReconciler[CR]) loggingProducers(roleName string) []productlogging.ContainerLogging {
 	if lp, ok := r.roleGroupHandler.(LoggingProducerProvider); ok {
-		return lp.LoggingProducers()
+		return lp.LoggingProducers(roleName)
 	}
 	return nil
 }
@@ -689,7 +689,7 @@ func (r *GenericReconciler[CR]) loggingProducers() []productlogging.ContainerLog
 // must be non-empty and resolvable; an unset name or a discovery failure is returned as an error,
 // failing loudly rather than shipping a Vector sidecar with no aggregator.
 func (r *GenericReconciler[CR]) resolveVectorAggregatorAddress(ctx context.Context, cr CR, buildCtx *RoleGroupBuildContext) error {
-	if !vectorEnabledFor(buildCtx) || len(r.loggingProducers()) == 0 {
+	if !vectorEnabledFor(buildCtx) || len(r.loggingProducers(buildCtx.RoleName)) == 0 {
 		return nil
 	}
 	provider, ok := any(cr).(VectorAggregatorProvider)

--- a/pkg/reconciler/role_group_handler.go
+++ b/pkg/reconciler/role_group_handler.go
@@ -184,7 +184,7 @@ type VectorAggregatorProvider interface {
 type LoggingProducerProvider interface {
 	// LoggingProducers returns the declared log-producer containers (the containers whose log
 	// files Vector collects; the provider RW-mounts the shared log volume on each).
-	LoggingProducers() []productlogging.ContainerLogging
+	LoggingProducers(roleName string) []productlogging.ContainerLogging
 	// LogVolumeSizeLimit returns the shared log volume SizeLimit override; "" uses the framework
 	// default (vector.DefaultLogVolumeSize).
 	LogVolumeSizeLimit() string

--- a/pkg/reconciler/role_group_handler.go
+++ b/pkg/reconciler/role_group_handler.go
@@ -182,8 +182,11 @@ type VectorAggregatorProvider interface {
 // configure the Vector sidecar (the single owner of the shared log volume) without depending on a
 // concrete handler type.
 type LoggingProducerProvider interface {
-	// LoggingProducers returns the declared log-producer containers (the containers whose log
-	// files Vector collects; the provider RW-mounts the shared log volume on each).
+	// LoggingProducers returns the declared log-producer containers for the given role (the
+	// containers whose log files Vector collects; the provider RW-mounts the shared log volume on
+	// each). roleName selects the declaration: an implementation may return a role-specific list
+	// (e.g. a per-role container name), falling back to a global default for roles without an
+	// override. The GenericReconciler calls it once per role group, passing buildCtx.RoleName.
 	LoggingProducers(roleName string) []productlogging.ContainerLogging
 	// LogVolumeSizeLimit returns the shared log volume SizeLimit override; "" uses the framework
 	// default (vector.DefaultLogVolumeSize).


### PR DESCRIPTION
## Motivation

`BaseRoleGroupHandler` supports **per-role** container/service ports (`RoleContainerPorts` / `SetRoleContainerPorts`), but the primary container name (`MainContainerName`) and the logging-producer declaration (`LoggingContainers`) were **global** — a single value shared by every role.

Products whose primary container name differs per role can't use the framework's declarative logging. HDFS is the motivating case: its roles are `namenode` / `datanode` / `journalnode`, and the documented CRD data model keys logging per role (`logging.containers.namenode`, `logging.containers.dataNode`, …). With a single global `LoggingContainers`/`MainContainerName`, all roles would share one container name, diverging from that contract. (Trino sidesteps this by using one container name — `trino` — for both roles.)

## Change

Add the per-role overrides, symmetric with `SetRoleContainerPorts`:
- `RoleMainContainerName` + `SetRoleMainContainerName`
- `RoleLoggingContainers` + `SetRoleLoggingContainers`

The three consumers resolve per-role first, falling back to the global field (fully backward compatible — products setting only the global fields are unaffected):
1. ConfigMap logging render (`RenderLoggingConfigMapData`)
2. primary container rename in `buildStatefulSet`
3. Vector producer declaration (`LoggingProducers`)

`LoggingProducerProvider.LoggingProducers` gains a `roleName` parameter. Only `BaseRoleGroupHandler` implements it (products embed it), and both framework call sites already have `buildCtx.RoleName`, so the signature change is internal.

## Tests

- New unit specs: per-role list wins over global; roles without an override fall back; nil maps initialize.
- `make test` (envtest) green; `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)