### PR TITLE
fix(builder): emit config env vars in sorted order to stop reconcile churn

### DIFF
--- a/pkg/builder/statefulset_builder.go
+++ b/pkg/builder/statefulset_builder.go
@@ -17,6 +17,8 @@ limitations under the License.
 package builder
 
 import (
+	"sort"
+
 	"github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
 	"github.com/zncdatadev/operator-go/pkg/config"
 	appsv1 "k8s.io/api/apps/v1"
@@ -521,12 +523,21 @@ func (b *StatefulSetBuilder) buildContainer() corev1.Container {
 		container.Args = b.Args
 	}
 
-	// Add environment variables from merged config
+	// Add environment variables from merged config. Iterate in sorted key order: EnvVars is a
+	// map, and Go map iteration order is randomized, so appending directly would produce a
+	// different container.Env ordering on every reconcile. That makes the rendered StatefulSet
+	// differ each time, so CreateOrUpdate issues an endless stream of no-op updates (the pods are
+	// recreated on every reconcile and never stabilize).
 	if b.Config != nil {
-		for k, v := range b.Config.EnvVars {
+		envKeys := make([]string, 0, len(b.Config.EnvVars))
+		for k := range b.Config.EnvVars {
+			envKeys = append(envKeys, k)
+		}
+		sort.Strings(envKeys)
+		for _, k := range envKeys {
 			container.Env = append(container.Env, corev1.EnvVar{
 				Name:  k,
-				Value: v,
+				Value: b.Config.EnvVars[k],
 			})
 		}
 		// Add CLI args

--- a/pkg/builder/statefulset_builder_test.go
+++ b/pkg/builder/statefulset_builder_test.go
@@ -927,6 +927,33 @@ var _ = Describe("StatefulSetBuilder", func() {
 			))
 		})
 
+		It("emits config env vars in a deterministic (sorted) order across builds", func() {
+			// EnvVars is a map; without sorting, Go's randomized map iteration would produce a
+			// different container.Env ordering each Build(), making the rendered StatefulSet
+			// differ every reconcile and causing an endless CreateOrUpdate loop.
+			cfg := &config.MergedConfig{
+				EnvVars: map[string]string{"DDD": "4", "AAA": "1", "CCC": "3", "BBB": "2", "EEE": "5"},
+			}
+			build := func() []string {
+				sts := builder.NewStatefulSetBuilder(name, namespace).
+					WithImage(image, corev1.PullIfNotPresent).
+					WithConfig(cfg).Build()
+				env := sts.Spec.Template.Spec.Containers[0].Env
+				names := make([]string, 0, len(env))
+				for _, e := range env {
+					names = append(names, e.Name)
+				}
+				return names
+			}
+			first := build()
+			// The five config keys appear in sorted order.
+			Expect(first).To(Equal([]string{"AAA", "BBB", "CCC", "DDD", "EEE"}))
+			// Repeated builds are byte-for-byte identical (no churn).
+			for i := 0; i < 20; i++ {
+				Expect(build()).To(Equal(first))
+			}
+		})
+
 		It("should include CLI args from merged config", func() {
 			cfg := &config.MergedConfig{
 				CliArgs: []string{"--arg1", "--arg2"},


### PR DESCRIPTION
## Problem

`StatefulSetBuilder` builds the container environment by ranging over `Config.EnvVars`, which is a `map[string]string`:

```go
for k, v := range b.Config.EnvVars {
    container.Env = append(container.Env, corev1.EnvVar{Name: k, Value: v})
}
```

Go **randomizes map iteration order**, so `container.Env` comes out in a different order on every `Build()`. The rendered StatefulSet therefore differs on every reconcile even when nothing has changed, and `controllerutil.CreateOrUpdate` issues an endless stream of no-op `Update`s. Since the differing field is in the **pod template**, every update recreates the pods — so any cluster that sets `envOverrides` **never stabilizes**: its pods are recreated almost continuously and never reach readiness/quorum.

Observed downstream (zookeeper-operator e2e): a 3-node TLS cluster with `envOverrides` whose StatefulSet `generation` climbed past 3000 within minutes (~9 updates/sec), pod ages constantly resetting, and `PodDisruptionBudget.status.currentHealthy` stuck below the replica count so the cluster never became available.

## Fix

Iterate the `EnvVars` keys in sorted order, so the rendered env — and thus the whole StatefulSet — is deterministic across reconciles.

## Tests

Adds a `statefulset_builder` test that builds with an unsorted `EnvVars` map and asserts (a) the config env vars appear in sorted order and (b) 20 repeated builds are byte-for-byte identical (no churn).

Labels/annotations built from maps elsewhere in the builder are unaffected — they are stored as maps on the object and compared order-independently; only the env **list** is order-sensitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)