### PR TITLE
feat: framework enhancements for the spark-k8s-operator migration (s3, oauth2-proxy, podOverrides fidelity, log file naming)

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -115,18 +115,20 @@ all kubedoop product images run as uid `1001`.
 | `capabilities.drop` | `[ALL]` | drop all Linux capabilities |
 | `seccompProfile.type` | `RuntimeDefault` | apply the runtime's default seccomp profile |
 
-### 3.3.2 Overriding via PodOverrides (REPLACE semantics)
+### 3.3.2 Overriding via PodOverrides (strategic-merge semantics)
 
-Products customize the security context through `MergedConfig.PodOverrides`. **The override
-REPLACES the whole `SecurityContext` object — there is NO deep merge.** A pod/container
-`SecurityContext` supplied via `PodOverrides` takes precedence over the framework default and
-wipes it; any default fields the product still wants (e.g. the hardening fields) must be
-**restated** in the override.
+Products customize the security context through `MergedConfig.PodOverrides`, which is applied
+as a Kubernetes **Strategic Merge Patch** (the merge strategy `docs/architecture.md` §2.6
+documents for the whole pod template). **Security contexts deep-merge per field**: an override
+stating only `runAsUser` keeps the framework-hardened remainder (`runAsNonRoot`,
+`capabilities.drop`, `seccompProfile`, …).
 
-This replace behavior is intentional: special images that cannot use uid 1001 override the
-**whole** SecurityContext via `PodOverrides`, restating the full set of fields appropriate for
-that image. The handler-wide `WithoutDefaultSecurityContext()` escape hatch disables the default
-entirely (the StatefulSet is then built with no SecurityContext unless `PodOverrides` supplies one).
+A field the override does not mention keeps its default, so an override must **explicitly
+restate** any default it wants to change — e.g. an image that must run as root sets both
+`runAsUser: 0` **and** `runAsNonRoot: false`; setting only `runAsUser: 0` inherits
+`runAsNonRoot: true` and the kubelet refuses to start the container. The handler-wide
+`WithoutDefaultSecurityContext()` escape hatch disables the default entirely (the StatefulSet
+is then built with no SecurityContext unless `PodOverrides` supplies one).
 
 ## 3.4 Security Benefits Summary
 

--- a/pkg/AGENTS.md
+++ b/pkg/AGENTS.md
@@ -19,6 +19,7 @@ Core packages for the operator framework, including CRD definitions, resource bu
 | `listener/` | Listener service and volume builders |
 | `sidecar/` | Sidecar injection logic |
 | `security/` | Security-related utilities |
+| `s3/` | S3 connection/bucket resolution and credential wiring |
 | `testutil/` | Testing helpers |
 
 ## Subdirectories
@@ -33,6 +34,7 @@ Core packages for the operator framework, including CRD definitions, resource bu
 - `listener/` - Listener builders
 - `sidecar/` - Sidecar logic
 - `security/` - Security utilities
+- `s3/` - S3 resolution and credentials
 - `testutil/` - Test helpers
 
 ## Working Instructions

--- a/pkg/builder/statefulset_builder.go
+++ b/pkg/builder/statefulset_builder.go
@@ -34,7 +34,11 @@ import (
 type StatefulSetBuilder struct {
 	Name      string
 	Namespace string
-	Labels    map[string]string
+	// MainContainerName, when set, names the primary container (default: Name). It must be
+	// set BEFORE Build() so podOverrides addressing the container by its user-facing name
+	// strategic-merge into it instead of appending a phantom container.
+	MainContainerName string
+	Labels            map[string]string
 	// SelectorLabels, when set, is used for the StatefulSet's immutable .spec.selector
 	// (and must be a subset of Labels, which are applied to the pod template). When empty,
 	// Labels is used for the selector. Decoupling the selector from the full descriptive
@@ -148,6 +152,22 @@ func (b *StatefulSetBuilder) selectorMatchLabels() map[string]string {
 		return b.SelectorLabels
 	}
 	return b.Labels
+}
+
+// WithMainContainerName names the primary container (default: the StatefulSet name). Set it
+// before Build(): the podOverrides strategic merge keys containers by name, so the primary
+// container must already carry its final, user-facing name when overrides are applied.
+func (b *StatefulSetBuilder) WithMainContainerName(name string) *StatefulSetBuilder {
+	b.MainContainerName = name
+	return b
+}
+
+// primaryContainerName returns the effective primary container name.
+func (b *StatefulSetBuilder) primaryContainerName() string {
+	if b.MainContainerName != "" {
+		return b.MainContainerName
+	}
+	return b.Name
 }
 
 // WithAnnotations sets the annotations.
@@ -504,7 +524,7 @@ func (b *StatefulSetBuilder) buildPodSpec() corev1.PodSpec {
 // buildContainer builds the main container.
 func (b *StatefulSetBuilder) buildContainer() corev1.Container {
 	container := corev1.Container{
-		Name:            b.Name,
+		Name:            b.primaryContainerName(),
 		Image:           b.Image,
 		ImagePullPolicy: b.ImagePullPolicy,
 		Ports:           b.Ports,
@@ -659,12 +679,19 @@ func (b *StatefulSetBuilder) applyPodOverrides(sts *appsv1.StatefulSet) {
 	}
 
 	override := b.PodOverrides.DeepCopy()
-	// Back-compat: an unnamed override container has always addressed the main container (which
-	// shares the StatefulSet's name). Normalize the name before the merge — an empty name would
-	// otherwise be treated as a distinct merge key and appended as a broken extra container.
+	// PodSpec.Containers is the one PodSpec field without omitempty: a nil slice marshals as
+	// "containers": null, which strategic merge treats as a DELETE directive — an
+	// annotations-only override would wipe every container. Normalize nil to empty (an empty
+	// merge-strategy list is a no-op).
+	if override.Spec.Containers == nil {
+		override.Spec.Containers = []corev1.Container{}
+	}
+	// Back-compat: an unnamed override container has always addressed the main container.
+	// Normalize the name before the merge — an empty name would otherwise be treated as a
+	// distinct merge key and appended as a broken extra container.
 	for i := range override.Spec.Containers {
 		if override.Spec.Containers[i].Name == "" {
-			override.Spec.Containers[i].Name = b.Name
+			override.Spec.Containers[i].Name = b.primaryContainerName()
 		}
 	}
 

--- a/pkg/builder/statefulset_builder.go
+++ b/pkg/builder/statefulset_builder.go
@@ -17,6 +17,7 @@ limitations under the License.
 package builder
 
 import (
+	"encoding/json"
 	"sort"
 
 	"github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
@@ -26,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/strategicpatch"
 )
 
 // StatefulSetBuilder constructs StatefulSet resources.
@@ -634,97 +636,80 @@ func (b *StatefulSetBuilder) buildStartupProbe() *corev1.Probe {
 	return nil
 }
 
-// applyPodOverrides applies pod template overrides to the StatefulSet.
+// applyPodOverrides applies pod template overrides to the StatefulSet with full fidelity: the
+// merged podOverrides template is strategic-merge-patched onto the built pod template, exactly
+// as kubectl would merge it. Containers merge by name (env/ports/volumeMounts within a container
+// merge by their own keys), so container-level overrides — resources, env, extra volume mounts —
+// land on the built containers instead of being dropped, and override-only containers are
+// appended as additional pod containers. Scalar and struct fields set in the override replace or
+// deep-merge into the base per strategic-merge-patch semantics; fields the override omits keep
+// the built values (so podOverrides.spec.terminationGracePeriodSeconds still wins over the
+// config-declared gracefulShutdownTimeout, and enableServiceLinks still wins over the framework
+// default, only when actually set).
+//
+// Security contexts now deep-merge per field rather than being replaced wholesale: an override
+// stating only runAsUser keeps the framework-hardened remainder. Overrides that need to unset a
+// field must state it explicitly.
+//
+// After the merge the selector labels are re-asserted on the pod template, so an override can
+// never break the invariant that the immutable .spec.selector matches the template labels.
 func (b *StatefulSetBuilder) applyPodOverrides(sts *appsv1.StatefulSet) {
 	if b.PodOverrides == nil {
 		return
 	}
 
-	// Override annotations
-	if len(b.PodOverrides.Annotations) > 0 {
-		if sts.Spec.Template.Annotations == nil {
-			sts.Spec.Template.Annotations = make(map[string]string)
-		}
-		for k, v := range b.PodOverrides.Annotations {
-			sts.Spec.Template.Annotations[k] = v
-		}
-	}
-
-	// Override labels
-	if len(b.PodOverrides.Labels) > 0 {
-		if sts.Spec.Template.Labels == nil {
-			sts.Spec.Template.Labels = make(map[string]string)
-		}
-		for k, v := range b.PodOverrides.Labels {
-			sts.Spec.Template.Labels[k] = v
+	override := b.PodOverrides.DeepCopy()
+	// Back-compat: an unnamed override container has always addressed the main container (which
+	// shares the StatefulSet's name). Normalize the name before the merge — an empty name would
+	// otherwise be treated as a distinct merge key and appended as a broken extra container.
+	for i := range override.Spec.Containers {
+		if override.Spec.Containers[i].Name == "" {
+			override.Spec.Containers[i].Name = b.Name
 		}
 	}
 
-	// Override affinity
-	if b.PodOverrides.Spec.Affinity != nil {
-		sts.Spec.Template.Spec.Affinity = b.PodOverrides.Spec.Affinity
+	merged, err := strategicMergePodTemplate(&sts.Spec.Template, override)
+	if err != nil {
+		// Structurally valid templates cannot realistically fail to marshal or patch; if it ever
+		// happens, keep the built template rather than emitting a half-merged one.
+		return
 	}
+	sts.Spec.Template = *merged
 
-	// Override tolerations
-	if len(b.PodOverrides.Spec.Tolerations) > 0 {
-		sts.Spec.Template.Spec.Tolerations = b.PodOverrides.Spec.Tolerations
+	// Re-assert the selector labels: the override may have replaced or removed labels the
+	// immutable .spec.selector matches on.
+	if sts.Spec.Template.Labels == nil {
+		sts.Spec.Template.Labels = make(map[string]string)
 	}
-
-	// Override node selector
-	if len(b.PodOverrides.Spec.NodeSelector) > 0 {
-		sts.Spec.Template.Spec.NodeSelector = b.PodOverrides.Spec.NodeSelector
+	for k, v := range b.selectorMatchLabels() {
+		sts.Spec.Template.Labels[k] = v
 	}
-
-	// Override termination grace period, so podOverrides.spec.terminationGracePeriodSeconds
-	// wins over the config-declared gracefulShutdownTimeout (the documented precedence).
-	if b.PodOverrides.Spec.TerminationGracePeriodSeconds != nil {
-		sts.Spec.Template.Spec.TerminationGracePeriodSeconds = b.PodOverrides.Spec.TerminationGracePeriodSeconds
-	}
-
-	// Override priority class name
-	if b.PodOverrides.Spec.PriorityClassName != "" {
-		sts.Spec.Template.Spec.PriorityClassName = b.PodOverrides.Spec.PriorityClassName
-	}
-
-	// Override enableServiceLinks. This runs at the end of Build(), so a user PodOverride wins over
-	// the framework default set via WithEnableServiceLinks before the build.
-	if b.PodOverrides.Spec.EnableServiceLinks != nil {
-		sts.Spec.Template.Spec.EnableServiceLinks = b.PodOverrides.Spec.EnableServiceLinks
-	}
-
-	// Override pod-level security context. PodOverrides REPLACES the whole pod security context
-	// (no deep merge): a product supplying one must restate any default fields it wants to keep.
-	// This is how special images override the framework default (e.g. a different RunAsUser).
-	if b.PodOverrides.Spec.SecurityContext != nil {
-		sts.Spec.Template.Spec.SecurityContext = b.PodOverrides.Spec.SecurityContext
-	}
-
-	// Override the main container's security context. PodOverrides addresses the main container
-	// by name (it shares the StatefulSet's name); when an override container with a security
-	// context is supplied, it REPLACES the whole container security context (no deep merge).
-	b.applyContainerSecurityContextOverride(sts)
 }
 
-// applyContainerSecurityContextOverride replaces the main container's security context with the
-// one supplied in PodOverrides, if any. The main container is matched by name (b.Name); an
-// unnamed override container is also accepted so callers don't have to know the container name.
-func (b *StatefulSetBuilder) applyContainerSecurityContextOverride(sts *appsv1.StatefulSet) {
-	containers := sts.Spec.Template.Spec.Containers
-	if len(containers) == 0 {
-		return
+// strategicMergePodTemplate merges the override pod template onto the base using the same
+// strategic-merge-patch machinery Kubernetes applies to pod templates.
+func strategicMergePodTemplate(base, override *corev1.PodTemplateSpec) (*corev1.PodTemplateSpec, error) {
+	baseBytes, err := json.Marshal(base)
+	if err != nil {
+		return nil, err
 	}
-	for i := range b.PodOverrides.Spec.Containers {
-		oc := &b.PodOverrides.Spec.Containers[i]
-		if oc.SecurityContext == nil {
-			continue
-		}
-		if oc.Name != "" && oc.Name != b.Name {
-			continue
-		}
-		// Apply to the main container (index 0 is the container built by this builder).
-		containers[0].SecurityContext = oc.SecurityContext
-		return
+	overrideBytes, err := json.Marshal(override)
+	if err != nil {
+		return nil, err
 	}
+	patchMeta, err := strategicpatch.NewPatchMetaFromStruct(corev1.PodTemplateSpec{})
+	if err != nil {
+		return nil, err
+	}
+	mergedBytes, err := strategicpatch.StrategicMergePatchUsingLookupPatchMeta(baseBytes, overrideBytes, patchMeta)
+	if err != nil {
+		return nil, err
+	}
+	var merged corev1.PodTemplateSpec
+	if err := json.Unmarshal(mergedBytes, &merged); err != nil {
+		return nil, err
+	}
+	return &merged, nil
 }
 
 // NamespacedName returns the NamespacedName for the StatefulSet.

--- a/pkg/builder/statefulset_builder_test.go
+++ b/pkg/builder/statefulset_builder_test.go
@@ -803,7 +803,7 @@ var _ = Describe("StatefulSetBuilder", func() {
 				WithPodOverrides(overrides).
 				Build()
 
-			names := []string{}
+			names := make([]string, 0, len(sts.Spec.Template.Spec.Containers))
 			for _, c := range sts.Spec.Template.Spec.Containers {
 				names = append(names, c.Name)
 			}
@@ -897,13 +897,13 @@ var _ = Describe("StatefulSetBuilder", func() {
 				WithPodOverrides(overrides).
 				Build()
 
-			mountPaths := []string{}
+			mountPaths := make([]string, 0, len(sts.Spec.Template.Spec.Containers[0].VolumeMounts))
 			for _, m := range sts.Spec.Template.Spec.Containers[0].VolumeMounts {
 				mountPaths = append(mountPaths, m.MountPath)
 			}
 			Expect(mountPaths).To(ConsistOf("/built", "/extra"))
 
-			volNames := []string{}
+			volNames := make([]string, 0, len(sts.Spec.Template.Spec.Volumes))
 			for _, v := range sts.Spec.Template.Spec.Volumes {
 				volNames = append(volNames, v.Name)
 			}

--- a/pkg/builder/statefulset_builder_test.go
+++ b/pkg/builder/statefulset_builder_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("StatefulSetBuilder", func() {
@@ -729,6 +730,184 @@ var _ = Describe("StatefulSetBuilder", func() {
 				Build()
 
 			Expect(sts.Spec.Template.Labels).To(HaveKeyWithValue("custom", "label"))
+		})
+	})
+
+	Describe("PodOverrides container-level fidelity", func() {
+		It("should merge container resources into the main container by name", func() {
+			overrides := &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: name,
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("2"),
+									corev1.ResourceMemory: resource.MustParse("2Gi"),
+								},
+							},
+						},
+					},
+				},
+			}
+			sts := stsBuilder.
+				WithImage(image, corev1.PullIfNotPresent).
+				WithPodOverrides(overrides).
+				Build()
+
+			Expect(sts.Spec.Template.Spec.Containers).To(HaveLen(1))
+			main := sts.Spec.Template.Spec.Containers[0]
+			Expect(main.Image).To(Equal(image), "merging resources must not clobber the built container")
+			Expect(main.Resources.Limits.Cpu().String()).To(Equal("2"))
+			Expect(main.Resources.Limits.Memory().String()).To(Equal("2Gi"))
+		})
+
+		It("should merge container env by name, overriding built values and adding new ones", func() {
+			overrides := &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: name,
+							Env: []corev1.EnvVar{
+								{Name: "COMMON_VAR", Value: "override-value"},
+								{Name: "EXTRA_VAR", Value: "extra-value"},
+							},
+						},
+					},
+				},
+			}
+			sts := stsBuilder.
+				WithImage(image, corev1.PullIfNotPresent).
+				AddEnvVar("COMMON_VAR", "built-value").
+				WithPodOverrides(overrides).
+				Build()
+
+			envByName := map[string]string{}
+			for _, e := range sts.Spec.Template.Spec.Containers[0].Env {
+				envByName[e.Name] = e.Value
+			}
+			Expect(envByName).To(HaveKeyWithValue("COMMON_VAR", "override-value"))
+			Expect(envByName).To(HaveKeyWithValue("EXTRA_VAR", "extra-value"))
+		})
+
+		It("should append override-only containers as additional pod containers", func() {
+			overrides := &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "extra-sidecar", Image: "sidecar:1.0"},
+					},
+				},
+			}
+			sts := stsBuilder.
+				WithImage(image, corev1.PullIfNotPresent).
+				WithPodOverrides(overrides).
+				Build()
+
+			names := []string{}
+			for _, c := range sts.Spec.Template.Spec.Containers {
+				names = append(names, c.Name)
+			}
+			Expect(names).To(ConsistOf(name, "extra-sidecar"))
+		})
+
+		It("should treat an unnamed override container as the main container (back-compat)", func() {
+			overrides := &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							SecurityContext: &corev1.SecurityContext{
+								RunAsUser: ptr.To(int64(1234)),
+							},
+						},
+					},
+				},
+			}
+			sts := stsBuilder.
+				WithImage(image, corev1.PullIfNotPresent).
+				WithPodOverrides(overrides).
+				Build()
+
+			Expect(sts.Spec.Template.Spec.Containers).To(HaveLen(1))
+			sc := sts.Spec.Template.Spec.Containers[0].SecurityContext
+			Expect(sc).NotTo(BeNil())
+			Expect(*sc.RunAsUser).To(Equal(int64(1234)))
+		})
+
+		It("should deep-merge the pod security context instead of replacing it", func() {
+			built := &corev1.PodSecurityContext{
+				RunAsUser: ptr.To(int64(1000)),
+				FSGroup:   ptr.To(int64(1000)),
+			}
+			overrides := &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{
+						RunAsUser: ptr.To(int64(0)),
+					},
+				},
+			}
+			sts := stsBuilder.
+				WithImage(image, corev1.PullIfNotPresent).
+				WithSecurityContext(nil, built).
+				WithPodOverrides(overrides).
+				Build()
+
+			sc := sts.Spec.Template.Spec.SecurityContext
+			Expect(sc).NotTo(BeNil())
+			Expect(*sc.RunAsUser).To(Equal(int64(0)), "the overridden field wins")
+			Expect(sc.FSGroup).NotTo(BeNil(), "fields the override omits keep the built values")
+			Expect(*sc.FSGroup).To(Equal(int64(1000)))
+		})
+
+		It("should re-assert selector labels the override tries to change", func() {
+			overrides := &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{"app": "hijacked"},
+				},
+			}
+			sts := stsBuilder.
+				WithSelectorLabels(map[string]string{"app": "test"}).
+				WithPodOverrides(overrides).
+				Build()
+
+			Expect(sts.Spec.Selector.MatchLabels).To(HaveKeyWithValue("app", "test"))
+			Expect(sts.Spec.Template.Labels).To(HaveKeyWithValue("app", "test"),
+				"pod template must keep matching the immutable selector")
+		})
+
+		It("should merge container volumeMounts and pod volumes", func() {
+			overrides := &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: name,
+							VolumeMounts: []corev1.VolumeMount{
+								{Name: "extra-vol", MountPath: "/extra"},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{Name: "extra-vol", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}},
+					},
+				},
+			}
+			sts := stsBuilder.
+				WithImage(image, corev1.PullIfNotPresent).
+				AddVolumeMount(corev1.VolumeMount{Name: "built-vol", MountPath: "/built"}).
+				AddVolume(corev1.Volume{Name: "built-vol", VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}}}).
+				WithPodOverrides(overrides).
+				Build()
+
+			mountPaths := []string{}
+			for _, m := range sts.Spec.Template.Spec.Containers[0].VolumeMounts {
+				mountPaths = append(mountPaths, m.MountPath)
+			}
+			Expect(mountPaths).To(ConsistOf("/built", "/extra"))
+
+			volNames := []string{}
+			for _, v := range sts.Spec.Template.Spec.Volumes {
+				volNames = append(volNames, v.Name)
+			}
+			Expect(volNames).To(ConsistOf("built-vol", "extra-vol"))
 		})
 	})
 

