### PR TITLE
test(reconciler): enlarge shared FakeRecorder buffer to avoid mid-suite hang

### DIFF
--- a/pkg/reconciler/suite_test.go
+++ b/pkg/reconciler/suite_test.go
@@ -65,7 +65,11 @@ var _ = BeforeSuite(func() {
 	k8sClient = testEnv.GetClient()
 	Expect(k8sClient).NotTo(BeNil())
 
-	recorder = record.NewFakeRecorder(100)
+	// Large buffer: this recorder is shared across the whole suite and never drained, so a small
+	// buffer fills up (FakeRecorder blocks on a full channel) and hangs a reconcile mid-suite —
+	// which specs trigger it depends on Ginkgo's randomized order. Specs that assert on emitted
+	// events use their own drained recorder instead.
+	recorder = record.NewFakeRecorder(10000)
 	Expect(recorder).NotTo(BeNil())
 })
 


### PR DESCRIPTION
## Problem

`pkg/reconciler/suite_test.go` creates a **suite-wide** `record.NewFakeRecorder(100)` in `BeforeSuite` and never drains it. `EmitCreateEvent` (called from `applyResource` on every reconcile that creates a resource) writes to this recorder's buffered channel. Once the **cumulative** `Created` events across the suite cross 100, the next `EmitCreateEvent` blocks on the full channel and the reconcile hangs until the test timeout.

Whether it triggers depends on Ginkgo's randomized spec order, so it's flaky — it reproduces on `main` independent of any feature branch (confirmed by running the compiled reconciler test binary on `main`: `panic: test timed out` with a `goroutine [chan send, 3 minutes]` in `FakeRecorder.writeEvent` → `EmitCreateEvent`).

## Fix

Bump the shared recorder's buffer to 10000. Specs that actually assert on emitted events already use their own separate, drained recorder, so nothing else changes.

With the fix the full reconciler suite runs deterministically: `Ran 328 of 328 Specs — SUCCESS! 328 Passed | 0 Failed` in ~8.5s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)