### PR TITLE
fix(productlogging): bind root logger appender refs in the log4j2 renderer

### DIFF
--- a/pkg/productlogging/generator.go
+++ b/pkg/productlogging/generator.go
@@ -139,6 +139,7 @@ func GenerateLog4j(configs map[string]LoggerConfig) (string, error) {
 // The output format is:
 // rootLogger.level=INFO
 // rootLogger.appenderRefs=stdout
+// rootLogger.appenderRef.stdout.ref=STDOUT
 // appenders=console
 // appender.console.type=Console
 // appender.console.name=STDOUT
@@ -445,10 +446,16 @@ func renderLog4j2(cfg LogConfig, opts RenderOptions) (string, error) {
 	var sb strings.Builder
 	sb.WriteString("# Log4j2 Configuration\n")
 	fmt.Fprintf(&sb, "rootLogger.level=%s\n", rootLevel)
+	// The appenderRefs line only declares reference identifiers; each identifier MUST be bound
+	// to an appender name via "rootLogger.appenderRef.<id>.ref=<AppenderName>", otherwise the
+	// root logger ends up with no appenders at all (no console output, empty log file).
 	if hasFile {
-		sb.WriteString("rootLogger.appenderRefs=stdout,file\n\n")
+		sb.WriteString("rootLogger.appenderRefs=stdout,file\n")
+		sb.WriteString("rootLogger.appenderRef.stdout.ref=STDOUT\n")
+		sb.WriteString("rootLogger.appenderRef.file.ref=FILE\n\n")
 	} else {
-		sb.WriteString("rootLogger.appenderRefs=stdout\n\n")
+		sb.WriteString("rootLogger.appenderRefs=stdout\n")
+		sb.WriteString("rootLogger.appenderRef.stdout.ref=STDOUT\n\n")
 	}
 
 	sb.WriteString("# Appenders\n")

--- a/pkg/productlogging/generator_test.go
+++ b/pkg/productlogging/generator_test.go
@@ -384,12 +384,28 @@ var _ = Describe("GenerateLog4j2", func() {
 		Expect(content).To(ContainSubstring("# Log4j2 Configuration"))
 		Expect(content).To(ContainSubstring("rootLogger.level=INFO"))
 		Expect(content).To(ContainSubstring("rootLogger.appenderRefs=stdout"))
+		Expect(content).To(ContainSubstring("rootLogger.appenderRef.stdout.ref=STDOUT"))
 		Expect(content).To(ContainSubstring("appenders=console"))
 		Expect(content).To(ContainSubstring("appender.console.type=Console"))
 		Expect(content).To(ContainSubstring("appender.console.layout.type=PatternLayout"))
 		Expect(content).To(ContainSubstring("loggers=com.example.app"))
 		Expect(content).To(ContainSubstring("logger.com_example_app.name=com.example.app"))
 		Expect(content).To(ContainSubstring("logger.com_example_app.level=INFO"))
+	})
+
+	It("binds both stdout and file appenderRefs to the root logger when file output is enabled", func() {
+		gen, err := productlogging.GeneratorFor(productlogging.LoggingFrameworkLog4j2)
+		Expect(err).ToNot(HaveOccurred())
+		content, err := gen.Render(
+			productlogging.LogConfig{},
+			productlogging.RenderOptions{FileOutputPath: "/kubedoop/log/zookeeper/zookeeper.log4j2.xml"},
+		)
+		Expect(err).ToNot(HaveOccurred())
+		// Both identifiers must be declared AND bound; without the file binding the rolling file
+		// appender is silently not wired to the root logger (empty log file, nothing to ship).
+		Expect(content).To(ContainSubstring("rootLogger.appenderRefs=stdout,file"))
+		Expect(content).To(ContainSubstring("rootLogger.appenderRef.stdout.ref=STDOUT"))
+		Expect(content).To(ContainSubstring("rootLogger.appenderRef.file.ref=FILE"))
 	})
 
 	It("should handle logger names with dollar sign", func() {


### PR DESCRIPTION
`renderLog4j2` declared `rootLogger.appenderRefs=stdout,file` but never emitted the required `rootLogger.appenderRef.<id>.ref=<AppenderName>` binding lines, so the root logger resolved to zero appenders: products using the log4j2 framework (hive metastore) produced no console output and an empty rolling log file, and the Vector pipeline had nothing to ship.

Caught by the hive-operator logging e2e. The log4j 1.x renderer (`log4j.rootLogger=LEVEL, CONSOLE, FILE`) was already correct.

## Testing

- `go build ./...` clean.
- `pkg/productlogging` unit tests pass, including the new `generator_test.go` assertion for the emitted `appenderRef.<id>.ref` lines.

> Split out of the original combined branch; the unrelated reconciler sidecar-image fix is #536.

🤖 Generated with [Claude Code](https://claude.com/claude-code)