--- a/pkg/builder/statefulset_builder_test.go
+++ b/pkg/builder/statefulset_builder_test.go
@@ -874,6 +874,62 @@ var _ = Describe("StatefulSetBuilder", func() {
 				"pod template must keep matching the immutable selector")
 		})
 
+		It("should keep the built containers when the override sets no containers", func() {
+			// Regression: PodSpec.Containers has no omitempty, so a nil slice marshals as
+			// "containers": null — a strategic-merge DELETE directive. An annotations-only or
+			// grace-period-only override must not wipe the pod's containers.
+			grace := int64(120)
+			overrides := &corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{"custom": "annotation"},
+				},
+				Spec: corev1.PodSpec{
+					TerminationGracePeriodSeconds: &grace,
+				},
+			}
+			sts := stsBuilder.
+				WithImage(image, corev1.PullIfNotPresent).
+				WithPodOverrides(overrides).
+				Build()
+
+			Expect(sts.Spec.Template.Spec.Containers).To(HaveLen(1))
+			Expect(sts.Spec.Template.Spec.Containers[0].Image).To(Equal(image))
+			Expect(sts.Spec.Template.Annotations).To(HaveKeyWithValue("custom", "annotation"))
+			Expect(*sts.Spec.Template.Spec.TerminationGracePeriodSeconds).To(Equal(grace))
+		})
+
+		It("should merge overrides addressing the main container by its significant name", func() {
+			// Regression: with WithMainContainerName("node"), an override container named
+			// "node" must merge into the primary container — not append a phantom,
+			// image-less second container (the merge runs inside Build(), so the primary
+			// container must already carry its final name).
+			overrides := &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "node",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU: resource.MustParse("2"),
+								},
+							},
+						},
+					},
+				},
+			}
+			sts := stsBuilder.
+				WithImage(image, corev1.PullIfNotPresent).
+				WithMainContainerName("node").
+				WithPodOverrides(overrides).
+				Build()
+
+			Expect(sts.Spec.Template.Spec.Containers).To(HaveLen(1))
+			main := sts.Spec.Template.Spec.Containers[0]
+			Expect(main.Name).To(Equal("node"))
+			Expect(main.Image).To(Equal(image), "the merged container keeps the built image")
+			Expect(main.Resources.Limits.Cpu().String()).To(Equal("2"))
+		})
+
 		It("should merge container volumeMounts and pod volumes", func() {
 			overrides := &corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{

--- a/pkg/productlogging/logging.go
+++ b/pkg/productlogging/logging.go
@@ -123,6 +123,11 @@ func RenderConfigFile(spec *v1alpha1.LoggingConfigSpec, decl ContainerLogging, w
 					"log file name %q for container %q must keep the framework suffix %q (it selects the Vector edge parser)",
 					decl.LogFileName, decl.Container, LogFileSuffix(decl.Framework))
 			}
+			if strings.Contains(decl.LogFileName, "/") {
+				return "", "", fmt.Errorf(
+					"log file name %q for container %q must be a bare file name: a path separator would escape the per-container log directory and the Vector collection glob",
+					decl.LogFileName, decl.Container)
+			}
 			logFileName = decl.LogFileName
 		}
 		// The stable path convention: "<KubedoopLogDir>/<lowercased container>/<file>". path.Join

--- a/pkg/productlogging/logging.go
+++ b/pkg/productlogging/logging.go
@@ -45,6 +45,12 @@ type ContainerLogging struct {
 	// Pattern overrides the encoder/layout pattern (product-specific, e.g. ZooKeeper's
 	// "[myid:%X{myid}]" MDC). Empty uses the framework default.
 	Pattern string
+	// LogFileName overrides the rolling log-file name (default ContainerLogFileName, e.g.
+	// "node.log4j2.xml") for products with an established file-name contract (e.g. Spark's
+	// "spark.log4j2.xml"). The name MUST keep the framework suffix (LogFileSuffix) — the
+	// Vector pipeline selects its edge parser by that suffix, so RenderConfigFile rejects a
+	// name that drops it. The per-container log directory is unaffected.
+	LogFileName string
 }
 
 // LogFileSuffix returns the framework-owned rolling log-file suffix for a producer container.
@@ -110,9 +116,18 @@ func RenderConfigFile(spec *v1alpha1.LoggingConfigSpec, decl ContainerLogging, w
 	}
 	opts := RenderOptions{Pattern: decl.Pattern}
 	if withFileAppender {
+		logFileName := ContainerLogFileName(decl.Framework, decl.Container)
+		if decl.LogFileName != "" {
+			if !strings.HasSuffix(decl.LogFileName, LogFileSuffix(decl.Framework)) {
+				return "", "", fmt.Errorf(
+					"log file name %q for container %q must keep the framework suffix %q (it selects the Vector edge parser)",
+					decl.LogFileName, decl.Container, LogFileSuffix(decl.Framework))
+			}
+			logFileName = decl.LogFileName
+		}
 		// The stable path convention: "<KubedoopLogDir>/<lowercased container>/<file>". path.Join
 		// collapses the trailing slash constant.KubedoopLogDir carries.
-		opts.FileOutputPath = path.Join(ContainerLogDir(decl.Container), ContainerLogFileName(decl.Framework, decl.Container))
+		opts.FileOutputPath = path.Join(ContainerLogDir(decl.Container), logFileName)
 	}
 	content, err := gen.Render(LogConfigFromSpec(spec), opts)
 	if err != nil {

--- a/pkg/productlogging/logging_test.go
+++ b/pkg/productlogging/logging_test.go
@@ -103,6 +103,26 @@ var _ = Describe("RenderConfigFile file path", func() {
 		Expect(productlogging.ContainerLogDir("Main")).To(Equal("/kubedoop/log/main"))
 	})
 
+	It("honors a LogFileName override that keeps the framework suffix", func() {
+		_, content, err := productlogging.RenderConfigFile(nil, productlogging.ContainerLogging{
+			Framework:   productlogging.LoggingFrameworkLog4j2,
+			Container:   "node",
+			LogFileName: "spark.log4j2.xml",
+		}, true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(content).To(ContainSubstring("/kubedoop/log/node/spark.log4j2.xml"))
+		Expect(content).NotTo(ContainSubstring("node.log4j2.xml"))
+	})
+
+	It("rejects a LogFileName override that drops the framework suffix", func() {
+		_, _, err := productlogging.RenderConfigFile(nil, productlogging.ContainerLogging{
+			Framework:   productlogging.LoggingFrameworkLog4j2,
+			Container:   "node",
+			LogFileName: "spark.log",
+		}, true)
+		Expect(err).To(MatchError(ContainSubstring("must keep the framework suffix")))
+	})
+
 	It("omits the file appender when withFileAppender is false (console-only)", func() {
 		_, content, err := productlogging.RenderConfigFile(nil, productlogging.ContainerLogging{
 			Framework: productlogging.LoggingFrameworkLogback,

--- a/pkg/productlogging/logging_test.go
+++ b/pkg/productlogging/logging_test.go
@@ -123,6 +123,15 @@ var _ = Describe("RenderConfigFile file path", func() {
 		Expect(err).To(MatchError(ContainSubstring("must keep the framework suffix")))
 	})
 
+	It("rejects a LogFileName override containing a path separator", func() {
+		_, _, err := productlogging.RenderConfigFile(nil, productlogging.ContainerLogging{
+			Framework:   productlogging.LoggingFrameworkLog4j2,
+			Container:   "node",
+			LogFileName: "../escape/spark.log4j2.xml",
+		}, true)
+		Expect(err).To(MatchError(ContainSubstring("must be a bare file name")))
+	})
+
 	It("omits the file appender when withFileAppender is false (console-only)", func() {
 		_, content, err := productlogging.RenderConfigFile(nil, productlogging.ContainerLogging{
 			Framework: productlogging.LoggingFrameworkLogback,

--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -733,16 +733,19 @@ func (h *BaseRoleGroupHandler[CR]) buildStatefulSet(
 		}
 	}
 
+	// Name the primary container when the product needs a significant name (e.g. to match its
+	// per-container logging key). This must reach the builder BEFORE Build(): podOverrides are
+	// strategic-merged by container name inside Build(), so an override addressing the
+	// user-facing name (e.g. "node") must find the primary container already carrying it — a
+	// post-build rename would leave the override appended as a phantom, image-less container.
+	// Sidecar injection below also sees the final name (the Vector provider RW-mounts the
+	// shared log volume on the producer containers by name).
+	if mainName := h.mainContainerNameFor(buildCtx.RoleName); mainName != "" {
+		stsBuilder.WithMainContainerName(mainName)
+	}
+
 	// Build the StatefulSet
 	sts := stsBuilder.Build()
-
-	// Rename the primary container when the product needs a significant name (e.g. to match
-	// its per-container logging key). The builder makes the primary container index 0. This runs
-	// before sidecar injection so the Vector provider (which RW-mounts the shared log volume on
-	// the producer containers by name) sees the final container names.
-	if mainName := h.mainContainerNameFor(buildCtx.RoleName); mainName != "" && len(sts.Spec.Template.Spec.Containers) > 0 {
-		sts.Spec.Template.Spec.Containers[0].Name = mainName
-	}
 
 	// Inject sidecars: prefer buildCtx (SDK auto-created), fallback to instance field
 	sidecarMgr := buildCtx.SidecarManager

--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -171,8 +171,9 @@ type BaseRoleGroupHandler[CR common.ClusterInterface] struct {
 	// container. When the framework default is in effect, this is
 	// security.NewPodSecurityBuilder().BuildDefaultSecurityContext(). Products override it via
 	// WithSecurityContext (or disable it via WithoutDefaultSecurityContext). Per-role-group
-	// customization goes through MergedConfig.PodOverrides, which REPLACES the security context
-	// (no deep merge — a product overriding must restate any fields it wants to keep).
+	// customization goes through MergedConfig.PodOverrides, which strategic-merges per field —
+	// an override must explicitly restate any default field it wants to CHANGE (e.g.
+	// runAsNonRoot: false alongside runAsUser: 0), while unmentioned fields keep the default.
 	containerSecurityContext *corev1.SecurityContext
 
 	// podSecurityContext is the pod-level security context applied to the pod spec. See
@@ -205,9 +206,9 @@ func (h *BaseRoleGroupHandler[CR]) WithSidecarManager(m *sidecar.SidecarManager)
 // WithSecurityContext overrides the framework's default pod/container security context for the
 // role group's StatefulSet. Passing nil for either argument removes that level's security
 // context entirely (the framework default is no longer applied). For per-role-group overrides,
-// prefer MergedConfig.PodOverrides instead of this handler-wide override; note that PodOverrides
-// REPLACES the security context (no deep merge), so an override must restate any fields it wants
-// to keep.
+// prefer MergedConfig.PodOverrides instead of this handler-wide override; PodOverrides
+// strategic-merges the security context per field, so an override must explicitly restate any
+// default field it wants to change (unmentioned fields keep the default).
 func (h *BaseRoleGroupHandler[CR]) WithSecurityContext(
 	containerCtx *corev1.SecurityContext,
 	podCtx *corev1.PodSecurityContext,
@@ -755,6 +756,29 @@ func (h *BaseRoleGroupHandler[CR]) buildStatefulSet(
 	if sidecarMgr != nil {
 		if err := sidecarMgr.InjectAll(&sts.Spec.Template.Spec); err != nil {
 			return nil, fmt.Errorf("sidecar injection failed: %w", err)
+		}
+	}
+
+	// Fail loudly on image-less containers instead of shipping a StatefulSet the API server
+	// rejects (a silent Degraded loop). The typical cause: a podOverride container whose name
+	// matches nothing — a typo, or a sidecar name; sidecars are injected AFTER the overrides
+	// merge, so they cannot be addressed by podOverrides.
+	mainName := stsBuilder.MainContainerName
+	if mainName == "" {
+		mainName = buildCtx.ResourceName
+	}
+	for _, c := range sts.Spec.Template.Spec.Containers {
+		if c.Image == "" {
+			return nil, fmt.Errorf(
+				"container %q has no image: a podOverrides container must either address an existing container by name (main container: %q) or be fully specified; sidecar containers cannot be overridden via podOverrides",
+				c.Name, mainName)
+		}
+	}
+	for _, c := range sts.Spec.Template.Spec.InitContainers {
+		if c.Image == "" {
+			return nil, fmt.Errorf(
+				"init container %q has no image: a podOverrides container must either address an existing container by name or be fully specified",
+				c.Name)
 		}
 	}
 

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -476,6 +476,79 @@ var _ = Describe("StatefulSet building", func() {
 		Expect(*resources.StatefulSet.Spec.Replicas).To(Equal(int32(3)))
 	})
 
+	It("consumes role-level config when the role group declares none (role->group fallback)", func() {
+		// Regression: only logging and overrides were merged role->group; role-level
+		// resources/affinity/gracefulShutdownTimeout were silently dropped.
+		merged := reconciler.MergeRoleGroupConfig(
+			&v1alpha1.RoleGroupConfigSpec{
+				GracefulShutdownTimeout: "60s",
+				Resources: &v1alpha1.ResourcesSpec{
+					CPU: &v1alpha1.CPUResource{Max: resource.MustParse("2")},
+				},
+			},
+			nil,
+		)
+		Expect(merged).NotTo(BeNil())
+		Expect(merged.GracefulShutdownTimeout).To(Equal("60s"))
+		Expect(merged.Resources.CPU.Max.String()).To(Equal("2"))
+	})
+
+	It("lets role group config win per field over role config", func() {
+		merged := reconciler.MergeRoleGroupConfig(
+			&v1alpha1.RoleGroupConfigSpec{
+				GracefulShutdownTimeout: "60s",
+				Resources: &v1alpha1.ResourcesSpec{
+					CPU:    &v1alpha1.CPUResource{Max: resource.MustParse("2")},
+					Memory: &v1alpha1.MemoryResource{Limit: resource.MustParse("2Gi")},
+				},
+			},
+			&v1alpha1.RoleGroupConfigSpec{
+				Resources: &v1alpha1.ResourcesSpec{
+					CPU: &v1alpha1.CPUResource{Max: resource.MustParse("4")},
+				},
+			},
+		)
+		Expect(merged.Resources.CPU.Max.String()).To(Equal("4"), "group wins")
+		Expect(merged.Resources.Memory.Limit.String()).To(Equal("2Gi"), "role fills the gap")
+		Expect(merged.GracefulShutdownTimeout).To(Equal("60s"))
+	})
+
+	It("merges a podOverride addressing the renamed main container instead of appending a phantom", func() {
+		// Regression: with MainContainerName set, a podOverride container carrying the
+		// user-facing name (the documented contract, e.g. spark's "node") must merge into the
+		// primary container. Before the fix the rename ran after Build(), so the override was
+		// appended as a second, image-less container and the API server rejected the
+		// StatefulSet.
+		handler.MainContainerName = "node"
+		buildCtx.MergedConfig = &config.MergedConfig{
+			PodOverrides: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "node",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceCPU:    resource.MustParse("2"),
+									corev1.ResourceMemory: resource.MustParse("3Gi"),
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
+		Expect(err).NotTo(HaveOccurred())
+
+		containers := resources.StatefulSet.Spec.Template.Spec.Containers
+		Expect(containers).To(HaveLen(1))
+		Expect(containers[0].Name).To(Equal("node"))
+		Expect(containers[0].Image).To(Equal("test-image:latest"), "the merged container keeps the built image")
+		Expect(containers[0].Resources.Limits.Cpu().String()).To(Equal("2"))
+		Expect(containers[0].Resources.Limits.Memory().String()).To(Equal("3Gi"))
+	})
+
 	It("forces replicas to 0 when the cluster is stopped, still building the StatefulSet", func() {
 		// Stopped scales pods to 0 while all resources are reconciled/preserved: the StatefulSet is
 		// still built (with the declared image, config volume, etc.), only its replica count is 0.

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -750,9 +750,11 @@ var _ = Describe("StatefulSet building", func() {
 		Expect(csc.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
 	})
 
-	It("should let PodOverrides REPLACE the default pod security context (no deep merge)", func() {
-		// The override sets only RunAsUser. Replace semantics mean the rest of the default
-		// (RunAsGroup, FSGroup, RunAsNonRoot, SeccompProfile) is wiped, not merged on top.
+	It("should deep-merge PodOverrides into the default pod security context (strategic merge)", func() {
+		// The override sets only RunAsUser. Strategic-merge semantics (the documented merge
+		// strategy for PodTemplate) mean the rest of the default hardening (RunAsGroup, FSGroup,
+		// RunAsNonRoot, SeccompProfile) is kept; an override must explicitly restate a field
+		// (e.g. runAsNonRoot: false) to change it.
 		buildCtx.MergedConfig = &config.MergedConfig{
 			PodOverrides: &corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
@@ -770,14 +772,14 @@ var _ = Describe("StatefulSet building", func() {
 		Expect(podSC).NotTo(BeNil())
 		Expect(podSC.RunAsUser).NotTo(BeNil())
 		Expect(*podSC.RunAsUser).To(Equal(int64(1234)))
-		// Negative assertions documenting REPLACE (not merge): default hardening fields are gone.
-		Expect(podSC.FSGroup).To(BeNil())
-		Expect(podSC.RunAsGroup).To(BeNil())
-		Expect(podSC.RunAsNonRoot).To(BeNil())
-		Expect(podSC.SeccompProfile).To(BeNil())
+		// The default hardening fields the override did not mention survive the merge.
+		Expect(podSC.FSGroup).NotTo(BeNil())
+		Expect(podSC.RunAsGroup).NotTo(BeNil())
+		Expect(podSC.RunAsNonRoot).NotTo(BeNil())
+		Expect(podSC.SeccompProfile).NotTo(BeNil())
 	})
 
-	It("should let PodOverrides REPLACE the default container security context (no deep merge)", func() {
+	It("should deep-merge PodOverrides into the default container security context (strategic merge)", func() {
 		buildCtx.MergedConfig = &config.MergedConfig{
 			PodOverrides: &corev1.PodTemplateSpec{
 				Spec: corev1.PodSpec{
@@ -802,11 +804,11 @@ var _ = Describe("StatefulSet building", func() {
 		Expect(csc).NotTo(BeNil())
 		Expect(csc.RunAsUser).NotTo(BeNil())
 		Expect(*csc.RunAsUser).To(Equal(int64(4321)))
-		// Negative assertions documenting REPLACE (not merge): default hardening fields are gone.
-		Expect(csc.AllowPrivilegeEscalation).To(BeNil())
-		Expect(csc.Capabilities).To(BeNil())
-		Expect(csc.RunAsNonRoot).To(BeNil())
-		Expect(csc.SeccompProfile).To(BeNil())
+		// The default hardening fields the override did not mention survive the merge.
+		Expect(csc.AllowPrivilegeEscalation).NotTo(BeNil())
+		Expect(csc.Capabilities).NotTo(BeNil())
+		Expect(csc.RunAsNonRoot).NotTo(BeNil())
+		Expect(csc.SeccompProfile).NotTo(BeNil())
 	})
 
 	It("should allow disabling the default security context", func() {
@@ -967,9 +969,13 @@ var _ = Describe("RoleGroupConfig affinity and gracefulShutdownTimeout consumpti
 
 		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
 		Expect(err).NotTo(HaveOccurred())
-		// The builder applies PodOverrides last, so the user's pod override replaces the
-		// config-declared affinity.
-		Expect(resources.StatefulSet.Spec.Template.Spec.Affinity).To(Equal(overrideAffinity))
+		// The builder applies PodOverrides last via strategic merge: affinity kinds the override
+		// sets win, while config-declared affinity kinds it does not mention are kept.
+		merged := resources.StatefulSet.Spec.Template.Spec.Affinity
+		Expect(merged).NotTo(BeNil())
+		Expect(merged.NodeAffinity).To(Equal(overrideAffinity.NodeAffinity))
+		Expect(merged.PodAntiAffinity).NotTo(BeNil(),
+			"config-declared podAntiAffinity survives a nodeAffinity-only override")
 	})
 
 	It("lets a PodOverrides terminationGracePeriodSeconds win over gracefulShutdownTimeout", func() {

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -476,6 +476,46 @@ var _ = Describe("StatefulSet building", func() {
 		Expect(*resources.StatefulSet.Spec.Replicas).To(Equal(int32(3)))
 	})
 
+	It("fails loudly when a podOverride container matches nothing (typo or sidecar name)", func() {
+		// Sidecars are injected AFTER the overrides merge, so an override naming one (or a
+		// typo) yields an image-less container; without this guard the API server would
+		// reject the StatefulSet and the CR would sit silently Degraded.
+		handler.MainContainerName = "node"
+		buildCtx.MergedConfig = &config.MergedConfig{
+			PodOverrides: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name: "vector",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		_, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
+		Expect(err).To(MatchError(ContainSubstring(`container "vector" has no image`)))
+		Expect(err).To(MatchError(ContainSubstring(`main container: "node"`)))
+	})
+
+	It("does not alias the live CR spec through the merged logging config", func() {
+		roleCfg := &v1alpha1.RoleGroupConfigSpec{
+			Logging: &v1alpha1.LoggingSpec{
+				EnableVectorAgent: ptr.To(true),
+			},
+		}
+		merged := reconciler.MergeRoleGroupConfig(roleCfg, &v1alpha1.RoleGroupConfigSpec{})
+		Expect(merged.Logging).NotTo(BeIdenticalTo(roleCfg.Logging),
+			"the merged result must be a fresh copy, never the CR's own object")
+
+		*merged.Logging.EnableVectorAgent = false
+		Expect(*roleCfg.Logging.EnableVectorAgent).To(BeTrue(),
+			"mutating the merge result must not touch the input")
+	})
+
 	It("consumes role-level config when the role group declares none (role->group fallback)", func() {
 		// Regression: only logging and overrides were merged role->group; role-level
 		// resources/affinity/gracefulShutdownTimeout were silently dropped.

--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -574,6 +574,13 @@ func (r *GenericReconciler[CR]) buildRoleGroupContext(cr CR, roleName string, ro
 	// logging config file generation read from a single merged source.
 	mergedConfig.Logging = productlogging.MergeLoggingSpec(roleSpec.GetConfig().Logging, groupSpec.GetConfig().Logging)
 
+	// Merge the role-level config into the role group config (group wins per field), so
+	// role-wide defaults for resources/affinity/gracefulShutdownTimeout reach every group —
+	// previously only logging and overrides were merged and role-level config was silently
+	// dropped. The merge works on copies; the CR's spec objects are never mutated.
+	mergedGroupSpec := groupSpec.DeepCopy()
+	mergedGroupSpec.Config = MergeRoleGroupConfig(roleSpec.GetConfig(), groupSpec.GetConfig())
+
 	resourceName := RoleGroupResourceName(cr.GetName(), roleName, groupName)
 
 	return &RoleGroupBuildContext{
@@ -584,7 +591,7 @@ func (r *GenericReconciler[CR]) buildRoleGroupContext(cr CR, roleName string, ro
 		RoleName:         roleName,
 		RoleSpec:         roleSpec,
 		RoleGroupName:    groupName,
-		RoleGroupSpec:    *groupSpec,
+		RoleGroupSpec:    *mergedGroupSpec,
 		MergedConfig:     mergedConfig,
 		ResourceName:     resourceName,
 		// Propagate the reconciler-managed ServiceAccount so the workload pods actually run as

--- a/pkg/reconciler/role_group_handler.go
+++ b/pkg/reconciler/role_group_handler.go
@@ -268,6 +268,47 @@ func RenderLoggingConfigMapData(buildCtx *RoleGroupBuildContext, producers []pro
 	return data, nil
 }
 
+// MergeRoleGroupConfig merges a role-level RoleGroupConfigSpec into a role group's config,
+// the group winning per field (resources merge per sub-field; logging deep-merges per
+// container via productlogging.MergeLoggingSpec). The inputs are never mutated; the result
+// is always a fresh copy (or nil when both inputs are nil). GenericReconciler applies this
+// when building the RoleGroupBuildContext, so role-wide config defaults reach every group.
+func MergeRoleGroupConfig(role, group *v1alpha1.RoleGroupConfigSpec) *v1alpha1.RoleGroupConfigSpec {
+	switch {
+	case role == nil && group == nil:
+		return nil
+	case role == nil:
+		return group.DeepCopy()
+	case group == nil:
+		return role.DeepCopy()
+	}
+
+	merged := group.DeepCopy()
+	if merged.Affinity == nil {
+		merged.Affinity = role.Affinity.DeepCopy()
+	}
+	if merged.GracefulShutdownTimeout == "" {
+		merged.GracefulShutdownTimeout = role.GracefulShutdownTimeout
+	}
+	merged.Logging = productlogging.MergeLoggingSpec(role.Logging, group.Logging)
+	if role.Resources != nil {
+		if merged.Resources == nil {
+			merged.Resources = role.Resources.DeepCopy()
+		} else {
+			if merged.Resources.CPU == nil {
+				merged.Resources.CPU = role.Resources.CPU.DeepCopy()
+			}
+			if merged.Resources.Memory == nil {
+				merged.Resources.Memory = role.Resources.Memory.DeepCopy()
+			}
+			if merged.Resources.Storage == nil {
+				merged.Resources.Storage = role.Resources.Storage.DeepCopy()
+			}
+		}
+	}
+	return merged
+}
+
 // RoleGroupHandler is the interface that product operators must implement
 // to define how resources are built for each role group.
 //

--- a/pkg/reconciler/role_group_handler.go
+++ b/pkg/reconciler/role_group_handler.go
@@ -273,6 +273,13 @@ func RenderLoggingConfigMapData(buildCtx *RoleGroupBuildContext, producers []pro
 // container via productlogging.MergeLoggingSpec). The inputs are never mutated; the result
 // is always a fresh copy (or nil when both inputs are nil). GenericReconciler applies this
 // when building the RoleGroupBuildContext, so role-wide config defaults reach every group.
+//
+// Caveat — gracefulShutdownTimeout: the commons CRD schema defaults this field to "30s", and
+// the API server stamps that default into EVERY config block that exists. A role-level value
+// therefore only reaches groups that declare no config block at all; a group with any config
+// (e.g. just resources) carries the server-stamped "30s", which wins here — indistinguishable
+// from an explicit group-level "30s". Fixing this properly means dropping the CRD-level
+// default (or making the field a *string) across the product CRDs.
 func MergeRoleGroupConfig(role, group *v1alpha1.RoleGroupConfigSpec) *v1alpha1.RoleGroupConfigSpec {
 	switch {
 	case role == nil && group == nil:
@@ -290,7 +297,9 @@ func MergeRoleGroupConfig(role, group *v1alpha1.RoleGroupConfigSpec) *v1alpha1.R
 	if merged.GracefulShutdownTimeout == "" {
 		merged.GracefulShutdownTimeout = role.GracefulShutdownTimeout
 	}
-	merged.Logging = productlogging.MergeLoggingSpec(role.Logging, group.Logging)
+	// MergeLoggingSpec may return one of its inputs unchanged (e.g. a nil counterpart);
+	// deep-copy so the merged config never aliases the live CR spec.
+	merged.Logging = productlogging.MergeLoggingSpec(role.Logging, group.Logging).DeepCopy()
 	if role.Resources != nil {
 		if merged.Resources == nil {
 			merged.Resources = role.Resources.DeepCopy()

--- a/pkg/s3/credentials.go
+++ b/pkg/s3/credentials.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package s3
+
+import (
+	"path"
+
+	"github.com/zncdatadev/operator-go/pkg/constant"
+	"github.com/zncdatadev/operator-go/pkg/security"
+)
+
+const (
+	// AccessKeyFile and SecretKeyFile are the file names the secret-operator serves for a
+	// credential SecretClass; the s3.kubedoop.dev CRDs document these keys.
+	AccessKeyFile = "ACCESS_KEY"
+	SecretKeyFile = "SECRET_KEY"
+
+	// DefaultCredentialsVolumeName is the conventional volume (and mount subdirectory)
+	// name for S3 credentials.
+	DefaultCredentialsVolumeName = "s3-credentials"
+)
+
+// CredentialsProvisioner returns a SecretProvisioner delivering this connection's
+// credentials as a secret-operator CSI volume, mounted at CredentialsMountPath(volumeName)
+// (the platform's /kubedoop/secret/<volume> convention). It satisfies
+// reconciler.VolumeProvider, so it can be appended to RoleGroupBuildContext.VolumeProviders
+// as-is. Returns nil when the connection carries no credentials (anonymous access) — a nil
+// provisioner must simply not be registered.
+func (c *ConnectionInfo) CredentialsProvisioner(volumeName string) *security.SecretProvisioner {
+	if c.Credentials == nil {
+		return nil
+	}
+	registration := security.CredentialsVolume(volumeName, c.Credentials.SecretClass)
+	if scope := security.ScopeString(c.Credentials.Scope); scope != "" {
+		registration = registration.WithScope(scope)
+	}
+	return security.NewSecretProvisioner().
+		WithMountBasePath(constant.KubedoopSecretDir).
+		Register(registration)
+}
+
+// CredentialsMountPath returns the mount path (no trailing slash) for a credentials volume
+// created by CredentialsProvisioner.
+func CredentialsMountPath(volumeName string) string {
+	return path.Join(constant.KubedoopSecretDir, volumeName)
+}
+
+// CredentialsExportScript returns a shell fragment exporting the mounted credential files
+// as the AWS SDK environment variables, for splicing into a container start script ahead of
+// the product launch command:
+//
+//	export AWS_ACCESS_KEY_ID="$(cat /kubedoop/secret/<volume>/ACCESS_KEY)"
+//	export AWS_SECRET_ACCESS_KEY="$(cat /kubedoop/secret/<volume>/SECRET_KEY)"
+func CredentialsExportScript(mountPath string) string {
+	return `export AWS_ACCESS_KEY_ID="$(cat ` + path.Join(mountPath, AccessKeyFile) + `)"
+export AWS_SECRET_ACCESS_KEY="$(cat ` + path.Join(mountPath, SecretKeyFile) + `)"`
+}

--- a/pkg/s3/properties.go
+++ b/pkg/s3/properties.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package s3
+
+import (
+	"net/url"
+	"strconv"
+)
+
+// S3AProperties renders the Hadoop S3A client properties for this connection, faithfully
+// reflecting the resolved spec: endpoint, addressing style, SSL flag, and (when set) the
+// signing region. Products merge these into their config files, prefixing as their product
+// requires (e.g. Spark prefixes each key with "spark.hadoop."). Keys a product needs to
+// pin differently (e.g. forcing path-style for a backend that requires it) can simply be
+// overwritten after merging.
+func (c *ConnectionInfo) S3AProperties() map[string]string {
+	props := map[string]string{
+		"fs.s3a.endpoint":               c.Endpoint.String(),
+		"fs.s3a.path.style.access":      strconv.FormatBool(c.PathStyle),
+		"fs.s3a.connection.ssl.enabled": strconv.FormatBool(c.TLSEnabled()),
+	}
+	if c.Region != "" {
+		props["fs.s3a.endpoint.region"] = c.Region
+	}
+	return props
+}
+
+// TLSEnabled reports whether the connection uses TLS (https endpoint).
+func (c *ConnectionInfo) TLSEnabled() bool {
+	return c.TLS != nil
+}
+
+// S3AURI renders an "s3a://<bucket>/<prefix>" URI for the bucket, e.g. for Spark's
+// spark.history.fs.logDirectory or any Hadoop-compatible input path.
+func (b *BucketInfo) S3AURI(prefix string) string {
+	uri := url.URL{
+		Scheme: "s3a",
+		Host:   b.BucketName,
+		Path:   prefix,
+	}
+	return uri.String()
+}

--- a/pkg/s3/resolver.go
+++ b/pkg/s3/resolver.go
@@ -1,0 +1,149 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package s3 resolves the s3.kubedoop.dev connection and bucket CRDs into the concrete
+// facts a product operator needs — endpoint URL, region, addressing style, TLS and
+// credentials — and wires the credential delivery (secret-operator CSI volume plus AWS SDK
+// env exports). Product CRDs embed inline-or-reference pairs for S3Connection/S3Bucket;
+// this package owns the resolution chain so each product no longer hand-rolls it.
+package s3
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"strconv"
+
+	commonsv1alpha1 "github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
+	s3v1alpha1 "github.com/zncdatadev/operator-go/pkg/apis/s3/v1alpha1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ConnectionInfo is a resolved S3 connection: every inline/reference indirection has been
+// followed and the endpoint facts are ready for config rendering.
+type ConnectionInfo struct {
+	// Endpoint is the S3 endpoint URL. The scheme is https when the connection declares
+	// TLS, http otherwise.
+	Endpoint url.URL
+
+	// Region is the signing region from the connection spec ("" when unset).
+	Region string
+
+	// PathStyle is the addressing style from the connection spec: true for path-style
+	// (required by most self-hosted backends such as MinIO), false for virtual-host style.
+	PathStyle bool
+
+	// TLS carries the connection's TLS verification spec, nil when TLS is not configured.
+	// CA material delivery is the product's concern for now.
+	TLS *s3v1alpha1.Tls
+
+	// Credentials names the SecretClass (and scope) delivering ACCESS_KEY/SECRET_KEY.
+	// Nil when the connection is anonymous.
+	Credentials *commonsv1alpha1.Credentials
+}
+
+// BucketInfo is a resolved S3 bucket: the bucket name plus its resolved connection.
+type BucketInfo struct {
+	ConnectionInfo
+
+	// BucketName is the bucket to address on the connection's endpoint.
+	BucketName string
+}
+
+// ResolveConnection resolves an inline-or-reference S3 connection pair into ConnectionInfo.
+// Exactly one of inline and reference must be set; the referenced S3Connection is fetched
+// from the given namespace.
+func ResolveConnection(ctx context.Context, c ctrlclient.Client, namespace string, inline *s3v1alpha1.S3ConnectionSpec, reference string) (*ConnectionInfo, error) {
+	spec, err := resolveConnectionSpec(ctx, c, namespace, inline, reference)
+	if err != nil {
+		return nil, err
+	}
+	return connectionInfoFromSpec(spec), nil
+}
+
+// ResolveBucket resolves an inline-or-reference S3 bucket pair into BucketInfo, following
+// the bucket's own inline-or-reference connection. Exactly one of inline and reference must
+// be set; referenced objects are fetched from the given namespace.
+func ResolveBucket(ctx context.Context, c ctrlclient.Client, namespace string, inline *s3v1alpha1.S3BucketSpec, reference string) (*BucketInfo, error) {
+	bucketSpec := inline
+	switch {
+	case inline != nil && reference != "":
+		return nil, fmt.Errorf("invalid S3 bucket: inline and reference are mutually exclusive")
+	case reference != "":
+		bucket := &s3v1alpha1.S3Bucket{}
+		if err := c.Get(ctx, ctrlclient.ObjectKey{Namespace: namespace, Name: reference}, bucket); err != nil {
+			return nil, fmt.Errorf("failed to get referenced S3Bucket %q: %w", reference, err)
+		}
+		bucketSpec = &bucket.Spec
+	case inline == nil:
+		return nil, fmt.Errorf("invalid S3 bucket: neither inline nor reference is set")
+	}
+
+	if bucketSpec.Connection == nil {
+		return nil, fmt.Errorf("invalid S3 bucket %q: no connection is set", bucketSpec.BucketName)
+	}
+	conn, err := ResolveConnection(ctx, c, namespace, bucketSpec.Connection.Inline, bucketSpec.Connection.Reference)
+	if err != nil {
+		return nil, err
+	}
+
+	return &BucketInfo{
+		ConnectionInfo: *conn,
+		BucketName:     bucketSpec.BucketName,
+	}, nil
+}
+
+// resolveConnectionSpec follows the inline-or-reference pair to a concrete connection spec.
+func resolveConnectionSpec(ctx context.Context, c ctrlclient.Client, namespace string, inline *s3v1alpha1.S3ConnectionSpec, reference string) (*s3v1alpha1.S3ConnectionSpec, error) {
+	switch {
+	case inline != nil && reference != "":
+		return nil, fmt.Errorf("invalid S3 connection: inline and reference are mutually exclusive")
+	case reference != "":
+		conn := &s3v1alpha1.S3Connection{}
+		if err := c.Get(ctx, ctrlclient.ObjectKey{Namespace: namespace, Name: reference}, conn); err != nil {
+			return nil, fmt.Errorf("failed to get referenced S3Connection %q: %w", reference, err)
+		}
+		return &conn.Spec, nil
+	case inline != nil:
+		return inline, nil
+	default:
+		return nil, fmt.Errorf("invalid S3 connection: neither inline nor reference is set")
+	}
+}
+
+// connectionInfoFromSpec maps a connection spec to resolved facts. The endpoint scheme
+// follows the TLS declaration: https when TLS is configured, http otherwise.
+func connectionInfoFromSpec(spec *s3v1alpha1.S3ConnectionSpec) *ConnectionInfo {
+	scheme := "http"
+	if spec.Tls != nil {
+		scheme = "https"
+	}
+	endpoint := url.URL{
+		Scheme: scheme,
+		Host:   spec.Host,
+	}
+	if spec.Port != 0 {
+		endpoint.Host += ":" + strconv.Itoa(spec.Port)
+	}
+
+	return &ConnectionInfo{
+		Endpoint:    endpoint,
+		Region:      spec.Region,
+		PathStyle:   spec.PathStyle,
+		TLS:         spec.Tls,
+		Credentials: spec.Credentials,
+	}
+}

--- a/pkg/s3/resolver_test.go
+++ b/pkg/s3/resolver_test.go
@@ -193,7 +193,7 @@ var _ = Describe("Credentials wiring", func() {
 
 		volumes := provisioner.Volumes()
 		Expect(volumes).To(HaveLen(1))
-		annotations := volumes[0].VolumeSource.Ephemeral.VolumeClaimTemplate.Annotations
+		annotations := volumes[0].Ephemeral.VolumeClaimTemplate.Annotations
 		Expect(annotations).To(HaveKeyWithValue(security.SecretClassAnnotation, "s3-credentials"))
 		Expect(annotations).NotTo(HaveKey(security.AnnotationSecretsFormat),
 			"plain credential secrets carry no format annotation")
@@ -217,7 +217,7 @@ var _ = Describe("Credentials wiring", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		provisioner := info.CredentialsProvisioner(s3.DefaultCredentialsVolumeName)
-		annotations := provisioner.Volumes()[0].VolumeSource.Ephemeral.VolumeClaimTemplate.Annotations
+		annotations := provisioner.Volumes()[0].Ephemeral.VolumeClaimTemplate.Annotations
 		Expect(annotations).To(HaveKeyWithValue(security.SecretClassScopeAnnotation, "node,pod,service=minio"))
 	})
 

--- a/pkg/s3/resolver_test.go
+++ b/pkg/s3/resolver_test.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package s3_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	commonsv1alpha1 "github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
+	s3v1alpha1 "github.com/zncdatadev/operator-go/pkg/apis/s3/v1alpha1"
+	"github.com/zncdatadev/operator-go/pkg/s3"
+	"github.com/zncdatadev/operator-go/pkg/security"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const namespace = "test-ns"
+
+func newFakeClient(objs ...ctrlclient.Object) ctrlclient.Client {
+	scheme := runtime.NewScheme()
+	Expect(s3v1alpha1.AddToScheme(scheme)).To(Succeed())
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
+
+func inlineConnection() *s3v1alpha1.S3ConnectionSpec {
+	return &s3v1alpha1.S3ConnectionSpec{
+		Host:      "minio",
+		Port:      9000,
+		PathStyle: true,
+		Region:    "us-east-1",
+		Credentials: &commonsv1alpha1.Credentials{
+			SecretClass: "s3-credentials",
+		},
+	}
+}
+
+var _ = Describe("ResolveConnection", func() {
+	It("resolves an inline connection", func() {
+		info, err := s3.ResolveConnection(context.Background(), newFakeClient(), namespace, inlineConnection(), "")
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(info.Endpoint.String()).To(Equal("http://minio:9000"))
+		Expect(info.PathStyle).To(BeTrue())
+		Expect(info.Region).To(Equal("us-east-1"))
+		Expect(info.TLSEnabled()).To(BeFalse())
+		Expect(info.Credentials.SecretClass).To(Equal("s3-credentials"))
+	})
+
+	It("resolves a referenced S3Connection from the CR namespace", func() {
+		conn := &s3v1alpha1.S3Connection{
+			ObjectMeta: metav1.ObjectMeta{Name: "minio", Namespace: namespace},
+			Spec:       *inlineConnection(),
+		}
+		info, err := s3.ResolveConnection(context.Background(), newFakeClient(conn), namespace, nil, "minio")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Endpoint.Host).To(Equal("minio:9000"))
+	})
+
+	It("uses https when the connection declares TLS", func() {
+		spec := inlineConnection()
+		spec.Tls = &s3v1alpha1.Tls{}
+		info, err := s3.ResolveConnection(context.Background(), newFakeClient(), namespace, spec, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Endpoint.Scheme).To(Equal("https"))
+		Expect(info.TLSEnabled()).To(BeTrue())
+	})
+
+	It("omits the port when unset", func() {
+		spec := inlineConnection()
+		spec.Port = 0
+		info, err := s3.ResolveConnection(context.Background(), newFakeClient(), namespace, spec, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.Endpoint.String()).To(Equal("http://minio"))
+	})
+
+	It("rejects inline and reference together", func() {
+		_, err := s3.ResolveConnection(context.Background(), newFakeClient(), namespace, inlineConnection(), "minio")
+		Expect(err).To(MatchError(ContainSubstring("mutually exclusive")))
+	})
+
+	It("rejects neither inline nor reference", func() {
+		_, err := s3.ResolveConnection(context.Background(), newFakeClient(), namespace, nil, "")
+		Expect(err).To(MatchError(ContainSubstring("neither inline nor reference")))
+	})
+
+	It("fails on a missing referenced S3Connection", func() {
+		_, err := s3.ResolveConnection(context.Background(), newFakeClient(), namespace, nil, "absent")
+		Expect(err).To(MatchError(ContainSubstring(`referenced S3Connection "absent"`)))
+	})
+})
+
+var _ = Describe("ResolveBucket", func() {
+	It("resolves an inline bucket with an inline connection", func() {
+		bucket := &s3v1alpha1.S3BucketSpec{
+			BucketName: "spark-history",
+			Connection: &s3v1alpha1.S3BucketConnectionSpec{Inline: inlineConnection()},
+		}
+		info, err := s3.ResolveBucket(context.Background(), newFakeClient(), namespace, bucket, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.BucketName).To(Equal("spark-history"))
+		Expect(info.Endpoint.String()).To(Equal("http://minio:9000"))
+	})
+
+	It("resolves a referenced bucket whose connection is itself a reference", func() {
+		conn := &s3v1alpha1.S3Connection{
+			ObjectMeta: metav1.ObjectMeta{Name: "minio", Namespace: namespace},
+			Spec:       *inlineConnection(),
+		}
+		bucket := &s3v1alpha1.S3Bucket{
+			ObjectMeta: metav1.ObjectMeta{Name: "spark-history", Namespace: namespace},
+			Spec: s3v1alpha1.S3BucketSpec{
+				BucketName: "spark-history",
+				Connection: &s3v1alpha1.S3BucketConnectionSpec{Reference: "minio"},
+			},
+		}
+		info, err := s3.ResolveBucket(context.Background(), newFakeClient(conn, bucket), namespace, nil, "spark-history")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.BucketName).To(Equal("spark-history"))
+		Expect(info.Endpoint.Host).To(Equal("minio:9000"))
+		Expect(info.Credentials.SecretClass).To(Equal("s3-credentials"))
+	})
+
+	It("fails on a bucket without a connection", func() {
+		bucket := &s3v1alpha1.S3BucketSpec{BucketName: "b"}
+		_, err := s3.ResolveBucket(context.Background(), newFakeClient(), namespace, bucket, "")
+		Expect(err).To(MatchError(ContainSubstring("no connection")))
+	})
+
+	It("fails on a missing referenced S3Bucket", func() {
+		_, err := s3.ResolveBucket(context.Background(), newFakeClient(), namespace, nil, "absent")
+		Expect(err).To(MatchError(ContainSubstring(`referenced S3Bucket "absent"`)))
+	})
+})
+
+var _ = Describe("BucketInfo rendering", func() {
+	It("renders the s3a URI", func() {
+		info := &s3.BucketInfo{BucketName: "spark-history"}
+		Expect(info.S3AURI("events")).To(Equal("s3a://spark-history/events"))
+	})
+
+	It("renders S3A properties faithfully from the resolved connection", func() {
+		info, err := s3.ResolveConnection(context.Background(), newFakeClient(), namespace, inlineConnection(), "")
+		Expect(err).NotTo(HaveOccurred())
+
+		props := info.S3AProperties()
+		Expect(props).To(HaveKeyWithValue("fs.s3a.endpoint", "http://minio:9000"))
+		Expect(props).To(HaveKeyWithValue("fs.s3a.path.style.access", "true"))
+		Expect(props).To(HaveKeyWithValue("fs.s3a.connection.ssl.enabled", "false"))
+		Expect(props).To(HaveKeyWithValue("fs.s3a.endpoint.region", "us-east-1"))
+	})
+
+	It("omits the region property when the region is unset", func() {
+		spec := inlineConnection()
+		spec.Region = ""
+		info, err := s3.ResolveConnection(context.Background(), newFakeClient(), namespace, spec, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.S3AProperties()).NotTo(HaveKey("fs.s3a.endpoint.region"))
+	})
+})
+
+var _ = Describe("Credentials wiring", func() {
+	It("returns no provisioner for anonymous connections", func() {
+		spec := inlineConnection()
+		spec.Credentials = nil
+		info, err := s3.ResolveConnection(context.Background(), newFakeClient(), namespace, spec, "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(info.CredentialsProvisioner("s3-credentials")).To(BeNil())
+	})
+
+	It("provisions a plain credential CSI volume under /kubedoop/secret", func() {
+		info, err := s3.ResolveConnection(context.Background(), newFakeClient(), namespace, inlineConnection(), "")
+		Expect(err).NotTo(HaveOccurred())
+
+		provisioner := info.CredentialsProvisioner(s3.DefaultCredentialsVolumeName)
+		Expect(provisioner).NotTo(BeNil())
+
+		volumes := provisioner.Volumes()
+		Expect(volumes).To(HaveLen(1))
+		annotations := volumes[0].VolumeSource.Ephemeral.VolumeClaimTemplate.Annotations
+		Expect(annotations).To(HaveKeyWithValue(security.SecretClassAnnotation, "s3-credentials"))
+		Expect(annotations).NotTo(HaveKey(security.AnnotationSecretsFormat),
+			"plain credential secrets carry no format annotation")
+		Expect(annotations).NotTo(HaveKey(security.SecretClassScopeAnnotation),
+			"no scope annotation when the credentials declare no scope")
+
+		mounts := provisioner.VolumeMounts()
+		Expect(mounts).To(HaveLen(1))
+		Expect(mounts[0].MountPath).To(Equal("/kubedoop/secret/s3-credentials"))
+		Expect(s3.CredentialsMountPath(s3.DefaultCredentialsVolumeName)).To(Equal("/kubedoop/secret/s3-credentials"))
+	})
+
+	It("renders the credentials scope with the secret-operator key=value convention", func() {
+		spec := inlineConnection()
+		spec.Credentials.Scope = &commonsv1alpha1.CredentialsScope{
+			Node:     true,
+			Pod:      true,
+			Services: []string{"minio"},
+		}
+		info, err := s3.ResolveConnection(context.Background(), newFakeClient(), namespace, spec, "")
+		Expect(err).NotTo(HaveOccurred())
+
+		provisioner := info.CredentialsProvisioner(s3.DefaultCredentialsVolumeName)
+		annotations := provisioner.Volumes()[0].VolumeSource.Ephemeral.VolumeClaimTemplate.Annotations
+		Expect(annotations).To(HaveKeyWithValue(security.SecretClassScopeAnnotation, "node,pod,service=minio"))
+	})
+
+	It("renders the AWS env export script", func() {
+		script := s3.CredentialsExportScript(s3.CredentialsMountPath("s3-credentials"))
+		Expect(script).To(ContainSubstring(`export AWS_ACCESS_KEY_ID="$(cat /kubedoop/secret/s3-credentials/ACCESS_KEY)"`))
+		Expect(script).To(ContainSubstring(`export AWS_SECRET_ACCESS_KEY="$(cat /kubedoop/secret/s3-credentials/SECRET_KEY)"`))
+	})
+})

--- a/pkg/s3/suite_test.go
+++ b/pkg/s3/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package s3_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestS3(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "S3 Suite")
+}

--- a/pkg/security/secret_class.go
+++ b/pkg/security/secret_class.go
@@ -17,6 +17,9 @@ limitations under the License.
 package security
 
 import (
+	"strings"
+
+	commonsv1alpha1 "github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
 	"github.com/zncdatadev/operator-go/pkg/constant"
 )
 
@@ -74,3 +77,28 @@ const (
 	ServiceScope        SecretScope = "service"
 	ListenerVolumeScope SecretScope = "listener-volume"
 )
+
+// ScopeString renders a commons CredentialsScope as the CSI scope annotation value the
+// secret-operator parses: comma-separated entries of "node", "pod", "service=<name>" and
+// "listener-volume=<name>". Named entries carry the key= prefix — bare service names are
+// skipped by the secret-operator's scope parser. Returns "" for a nil or empty scope (the
+// scope annotation should then be omitted).
+func ScopeString(scope *commonsv1alpha1.CredentialsScope) string {
+	if scope == nil {
+		return ""
+	}
+	entries := []string{}
+	if scope.Node {
+		entries = append(entries, string(NodeScope))
+	}
+	if scope.Pod {
+		entries = append(entries, string(PodScope))
+	}
+	for _, svc := range scope.Services {
+		entries = append(entries, string(ServiceScope)+"="+svc)
+	}
+	for _, lv := range scope.ListenerVolumes {
+		entries = append(entries, string(ListenerVolumeScope)+"="+lv)
+	}
+	return strings.Join(entries, CommonDelimiter)
+}

--- a/pkg/security/secret_class_test.go
+++ b/pkg/security/secret_class_test.go
@@ -54,7 +54,7 @@ var _ = Describe("CredentialsVolume", func() {
 
 		volumes := provisioner.Volumes()
 		Expect(volumes).To(HaveLen(1))
-		annotations := volumes[0].VolumeSource.Ephemeral.VolumeClaimTemplate.Annotations
+		annotations := volumes[0].Ephemeral.VolumeClaimTemplate.Annotations
 		Expect(annotations).To(HaveKeyWithValue(security.SecretClassAnnotation, "s3-credentials"))
 		Expect(annotations).NotTo(HaveKey(security.AnnotationSecretsFormat))
 		Expect(annotations).NotTo(HaveKey(security.SecretClassScopeAnnotation))
@@ -64,7 +64,7 @@ var _ = Describe("CredentialsVolume", func() {
 		provisioner := security.NewSecretProvisioner().
 			Register(security.CredentialsVolume("creds", "class").WithScope("node,pod"))
 
-		annotations := provisioner.Volumes()[0].VolumeSource.Ephemeral.VolumeClaimTemplate.Annotations
+		annotations := provisioner.Volumes()[0].Ephemeral.VolumeClaimTemplate.Annotations
 		Expect(annotations).To(HaveKeyWithValue(security.SecretClassScopeAnnotation, "node,pod"))
 	})
 })

--- a/pkg/security/secret_class_test.go
+++ b/pkg/security/secret_class_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package security_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	commonsv1alpha1 "github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
+	"github.com/zncdatadev/operator-go/pkg/security"
+)
+
+var _ = Describe("ScopeString", func() {
+	It("returns empty for a nil scope", func() {
+		Expect(security.ScopeString(nil)).To(Equal(""))
+	})
+
+	It("returns empty for an empty scope", func() {
+		Expect(security.ScopeString(&commonsv1alpha1.CredentialsScope{})).To(Equal(""))
+	})
+
+	It("renders node and pod scopes as bare entries", func() {
+		scope := &commonsv1alpha1.CredentialsScope{Node: true, Pod: true}
+		Expect(security.ScopeString(scope)).To(Equal("node,pod"))
+	})
+
+	It("renders services and listener volumes with the key=value convention", func() {
+		scope := &commonsv1alpha1.CredentialsScope{
+			Services:        []string{"minio", "gateway"},
+			ListenerVolumes: []string{"listener"},
+		}
+		Expect(security.ScopeString(scope)).To(
+			Equal("service=minio,service=gateway,listener-volume=listener"))
+	})
+})
+
+var _ = Describe("CredentialsVolume", func() {
+	It("provisions a volume with only the class annotation by default", func() {
+		provisioner := security.NewSecretProvisioner().
+			Register(security.CredentialsVolume("s3-credentials", "s3-credentials"))
+
+		volumes := provisioner.Volumes()
+		Expect(volumes).To(HaveLen(1))
+		annotations := volumes[0].VolumeSource.Ephemeral.VolumeClaimTemplate.Annotations
+		Expect(annotations).To(HaveKeyWithValue(security.SecretClassAnnotation, "s3-credentials"))
+		Expect(annotations).NotTo(HaveKey(security.AnnotationSecretsFormat))
+		Expect(annotations).NotTo(HaveKey(security.SecretClassScopeAnnotation))
+	})
+
+	It("carries a scope when one is set", func() {
+		provisioner := security.NewSecretProvisioner().
+			Register(security.CredentialsVolume("creds", "class").WithScope("node,pod"))
+
+		annotations := provisioner.Volumes()[0].VolumeSource.Ephemeral.VolumeClaimTemplate.Annotations
+		Expect(annotations).To(HaveKeyWithValue(security.SecretClassScopeAnnotation, "node,pod"))
+	})
+})

--- a/pkg/security/secret_provisioner.go
+++ b/pkg/security/secret_provisioner.go
@@ -133,6 +133,19 @@ func Custom(volumeName, secretClass string, format SecretFormat) *SecretVolumeRe
 	}
 }
 
+// CredentialsVolume creates a secret volume registration for plain credential secrets
+// (e.g. S3 or database access keys) that carry no format annotation — the secret-operator
+// serves the secret's keys as files verbatim. No scope is set by default (matching how
+// credential secrets are typically class-resolved); use WithScope, e.g. with ScopeString,
+// to add one.
+func CredentialsVolume(volumeName, secretClass string) *SecretVolumeRegistration {
+	return &SecretVolumeRegistration{
+		volumeName:  volumeName,
+		secretClass: secretClass,
+		storageSize: defaultSecretStorageSize,
+	}
+}
+
 // WithScope sets the CSI scope annotation value. Default is "pod,node".
 func (r *SecretVolumeRegistration) WithScope(scope string) *SecretVolumeRegistration {
 	r.scope = scope
@@ -193,9 +206,16 @@ func (r *SecretVolumeRegistration) WithExtraAnnotation(key, value string) *Secre
 // buildAnnotations constructs the PVC template annotations for this registration.
 func (r *SecretVolumeRegistration) buildAnnotations() map[string]string {
 	annotations := map[string]string{
-		SecretClassAnnotation:      r.secretClass,
-		SecretClassScopeAnnotation: r.scope,
-		AnnotationSecretsFormat:    string(r.format),
+		SecretClassAnnotation: r.secretClass,
+	}
+
+	// Scope and format are omitted when empty (plain credential volumes have neither);
+	// every typed constructor sets both, so their annotations are unchanged.
+	if r.scope != "" {
+		annotations[SecretClassScopeAnnotation] = r.scope
+	}
+	if r.format != "" {
+		annotations[AnnotationSecretsFormat] = string(r.format)
 	}
 
 	// PKCS12 password is only applicable to PKCS12 format

--- a/pkg/sidecar/interface.go
+++ b/pkg/sidecar/interface.go
@@ -69,3 +69,13 @@ type SidecarProvider interface {
 	// Validate validates the provider's dependencies (e.g., required ConfigMaps).
 	Validate(ctx context.Context, c client.Client, namespace string) error
 }
+
+// OwnImageProvider is optionally implemented by sidecar providers that ship their own
+// upstream image (e.g. oauth2-proxy) rather than running a command inside the product
+// image (e.g. Vector, JMX Exporter). SidecarManager.SetProductImage skips such providers,
+// so their pinned default image stays reachable when a product registers them with an
+// empty SidecarConfig.Image.
+type OwnImageProvider interface {
+	// OwnsImage reports whether the provider supplies its own default image.
+	OwnsImage() bool
+}

--- a/pkg/sidecar/manager.go
+++ b/pkg/sidecar/manager.go
@@ -103,6 +103,16 @@ func ValidateConfigMapExists(ctx context.Context, c client.Client, namespace, na
 	return nil
 }
 
+// ValidateSecretExists validates that a Secret exists.
+func ValidateSecretExists(ctx context.Context, c client.Client, namespace, name string) error {
+	secret := &corev1.Secret{}
+	err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, secret)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
 // Register registers a sidecar provider with its configuration.
 func (m *SidecarManager) Register(provider SidecarProvider, config *SidecarConfig) {
 	m.providers[provider.Name()] = provider

--- a/pkg/sidecar/manager.go
+++ b/pkg/sidecar/manager.go
@@ -201,14 +201,22 @@ func (m *SidecarManager) Count() int {
 // SetProductImage sets the product image on all enabled sidecar configs that
 // don't already have an image or pull policy set. This is used to propagate
 // the product container image to built-in sidecars (e.g. JMX Exporter) that
-// run as different commands within the same product image.
+// run as different commands within the same product image. Providers that ship
+// their own upstream image (OwnImageProvider, e.g. oauth2-proxy) are skipped —
+// filling their empty config.Image with the product image would silently run
+// the product entrypoint in place of the sidecar.
 func (m *SidecarManager) SetProductImage(image string, pullPolicy corev1.PullPolicy) error {
 	if image == "" {
 		return fmt.Errorf("product image must not be empty")
 	}
-	for _, config := range m.configs {
+	for name, config := range m.configs {
 		if !config.Enabled {
 			continue
+		}
+		if provider, ok := m.providers[name]; ok {
+			if own, ok := provider.(OwnImageProvider); ok && own.OwnsImage() {
+				continue
+			}
 		}
 		if config.Image == "" {
 			config.Image = image
@@ -248,21 +256,53 @@ func AddVolumeMounts(container *corev1.Container, mounts []corev1.VolumeMount) {
 	}
 }
 
-// AddEnvVars adds environment variables to a container.
+// AddEnvVars adds environment variables to a container. Env vars whose names are already
+// present are left untouched ("additional" semantics); use AddOrReplaceEnvVars for override
+// semantics. Names are applied in sorted order — map iteration is randomized, and a
+// nondeterministic env order would re-render the pod template on every reconcile.
 func AddEnvVars(container *corev1.Container, envVars map[string]string) {
 	existingEnv := make(map[string]bool)
 	for _, e := range container.Env {
 		existingEnv[e.Name] = true
 	}
 
-	for name, value := range envVars {
+	for _, name := range sortedKeys(envVars) {
 		if !existingEnv[name] {
 			container.Env = append(container.Env, corev1.EnvVar{
 				Name:  name,
-				Value: value,
+				Value: envVars[name],
 			})
 		}
 	}
+}
+
+// AddOrReplaceEnvVars sets environment variables on a container with override semantics:
+// a same-named existing env var is replaced in place, new names are appended in sorted
+// order. Providers whose entire configuration surface is env vars (e.g. oauth2-proxy) use
+// this so SidecarConfig.EnvVars can actually change their built-in defaults.
+func AddOrReplaceEnvVars(container *corev1.Container, envVars map[string]string) {
+	index := make(map[string]int, len(container.Env))
+	for i, e := range container.Env {
+		index[e.Name] = i
+	}
+
+	for _, name := range sortedKeys(envVars) {
+		if i, ok := index[name]; ok {
+			container.Env[i] = corev1.EnvVar{Name: name, Value: envVars[name]}
+		} else {
+			container.Env = append(container.Env, corev1.EnvVar{Name: name, Value: envVars[name]})
+		}
+	}
+}
+
+// sortedKeys returns the map's keys in sorted order, for deterministic env rendering.
+func sortedKeys(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // AddPorts adds ports to a container.

--- a/pkg/sidecar/manager_test.go
+++ b/pkg/sidecar/manager_test.go
@@ -583,6 +583,42 @@ var _ = Describe("Sidecar Helper Functions", func() {
 			// VAR1 should keep old value since it already exists
 			Expect(container.Env[0].Value).To(Equal("old"))
 		})
+
+		It("should append new variables in sorted, deterministic order", func() {
+			// Map iteration is randomized; unsorted appends would re-render the pod
+			// template every reconcile (perpetual StatefulSet churn).
+			container := &corev1.Container{}
+			sidecar.AddEnvVars(container, map[string]string{
+				"ZULU": "z", "ALPHA": "a", "MIKE": "m",
+			})
+			names := make([]string, 0, len(container.Env))
+			for _, e := range container.Env {
+				names = append(names, e.Name)
+			}
+			Expect(names).To(Equal([]string{"ALPHA", "MIKE", "ZULU"}))
+		})
+	})
+
+	Describe("AddOrReplaceEnvVars", func() {
+		It("replaces same-named vars in place and appends new ones sorted", func() {
+			container := &corev1.Container{
+				Env: []corev1.EnvVar{
+					{Name: "KEEP", Value: "kept"},
+					{Name: "VAR1", Value: "old"},
+				},
+			}
+
+			sidecar.AddOrReplaceEnvVars(container, map[string]string{
+				"VAR1": "new",
+				"VAR2": "value2",
+			})
+
+			Expect(container.Env).To(HaveLen(3))
+			Expect(container.Env[0]).To(Equal(corev1.EnvVar{Name: "KEEP", Value: "kept"}))
+			Expect(container.Env[1]).To(Equal(corev1.EnvVar{Name: "VAR1", Value: "new"}),
+				"same-named var replaced in place, position preserved")
+			Expect(container.Env[2]).To(Equal(corev1.EnvVar{Name: "VAR2", Value: "value2"}))
+		})
 	})
 
 	Describe("AddPorts", func() {

--- a/pkg/sidecar/oauth2_proxy.go
+++ b/pkg/sidecar/oauth2_proxy.go
@@ -1,0 +1,283 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sidecar
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+
+	authv1alpha1 "github.com/zncdatadev/operator-go/pkg/apis/authentication/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// OAuth2ProxySidecarName is the name of the oauth2-proxy sidecar container.
+	OAuth2ProxySidecarName = "oauth2-proxy"
+	// OAuth2ProxyPort is the default oauth2-proxy listen port.
+	OAuth2ProxyPort = 4180
+	// OAuth2ProxyPortName is the default name of the oauth2-proxy container port.
+	OAuth2ProxyPortName = "oauth2-proxy"
+	// DefaultOAuth2ProxyImage is the default (pinned) oauth2-proxy image. Products
+	// override it per role group via SidecarConfig.Image.
+	DefaultOAuth2ProxyImage = "quay.io/oauth2-proxy/oauth2-proxy:v7.8.2"
+
+	// OIDCClientIDKey and OIDCClientSecretKey are the keys a client-credentials Secret
+	// must carry, matching the platform's AuthenticationClass OIDC documentation.
+	OIDCClientIDKey     = "CLIENT_ID"
+	OIDCClientSecretKey = "CLIENT_SECRET"
+)
+
+// defaultOIDCScopes are requested when the AuthenticationClass declares no scopes.
+var defaultOIDCScopes = []string{"openid", "email", "profile"}
+
+// OAuth2ProxySidecarProvider injects an oauth2-proxy authentication proxy in front of a
+// product's HTTP endpoint, wired from an AuthenticationClass OIDC provider. The proxy
+// terminates the OIDC login flow on its own port and forwards authenticated requests to the
+// product container over localhost; the product's client-facing Service should target the
+// proxy port instead of the upstream port.
+type OAuth2ProxySidecarProvider struct {
+	name                    string
+	port                    int32
+	upstreamPort            int32
+	oidcProvider            *authv1alpha1.OIDCProvider
+	clientCredentialsSecret string
+	extraScopes             []string
+	cookieSecret            string
+}
+
+// OAuth2ProxyOption customizes an OAuth2ProxySidecarProvider.
+type OAuth2ProxyOption func(*OAuth2ProxySidecarProvider)
+
+// WithOAuth2ProxyPort overrides the proxy listen port (default 4180).
+func WithOAuth2ProxyPort(port int32) OAuth2ProxyOption {
+	return func(p *OAuth2ProxySidecarProvider) { p.port = port }
+}
+
+// WithOAuth2ProxyExtraScopes appends product-requested scopes to the provider scopes.
+func WithOAuth2ProxyExtraScopes(scopes ...string) OAuth2ProxyOption {
+	return func(p *OAuth2ProxySidecarProvider) { p.extraScopes = append(p.extraScopes, scopes...) }
+}
+
+// WithOAuth2ProxyCookieSecret replaces the derived cookie secret with an explicit one
+// (e.g. sourced from a Secret by the product).
+func WithOAuth2ProxyCookieSecret(secret string) OAuth2ProxyOption {
+	return func(p *OAuth2ProxySidecarProvider) { p.cookieSecret = secret }
+}
+
+// WithOAuth2ProxyContainerName overrides the sidecar container name.
+func WithOAuth2ProxyContainerName(name string) OAuth2ProxyOption {
+	return func(p *OAuth2ProxySidecarProvider) { p.name = name }
+}
+
+// NewOAuth2ProxySidecarProvider creates an oauth2-proxy sidecar provider.
+//
+// oidcProvider is the resolved AuthenticationClass OIDC provider (the product fetches the
+// class and asserts the provider type). clientCredentialsSecret names a Secret carrying
+// CLIENT_ID/CLIENT_SECRET. upstreamPort is the product container port the proxy forwards
+// to on localhost. cookieSeed must be stable per product instance across reconciles —
+// typically the CR's UID — so the derived session cookie secret does not churn pods; see
+// DeterministicCookieSecret.
+func NewOAuth2ProxySidecarProvider(oidcProvider *authv1alpha1.OIDCProvider, clientCredentialsSecret string, upstreamPort int32, cookieSeed string, opts ...OAuth2ProxyOption) *OAuth2ProxySidecarProvider {
+	p := &OAuth2ProxySidecarProvider{
+		name:                    OAuth2ProxySidecarName,
+		port:                    OAuth2ProxyPort,
+		upstreamPort:            upstreamPort,
+		oidcProvider:            oidcProvider,
+		clientCredentialsSecret: clientCredentialsSecret,
+		cookieSecret:            DeterministicCookieSecret(cookieSeed),
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// Name returns the sidecar name.
+func (p *OAuth2ProxySidecarProvider) Name() string {
+	return p.name
+}
+
+// Validate validates that the client credentials Secret exists.
+func (p *OAuth2ProxySidecarProvider) Validate(ctx context.Context, c client.Client, namespace string) error {
+	if p.oidcProvider == nil {
+		return fmt.Errorf("oauth2-proxy: OIDC provider is required")
+	}
+	if err := ValidateSecretExists(ctx, c, namespace, p.clientCredentialsSecret); err != nil {
+		return fmt.Errorf("oauth2-proxy client credentials secret %q not found: %w", p.clientCredentialsSecret, err)
+	}
+	return nil
+}
+
+// Inject injects the oauth2-proxy sidecar into the pod spec as a native sidecar (init
+// container with restartPolicy Always), following the SidecarManager's single-owner model.
+// This method is idempotent — calling it multiple times will not duplicate the container.
+func (p *OAuth2ProxySidecarProvider) Inject(podSpec *corev1.PodSpec, config *SidecarConfig) error {
+	if config == nil {
+		config = &SidecarConfig{Enabled: true}
+	}
+
+	image := config.Image
+	if image == "" {
+		image = DefaultOAuth2ProxyImage
+	}
+	pullPolicy := corev1.PullIfNotPresent
+	if config.ImagePullPolicy != "" {
+		pullPolicy = config.ImagePullPolicy
+	}
+
+	scopes := p.oidcProvider.Scopes
+	if len(scopes) == 0 {
+		scopes = defaultOIDCScopes
+	}
+	scopes = append(append([]string{}, scopes...), p.extraScopes...)
+
+	container := &corev1.Container{
+		Name:            p.name,
+		Image:           image,
+		ImagePullPolicy: pullPolicy,
+		Env: []corev1.EnvVar{
+			{Name: "OAUTH2_PROXY_COOKIE_SECRET", Value: p.cookieSecret},
+			{
+				Name: "OAUTH2_PROXY_CLIENT_ID",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: p.clientCredentialsSecret},
+						Key:                  OIDCClientIDKey,
+					},
+				},
+			},
+			{
+				Name: "OAUTH2_PROXY_CLIENT_SECRET",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: p.clientCredentialsSecret},
+						Key:                  OIDCClientSecretKey,
+					},
+				},
+			},
+			{Name: "OAUTH2_PROXY_OIDC_ISSUER_URL", Value: OIDCIssuerURL(p.oidcProvider)},
+			{Name: "OAUTH2_PROXY_SCOPE", Value: strings.Join(scopes, " ")},
+			{Name: "OAUTH2_PROXY_PROVIDER", Value: OAuth2ProxyProviderFor(p.oidcProvider.ProviderHint)},
+			{Name: "OAUTH2_PROXY_UPSTREAMS", Value: "http://localhost:" + strconv.Itoa(int(p.upstreamPort))},
+			{Name: "OAUTH2_PROXY_HTTP_ADDRESS", Value: "0.0.0.0:" + strconv.Itoa(int(p.port))},
+			// The proxy serves plain HTTP inside the pod network; secure cookies would be
+			// dropped by browsers on http:// service URLs. Products terminating TLS in
+			// front can override via SidecarConfig.EnvVars.
+			{Name: "OAUTH2_PROXY_COOKIE_SECURE", Value: "false"},
+			{Name: "OAUTH2_PROXY_WHITELIST_DOMAINS", Value: "*"},
+			{Name: "OAUTH2_PROXY_CODE_CHALLENGE_METHOD", Value: "S256"},
+			{Name: "OAUTH2_PROXY_EMAIL_DOMAINS", Value: "*"},
+		},
+		Ports: []corev1.ContainerPort{
+			{Name: OAuth2ProxyPortName, ContainerPort: p.port, Protocol: corev1.ProtocolTCP},
+		},
+		Resources: corev1.ResourceRequirements{
+			Limits: corev1.ResourceList{
+				corev1.ResourceCPU:    resource.MustParse("600m"),
+				corev1.ResourceMemory: resource.MustParse("512Mi"),
+			},
+		},
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler: corev1.ProbeHandler{
+				HTTPGet: &corev1.HTTPGetAction{
+					Path: "/ping",
+					Port: intstr.FromInt(int(p.port)),
+				},
+			},
+			InitialDelaySeconds: 5,
+			TimeoutSeconds:      5,
+			PeriodSeconds:       10,
+		},
+	}
+
+	if config.Resources != nil {
+		container.Resources = *config.Resources
+	}
+	if config.SecurityContext != nil {
+		container.SecurityContext = config.SecurityContext
+	}
+	if len(config.EnvVars) > 0 {
+		AddEnvVars(container, config.EnvVars)
+	}
+	if len(config.VolumeMounts) > 0 {
+		AddVolumeMounts(container, config.VolumeMounts)
+	}
+	if len(config.Ports) > 0 {
+		container.Ports = config.Ports
+	}
+
+	// oauth2-proxy is a long-running traffic-serving sidecar: inject it as a native sidecar
+	// so kubelet starts it before (and stops it after) the main container.
+	container.RestartPolicy = SidecarRestartPolicy()
+	AddOrReplaceInitContainer(podSpec, container)
+
+	AddVolumes(podSpec, config.Volumes)
+
+	return nil
+}
+
+// OIDCIssuerURL renders the issuer URL for an AuthenticationClass OIDC provider:
+// scheme from the provider TLS declaration, host from hostname (plus port unless it is the
+// scheme default), and path from rootPath.
+func OIDCIssuerURL(provider *authv1alpha1.OIDCProvider) string {
+	scheme := "http"
+	if provider.TLS != nil {
+		scheme = "https"
+	}
+	issuer := url.URL{
+		Scheme: scheme,
+		Host:   provider.Hostname,
+		Path:   provider.RootPath,
+	}
+	port := provider.Port
+	isSchemeDefault := (scheme == "http" && port == 80) || (scheme == "https" && port == 443)
+	if port != 0 && !isSchemeDefault {
+		issuer.Host += ":" + strconv.Itoa(port)
+	}
+	return issuer.String()
+}
+
+// OAuth2ProxyProviderFor maps an AuthenticationClass providerHint to the oauth2-proxy
+// provider name. Hints with a dedicated oauth2-proxy implementation map to it (keycloak →
+// keycloak-oidc); anything else, including an empty hint, uses the generic oidc provider.
+func OAuth2ProxyProviderFor(providerHint string) string {
+	switch providerHint {
+	case "keycloak":
+		return "keycloak-oidc"
+	case "":
+		return "oidc"
+	default:
+		return providerHint
+	}
+}
+
+// DeterministicCookieSecret derives a stable oauth2-proxy cookie secret from a seed
+// (typically the CR UID): base64(sha256(seed)), which oauth2-proxy decodes to a 32-byte
+// secret. Deriving instead of generating keeps reconciles idempotent — a random secret
+// would roll every pod on every reconcile.
+func DeterministicCookieSecret(seed string) string {
+	hash := sha256.Sum256([]byte(seed))
+	return base64.StdEncoding.EncodeToString(hash[:])
+}

--- a/pkg/sidecar/oauth2_proxy.go
+++ b/pkg/sidecar/oauth2_proxy.go
@@ -28,7 +28,6 @@ import (
 	authv1alpha1 "github.com/zncdatadev/operator-go/pkg/apis/authentication/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -134,6 +133,9 @@ func (p *OAuth2ProxySidecarProvider) Validate(ctx context.Context, c client.Clie
 // container with restartPolicy Always), following the SidecarManager's single-owner model.
 // This method is idempotent — calling it multiple times will not duplicate the container.
 func (p *OAuth2ProxySidecarProvider) Inject(podSpec *corev1.PodSpec, config *SidecarConfig) error {
+	if p.oidcProvider == nil {
+		return fmt.Errorf("oauth2-proxy: OIDC provider is required")
+	}
 	if config == nil {
 		config = &SidecarConfig{Enabled: true}
 	}
@@ -199,17 +201,9 @@ func (p *OAuth2ProxySidecarProvider) Inject(podSpec *corev1.PodSpec, config *Sid
 				corev1.ResourceMemory: resource.MustParse("512Mi"),
 			},
 		},
-		ReadinessProbe: &corev1.Probe{
-			ProbeHandler: corev1.ProbeHandler{
-				HTTPGet: &corev1.HTTPGetAction{
-					Path: "/ping",
-					Port: intstr.FromInt(int(p.port)),
-				},
-			},
-			InitialDelaySeconds: 5,
-			TimeoutSeconds:      5,
-			PeriodSeconds:       10,
-		},
+		// Deliberately no readiness probe: as a native sidecar, an unready oauth2-proxy
+		// would gate readiness of the WHOLE pod — an issuer (IdP) outage would take the
+		// product's non-auth ports out of every Service, not just the login flow.
 	}
 
 	if config.Resources != nil {
@@ -274,10 +268,13 @@ func OAuth2ProxyProviderFor(providerHint string) string {
 }
 
 // DeterministicCookieSecret derives a stable oauth2-proxy cookie secret from a seed
-// (typically the CR UID): base64(sha256(seed)), which oauth2-proxy decodes to a 32-byte
-// secret. Deriving instead of generating keeps reconciles idempotent — a random secret
-// would roll every pod on every reconcile.
+// (typically the CR UID): the URL-safe, unpadded base64 of sha256(seed), which
+// oauth2-proxy's SecretBytes decodes to a 32-byte secret. URL-safe encoding is load-bearing:
+// oauth2-proxy attempts ONLY base64.URLEncoding — a standard-encoded value containing '+'
+// or '/' fails that decode and falls back to the raw 43/44-byte string, an invalid secret
+// length that crash-loops the proxy. Deriving instead of generating keeps reconciles
+// idempotent — a random secret would roll every pod on every reconcile.
 func DeterministicCookieSecret(seed string) string {
 	hash := sha256.Sum256([]byte(seed))
-	return base64.StdEncoding.EncodeToString(hash[:])
+	return base64.RawURLEncoding.EncodeToString(hash[:])
 }

--- a/pkg/sidecar/oauth2_proxy.go
+++ b/pkg/sidecar/oauth2_proxy.go
@@ -118,6 +118,14 @@ func (p *OAuth2ProxySidecarProvider) Name() string {
 	return p.name
 }
 
+// OwnsImage implements OwnImageProvider: oauth2-proxy ships as its own upstream image, so
+// SetProductImage must not fill an empty SidecarConfig.Image with the product image —
+// DefaultOAuth2ProxyImage stays reachable for a plain `&SidecarConfig{Enabled: true}`
+// registration.
+func (p *OAuth2ProxySidecarProvider) OwnsImage() bool {
+	return true
+}
+
 // Validate validates that the client credentials Secret exists.
 func (p *OAuth2ProxySidecarProvider) Validate(ctx context.Context, c client.Client, namespace string) error {
 	if p.oidcProvider == nil {
@@ -147,6 +155,13 @@ func (p *OAuth2ProxySidecarProvider) Inject(podSpec *corev1.PodSpec, config *Sid
 	pullPolicy := corev1.PullIfNotPresent
 	if config.ImagePullPolicy != "" {
 		pullPolicy = config.ImagePullPolicy
+	}
+
+	// The effective listen port: a SidecarConfig.Ports override wins, so the declared port
+	// and the OAUTH2_PROXY_HTTP_ADDRESS the proxy actually binds can never diverge.
+	port := p.port
+	if len(config.Ports) > 0 {
+		port = config.Ports[0].ContainerPort
 	}
 
 	scopes := p.oidcProvider.Scopes
@@ -183,17 +198,17 @@ func (p *OAuth2ProxySidecarProvider) Inject(podSpec *corev1.PodSpec, config *Sid
 			{Name: "OAUTH2_PROXY_SCOPE", Value: strings.Join(scopes, " ")},
 			{Name: "OAUTH2_PROXY_PROVIDER", Value: OAuth2ProxyProviderFor(p.oidcProvider.ProviderHint)},
 			{Name: "OAUTH2_PROXY_UPSTREAMS", Value: "http://localhost:" + strconv.Itoa(int(p.upstreamPort))},
-			{Name: "OAUTH2_PROXY_HTTP_ADDRESS", Value: "0.0.0.0:" + strconv.Itoa(int(p.port))},
+			{Name: "OAUTH2_PROXY_HTTP_ADDRESS", Value: "0.0.0.0:" + strconv.Itoa(int(port))},
 			// The proxy serves plain HTTP inside the pod network; secure cookies would be
 			// dropped by browsers on http:// service URLs. Products terminating TLS in
-			// front can override via SidecarConfig.EnvVars.
+			// front override via SidecarConfig.EnvVars (applied with replace semantics below).
 			{Name: "OAUTH2_PROXY_COOKIE_SECURE", Value: "false"},
 			{Name: "OAUTH2_PROXY_WHITELIST_DOMAINS", Value: "*"},
 			{Name: "OAUTH2_PROXY_CODE_CHALLENGE_METHOD", Value: "S256"},
 			{Name: "OAUTH2_PROXY_EMAIL_DOMAINS", Value: "*"},
 		},
 		Ports: []corev1.ContainerPort{
-			{Name: OAuth2ProxyPortName, ContainerPort: p.port, Protocol: corev1.ProtocolTCP},
+			{Name: OAuth2ProxyPortName, ContainerPort: port, Protocol: corev1.ProtocolTCP},
 		},
 		Resources: corev1.ResourceRequirements{
 			Limits: corev1.ResourceList{
@@ -212,8 +227,11 @@ func (p *OAuth2ProxySidecarProvider) Inject(podSpec *corev1.PodSpec, config *Sid
 	if config.SecurityContext != nil {
 		container.SecurityContext = config.SecurityContext
 	}
+	// Replace semantics, not add-only: oauth2-proxy's whole configuration surface IS env
+	// vars, so SidecarConfig.EnvVars must be able to change the built-in defaults (e.g.
+	// OAUTH2_PROXY_COOKIE_SECURE=true behind TLS, tightening OAUTH2_PROXY_EMAIL_DOMAINS).
 	if len(config.EnvVars) > 0 {
-		AddEnvVars(container, config.EnvVars)
+		AddOrReplaceEnvVars(container, config.EnvVars)
 	}
 	if len(config.VolumeMounts) > 0 {
 		AddVolumeMounts(container, config.VolumeMounts)

--- a/pkg/sidecar/oauth2_proxy_test.go
+++ b/pkg/sidecar/oauth2_proxy_test.go
@@ -18,6 +18,7 @@ package sidecar_test
 
 import (
 	"encoding/base64"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -164,18 +165,48 @@ var _ = Describe("OAuth2ProxyProviderFor", func() {
 })
 
 var _ = Describe("DeterministicCookieSecret", func() {
-	It("is stable and decodes to 32 bytes", func() {
+	It("is stable and URL-safe-decodes to 32 bytes, as oauth2-proxy requires", func() {
 		first := sidecar.DeterministicCookieSecret("cr-uid")
 		second := sidecar.DeterministicCookieSecret("cr-uid")
 		Expect(first).To(Equal(second))
 
-		raw, err := base64.StdEncoding.DecodeString(first)
+		// oauth2-proxy's SecretBytes attempts ONLY unpadded URL-safe base64; a value with
+		// '+' or '/' would fall back to the raw string (invalid length) and crash the proxy.
+		Expect(first).NotTo(ContainSubstring("+"))
+		Expect(first).NotTo(ContainSubstring("/"))
+		Expect(first).NotTo(ContainSubstring("="))
+		raw, err := base64.RawURLEncoding.DecodeString(first)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(raw).To(HaveLen(32))
+	})
+
+	It("stays URL-safe across many seeds", func() {
+		for i := 0; i < 256; i++ {
+			secret := sidecar.DeterministicCookieSecret(fmt.Sprintf("seed-%d", i))
+			_, err := base64.RawURLEncoding.DecodeString(secret)
+			Expect(err).NotTo(HaveOccurred(), "seed-%d", i)
+		}
 	})
 
 	It("differs per seed", func() {
 		Expect(sidecar.DeterministicCookieSecret("a")).NotTo(
 			Equal(sidecar.DeterministicCookieSecret("b")))
+	})
+})
+
+var _ = Describe("OAuth2ProxySidecarProvider readiness coupling", func() {
+	It("injects no readiness probe (an unready native sidecar would gate the whole pod)", func() {
+		podSpec := &corev1.PodSpec{Containers: []corev1.Container{{Name: "node"}}}
+		provider := sidecar.NewOAuth2ProxySidecarProvider(
+			keycloakProvider(), "oidc-credentials", 18080, "cr-uid")
+
+		Expect(provider.Inject(podSpec, nil)).To(Succeed())
+		Expect(podSpec.InitContainers[0].ReadinessProbe).To(BeNil())
+	})
+
+	It("rejects injection without an OIDC provider", func() {
+		podSpec := &corev1.PodSpec{Containers: []corev1.Container{{Name: "node"}}}
+		provider := sidecar.NewOAuth2ProxySidecarProvider(nil, "oidc-credentials", 18080, "cr-uid")
+		Expect(provider.Inject(podSpec, nil)).To(MatchError(ContainSubstring("OIDC provider is required")))
 	})
 })

--- a/pkg/sidecar/oauth2_proxy_test.go
+++ b/pkg/sidecar/oauth2_proxy_test.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sidecar_test
+
+import (
+	"encoding/base64"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	authv1alpha1 "github.com/zncdatadev/operator-go/pkg/apis/authentication/v1alpha1"
+	"github.com/zncdatadev/operator-go/pkg/sidecar"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func keycloakProvider() *authv1alpha1.OIDCProvider {
+	return &authv1alpha1.OIDCProvider{
+		Hostname:     "keycloak.test-ns.svc.cluster.local",
+		Port:         8080,
+		RootPath:     "/realms/kubedoop",
+		ProviderHint: "keycloak",
+		Scopes:       []string{"openid", "email", "profile"},
+	}
+}
+
+func envByName(container *corev1.Container) map[string]corev1.EnvVar {
+	out := map[string]corev1.EnvVar{}
+	for _, e := range container.Env {
+		out[e.Name] = e
+	}
+	return out
+}
+
+var _ = Describe("OAuth2ProxySidecarProvider", func() {
+	var podSpec *corev1.PodSpec
+
+	BeforeEach(func() {
+		podSpec = &corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "node"}},
+		}
+	})
+
+	It("injects a native sidecar with the full OAUTH2_PROXY env set", func() {
+		provider := sidecar.NewOAuth2ProxySidecarProvider(
+			keycloakProvider(), "oidc-credentials", 18080, "cr-uid")
+
+		Expect(provider.Inject(podSpec, nil)).To(Succeed())
+
+		Expect(podSpec.InitContainers).To(HaveLen(1))
+		container := &podSpec.InitContainers[0]
+		Expect(container.Name).To(Equal(sidecar.OAuth2ProxySidecarName))
+		Expect(container.Image).To(Equal(sidecar.DefaultOAuth2ProxyImage))
+		Expect(container.RestartPolicy).NotTo(BeNil())
+		Expect(*container.RestartPolicy).To(Equal(corev1.ContainerRestartPolicyAlways))
+
+		envs := envByName(container)
+		Expect(envs["OAUTH2_PROXY_OIDC_ISSUER_URL"].Value).To(
+			Equal("http://keycloak.test-ns.svc.cluster.local:8080/realms/kubedoop"))
+		Expect(envs["OAUTH2_PROXY_PROVIDER"].Value).To(Equal("keycloak-oidc"))
+		Expect(envs["OAUTH2_PROXY_SCOPE"].Value).To(Equal("openid email profile"))
+		Expect(envs["OAUTH2_PROXY_UPSTREAMS"].Value).To(Equal("http://localhost:18080"))
+		Expect(envs["OAUTH2_PROXY_HTTP_ADDRESS"].Value).To(Equal("0.0.0.0:4180"))
+		Expect(envs["OAUTH2_PROXY_COOKIE_SECURE"].Value).To(Equal("false"))
+		Expect(envs["OAUTH2_PROXY_CODE_CHALLENGE_METHOD"].Value).To(Equal("S256"))
+		Expect(envs["OAUTH2_PROXY_EMAIL_DOMAINS"].Value).To(Equal("*"))
+		Expect(envs["OAUTH2_PROXY_WHITELIST_DOMAINS"].Value).To(Equal("*"))
+
+		Expect(envs["OAUTH2_PROXY_CLIENT_ID"].ValueFrom.SecretKeyRef.Name).To(Equal("oidc-credentials"))
+		Expect(envs["OAUTH2_PROXY_CLIENT_ID"].ValueFrom.SecretKeyRef.Key).To(Equal("CLIENT_ID"))
+		Expect(envs["OAUTH2_PROXY_CLIENT_SECRET"].ValueFrom.SecretKeyRef.Key).To(Equal("CLIENT_SECRET"))
+
+		Expect(container.Ports).To(HaveLen(1))
+		Expect(container.Ports[0].ContainerPort).To(Equal(int32(4180)))
+	})
+
+	It("is idempotent", func() {
+		provider := sidecar.NewOAuth2ProxySidecarProvider(
+			keycloakProvider(), "oidc-credentials", 18080, "cr-uid")
+
+		Expect(provider.Inject(podSpec, nil)).To(Succeed())
+		Expect(provider.Inject(podSpec, nil)).To(Succeed())
+		Expect(podSpec.InitContainers).To(HaveLen(1))
+	})
+
+	It("appends extra scopes after the provider scopes", func() {
+		provider := sidecar.NewOAuth2ProxySidecarProvider(
+			keycloakProvider(), "oidc-credentials", 18080, "cr-uid",
+			sidecar.WithOAuth2ProxyExtraScopes("groups"))
+
+		Expect(provider.Inject(podSpec, nil)).To(Succeed())
+		envs := envByName(&podSpec.InitContainers[0])
+		Expect(envs["OAUTH2_PROXY_SCOPE"].Value).To(Equal("openid email profile groups"))
+	})
+
+	It("falls back to the default scopes when the provider declares none", func() {
+		oidc := keycloakProvider()
+		oidc.Scopes = nil
+		provider := sidecar.NewOAuth2ProxySidecarProvider(oidc, "oidc-credentials", 18080, "cr-uid")
+
+		Expect(provider.Inject(podSpec, nil)).To(Succeed())
+		envs := envByName(&podSpec.InitContainers[0])
+		Expect(envs["OAUTH2_PROXY_SCOPE"].Value).To(Equal("openid email profile"))
+	})
+
+	It("honors port and image overrides", func() {
+		provider := sidecar.NewOAuth2ProxySidecarProvider(
+			keycloakProvider(), "oidc-credentials", 8080, "cr-uid",
+			sidecar.WithOAuth2ProxyPort(9999))
+
+		Expect(provider.Inject(podSpec, &sidecar.SidecarConfig{Image: "custom/oauth2-proxy:v0.0.1"})).To(Succeed())
+		container := &podSpec.InitContainers[0]
+		Expect(container.Image).To(Equal("custom/oauth2-proxy:v0.0.1"))
+		envs := envByName(container)
+		Expect(envs["OAUTH2_PROXY_HTTP_ADDRESS"].Value).To(Equal("0.0.0.0:9999"))
+		Expect(container.Ports[0].ContainerPort).To(Equal(int32(9999)))
+	})
+})
+
+var _ = Describe("OIDCIssuerURL", func() {
+	It("includes a non-default port", func() {
+		Expect(sidecar.OIDCIssuerURL(keycloakProvider())).To(
+			Equal("http://keycloak.test-ns.svc.cluster.local:8080/realms/kubedoop"))
+	})
+
+	It("omits the scheme-default port", func() {
+		oidc := keycloakProvider()
+		oidc.Port = 80
+		Expect(sidecar.OIDCIssuerURL(oidc)).To(
+			Equal("http://keycloak.test-ns.svc.cluster.local/realms/kubedoop"))
+	})
+
+	It("uses https when the provider declares TLS", func() {
+		oidc := keycloakProvider()
+		oidc.TLS = &authv1alpha1.OIDCTls{}
+		oidc.Port = 443
+		Expect(sidecar.OIDCIssuerURL(oidc)).To(
+			Equal("https://keycloak.test-ns.svc.cluster.local/realms/kubedoop"))
+	})
+})
+
+var _ = Describe("OAuth2ProxyProviderFor", func() {
+	It("maps keycloak to keycloak-oidc", func() {
+		Expect(sidecar.OAuth2ProxyProviderFor("keycloak")).To(Equal("keycloak-oidc"))
+	})
+	It("defaults an empty hint to the generic oidc provider", func() {
+		Expect(sidecar.OAuth2ProxyProviderFor("")).To(Equal("oidc"))
+	})
+	It("passes other hints through", func() {
+		Expect(sidecar.OAuth2ProxyProviderFor("oidc")).To(Equal("oidc"))
+	})
+})
+
+var _ = Describe("DeterministicCookieSecret", func() {
+	It("is stable and decodes to 32 bytes", func() {
+		first := sidecar.DeterministicCookieSecret("cr-uid")
+		second := sidecar.DeterministicCookieSecret("cr-uid")
+		Expect(first).To(Equal(second))
+
+		raw, err := base64.StdEncoding.DecodeString(first)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(raw).To(HaveLen(32))
+	})
+
+	It("differs per seed", func() {
+		Expect(sidecar.DeterministicCookieSecret("a")).NotTo(
+			Equal(sidecar.DeterministicCookieSecret("b")))
+	})
+})

--- a/pkg/sidecar/oauth2_proxy_test.go
+++ b/pkg/sidecar/oauth2_proxy_test.go
@@ -116,6 +116,58 @@ var _ = Describe("OAuth2ProxySidecarProvider", func() {
 		Expect(envs["OAUTH2_PROXY_SCOPE"].Value).To(Equal("openid email profile"))
 	})
 
+	It("lets SidecarConfig.EnvVars override built-in defaults (replace semantics)", func() {
+		provider := sidecar.NewOAuth2ProxySidecarProvider(
+			keycloakProvider(), "oidc-credentials", 18080, "cr-uid")
+
+		Expect(provider.Inject(podSpec, &sidecar.SidecarConfig{
+			EnvVars: map[string]string{
+				"OAUTH2_PROXY_COOKIE_SECURE": "true",
+				"OAUTH2_PROXY_EXTRA_KNOB":    "custom",
+			},
+		})).To(Succeed())
+
+		envs := envByName(&podSpec.InitContainers[0])
+		Expect(envs["OAUTH2_PROXY_COOKIE_SECURE"].Value).To(Equal("true"),
+			"a same-named default must be replaced, not silently kept")
+		Expect(envs["OAUTH2_PROXY_EXTRA_KNOB"].Value).To(Equal("custom"))
+
+		names := map[string]int{}
+		for _, e := range podSpec.InitContainers[0].Env {
+			names[e.Name]++
+		}
+		Expect(names["OAUTH2_PROXY_COOKIE_SECURE"]).To(Equal(1), "no duplicate env entries")
+	})
+
+	It("keeps the declared port and HTTP_ADDRESS aligned under a SidecarConfig.Ports override", func() {
+		provider := sidecar.NewOAuth2ProxySidecarProvider(
+			keycloakProvider(), "oidc-credentials", 18080, "cr-uid")
+
+		Expect(provider.Inject(podSpec, &sidecar.SidecarConfig{
+			Ports: []corev1.ContainerPort{{Name: "auth", ContainerPort: 9999}},
+		})).To(Succeed())
+
+		container := &podSpec.InitContainers[0]
+		Expect(container.Ports[0].ContainerPort).To(Equal(int32(9999)))
+		envs := envByName(container)
+		Expect(envs["OAUTH2_PROXY_HTTP_ADDRESS"].Value).To(Equal("0.0.0.0:9999"),
+			"the proxy must actually listen on the declared port")
+	})
+
+	It("keeps its pinned image when the manager propagates the product image", func() {
+		manager := sidecar.NewSidecarManager()
+		provider := sidecar.NewOAuth2ProxySidecarProvider(
+			keycloakProvider(), "oidc-credentials", 18080, "cr-uid")
+		manager.Register(provider, &sidecar.SidecarConfig{Enabled: true})
+
+		Expect(manager.SetProductImage("quay.io/zncdatadev/spark-k8s:3.5.5", corev1.PullIfNotPresent)).To(Succeed())
+		Expect(manager.InjectAll(podSpec)).To(Succeed())
+
+		Expect(podSpec.InitContainers).To(HaveLen(1))
+		Expect(podSpec.InitContainers[0].Image).To(Equal(sidecar.DefaultOAuth2ProxyImage),
+			"OwnsImage must shield the provider from product-image propagation")
+	})
+
 	It("honors port and image overrides", func() {
 		provider := sidecar.NewOAuth2ProxySidecarProvider(
 			keycloakProvider(), "oidc-credentials", 8080, "cr-uid",


### PR DESCRIPTION
## Summary

Four framework enhancements extracted from (and consumed by) the spark-k8s-operator migration to the GenericReconciler framework, plus fixes for defects surfaced by an adversarial review and a full chainsaw e2e run of the migrated operator. Each commit is an independent unit:

### 1. `fix(builder)`: podOverrides applied via full strategic merge (c0bc068 + follow-ups)
`applyPodOverrides` copied only a whitelist of pod fields, silently dropping container-level overrides (resources, env, volumeMounts, extra containers) — even though `docs/architecture.md` §2.6 documents podOverrides as a Kubernetes Strategic Merge Patch. Now a real strategic merge, with three correctness guards found during review:
- `PodSpec.Containers` is the one field without `omitempty`: a nil slice marshaled as `"containers": null` — a strategic-merge DELETE that wiped every container from an annotations-only override. Normalized to an empty list.
- the primary container must carry its final name **before** the merge: the post-build rename to `MainContainerName` meant an override addressing the documented container name (e.g. spark's `node`) appended a phantom, image-less container that the API server rejected. New `StatefulSetBuilder.WithMainContainerName`, passed through by `BaseRoleGroupHandler`.
- selector labels are re-asserted after the merge so an override can never break the immutable `.spec.selector` match.

Note the intentional semantic change: security contexts now deep-merge per field instead of replacing wholesale (an override must state `runAsNonRoot: false` explicitly alongside `runAsUser: 0`). Docs already describe merge semantics; the two tests asserting REPLACE were updated.

### 2. `feat(s3)`: S3 resolver module + plain credential secret volumes (c0e3cb4)
hive and spark each hand-roll ~200 near-identical lines for the S3Bucket/S3Connection inline-or-reference chain, the credential CSI volume and the AWS env exports — hive's `s3.go` explicitly defers path-style rendering "to the operator-go S3 rendering helper". This adds `pkg/s3` (ResolveConnection/ResolveBucket → ConnectionInfo/BucketInfo, faithful `S3AProperties`, `CredentialsProvisioner` under `/kubedoop/secret/<volume>`, `CredentialsExportScript`) and, in `pkg/security`, the `CredentialsVolume` registration for format-less credential secrets plus `ScopeString` — which renders the secret-operator's `service=<name>` / `listener-volume=<name>` convention (bare service names, as products emit today, are silently skipped by the CSI scope parser).

### 3. `feat(sidecar)`: oauth2-proxy provider (4e782de)
OIDC-fronting products hand-roll the oauth2-proxy container (spark today with a `:latest` image; superset/airflow have the same need). The provider builds it from a resolved AuthenticationClass `OIDCProvider` + client-credentials Secret, injected as a native sidecar via the SidecarManager. Review fixes folded in:
- `DeterministicCookieSecret` now emits unpadded URL-safe base64: oauth2-proxy's `SecretBytes` attempts **only** URL-safe decoding, so a standard-base64 value containing `+`/`/` (~74% of seeds) fell back to a 43/44-byte raw string — an invalid length that crash-loops the proxy.
- no readiness probe: an unready native sidecar gates the whole pod, so an IdP outage would take the product's non-auth ports out of every Service.
- image pinned to `quay.io/oauth2-proxy/oauth2-proxy:v7.8.2`, overridable per role group.

### 4. `feat(productlogging)`: LogFileName override (03400ba)
The rolling log-file name was hard-derived as `<container><suffix>`; spark's vector contract pins `spark.log4j2.xml` while the container must be named `node`. The override validates the framework suffix (it selects the Vector edge parser) and rejects path separators.

### 5. `fix(reconciler)`: role-level config no longer silently dropped (633811a)
Only logging and overrides were merged role→group; role-level `config` (resources/affinity/gracefulShutdownTimeout) never reached the role groups. New exported `MergeRoleGroupConfig` (group wins per field) applied in `buildRoleGroupContext`. hive/zookeeper inherit the fix.

## Validation

- `make test` (all packages) and `make lint` (0 issues) green.
- Consumed by the spark-k8s-operator refactor (`replace`d to this branch): **all six chainsaw e2e suites pass unchanged** — smoke/{cluster-operation,observability,override-pdb,submit-task}, logging (Vector aggregator receives `container=node`, `file=spark.log4j2.xml`, `errors=[]`), oidc (full Keycloak login flow through the native-sidecar proxy) — on kind v1.35.0.

## Known follow-ups (not in this PR)

- The cookie secret derives from the CR UID (not secret material) and lands in the pod spec as plain env — same posture as the previous hand-rolled spark implementation; a Secret-backed option is a natural follow-up.
- `applyPodOverrides` still silently keeps the built template if the strategic merge itself errors (structurally unreachable for valid templates); surfacing a builder error would need a `Build() error` signature change.
- TLS CA delivery for https S3 endpoints remains the product's concern (`ConnectionInfo.TLS` is exposed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)