### PR TITLE
fix(reconciler): propagate the product image to sidecars for embedding handlers

### DIFF
--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -258,6 +258,27 @@ func (h *BaseRoleGroupHandler[CR]) BuildResources(
 
 	resources := &RoleGroupResources{}
 
+	// Propagate the product image to the registered sidecars (e.g. Vector, which ships inside
+	// the product image). This must happen here — not earlier in GenericReconciler — because the
+	// documented embedding pattern resolves the CR-driven image inside the product's
+	// BuildResources override, immediately before delegating to this method; any earlier
+	// propagation would see a stale (or empty) image. Doing it in the base implementation means
+	// every embedding handler gets it for free instead of hand-calling SetProductImage.
+	//
+	// Select the manager exactly as sidecar injection does below (prefer the SDK-created one,
+	// fall back to the instance field) so propagation and injection can never target different
+	// managers. Call SetProductImage unconditionally: it rejects an empty image, so a
+	// misconfigured product fails loudly here instead of silently injecting a sidecar with an
+	// empty image field.
+	if sidecarMgr := buildCtx.SidecarManager; sidecarMgr != nil || h.sidecarManager != nil {
+		if sidecarMgr == nil {
+			sidecarMgr = h.sidecarManager
+		}
+		if err := sidecarMgr.SetProductImage(h.containerImage(buildCtx.RoleName), h.ImagePullPolicy); err != nil {
+			return nil, fmt.Errorf("failed to set product image on sidecars: %w", err)
+		}
+	}
+
 	// Build labels
 	labels := h.buildLabels(buildCtx)
 

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -1778,3 +1778,74 @@ var _ = Describe("VolumeProvider injection", func() {
 		Expect(primaryMountNames(resources.StatefulSet)).To(ConsistOf("config"))
 	})
 })
+
+// embeddingImageHandler mimics the documented product pattern: a handler embedding
+// BaseRoleGroupHandler that resolves the CR-driven image inside its BuildResources override,
+// immediately before delegating to the base implementation.
+type embeddingImageHandler struct {
+	*reconciler.BaseRoleGroupHandler[common.ClusterInterface]
+	image string
+}
+
+func (h *embeddingImageHandler) BuildResources(
+	ctx context.Context,
+	k8sClient client.Client,
+	cr common.ClusterInterface,
+	buildCtx *reconciler.RoleGroupBuildContext,
+) (*reconciler.RoleGroupResources, error) {
+	h.Image = h.image
+	return h.BaseRoleGroupHandler.BuildResources(ctx, k8sClient, cr, buildCtx)
+}
+
+var _ = Describe("Sidecar product image propagation", func() {
+	// Regression: the propagation used to live in GenericReconciler behind a concrete
+	// *BaseRoleGroupHandler type assertion, so embedding handlers (every product operator)
+	// never had the product image set on framework-registered sidecars and had to call
+	// SetProductImage by hand.
+	It("propagates the image resolved in an embedding handler's BuildResources to the Vector sidecar", func() {
+		base := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("", testScheme)
+		base.LoggingContainers = []productlogging.ContainerLogging{{
+			Container: "main",
+			Framework: productlogging.LoggingFrameworkLogback,
+		}}
+		handler := &embeddingImageHandler{BaseRoleGroupHandler: base, image: "product-image:1.2.3"}
+
+		mgr := sidecar.NewSidecarManager()
+		mgr.Register(
+			vector.NewVectorSidecarProvider("",
+				vector.WithConfigMapName("test-cluster-default"),
+				vector.WithProducers([]string{"main"})),
+			&sidecar.SidecarConfig{Enabled: true},
+		)
+
+		mockCR := testutil.WrapMockCluster(testutil.NewMockCluster("test-cluster", "default"))
+		buildCtx := &reconciler.RoleGroupBuildContext{
+			ClusterName:      "test-cluster",
+			ClusterNamespace: "default",
+			RoleName:         "test-role",
+			RoleSpec:         &v1alpha1.RoleSpec{},
+			RoleGroupName:    "default",
+			RoleGroupSpec:    v1alpha1.RoleGroupSpec{Replicas: ptr.To(int32(1))},
+			ResourceName:     "test-cluster-default",
+			SidecarManager:   mgr,
+			MergedConfig: &config.MergedConfig{
+				Logging: &v1alpha1.LoggingSpec{
+					EnableVectorAgent: ptr.To(true),
+					Containers:        map[string]v1alpha1.LoggingConfigSpec{"main": {}},
+				},
+			},
+		}
+
+		resources, err := handler.BuildResources(context.Background(), k8sClient, mockCR, buildCtx)
+		Expect(err).NotTo(HaveOccurred())
+
+		podSpec := resources.StatefulSet.Spec.Template.Spec
+		var vectorImage string
+		for _, c := range append(podSpec.InitContainers, podSpec.Containers...) {
+			if c.Name == vector.VectorSidecarName {
+				vectorImage = c.Image
+			}
+		}
+		Expect(vectorImage).To(Equal("product-image:1.2.3"))
+	})
+})

--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -501,18 +501,11 @@ func (r *GenericReconciler[CR]) reconcileRoleGroup(ctx context.Context, cr CR, r
 		return NewResourceBuildError("resources", roleName, groupName, "failed to resolve vector aggregator address", err)
 	}
 
-	// Auto-create SidecarManager based on CRD configuration
+	// Auto-create SidecarManager based on CRD configuration. The product image is propagated to
+	// the registered sidecars by BaseRoleGroupHandler.BuildResources — after the product's
+	// BuildResources override has resolved the CR-driven image — so both plain and embedding
+	// handlers are covered without a concrete-type assertion here.
 	buildCtx.SidecarManager = r.buildSidecarManager(ctx, buildCtx)
-
-	// Set product image on sidecar manager so sidecars use the product image
-	if buildCtx.SidecarManager != nil {
-		if handler, ok := r.roleGroupHandler.(*BaseRoleGroupHandler[CR]); ok {
-			image := handler.containerImage(buildCtx.RoleName)
-			if err := buildCtx.SidecarManager.SetProductImage(image, handler.ImagePullPolicy); err != nil {
-				return NewResourceBuildError("sidecar", roleName, groupName, "failed to set product image", err)
-			}
-		}
-	}
 
 	// Delegate to handler for resource building
 	resources, err := r.roleGroupHandler.BuildResources(ctx, r.client, cr, buildCtx)


### PR DESCRIPTION
`GenericReconciler` propagated the resolved product image to registered sidecars behind a concrete `*BaseRoleGroupHandler[CR]` type assertion. That assertion never matches the documented embedding pattern:

```go
type XHandler struct { *BaseRoleGroupHandler }
```

so the propagation was silently skipped for every product operator, forcing each to call `SetProductImage` by hand — and forgetting it produced an invalid Vector container with an empty `image`.

Fix: move the propagation into `BaseRoleGroupHandler.BuildResources`, after the product override has resolved the CR-driven image and immediately before sidecar injection, so both plain and embedding handlers are covered and the image is never stale.

## Testing

- `go build ./...` clean.
- `pkg/reconciler` (envtest) passes, including the new `base_role_group_handler_test.go` cases asserting image propagation through an embedding handler.

> Split out of the original combined branch; the unrelated log4j2 renderer fix now lives in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)