### PR TITLE
fix(sidecar): stop leaking the oauth2-proxy session key and admitting everyone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,30 @@ changes are listed below.**
 - `testutil.ClusterWrapper` and `testutil.WrapMockCluster` are removed; `testutil.MockCluster`
   implements `common.ClusterInterface` directly and `testutil.MockRoleGroupHandler` is bound to
   `*testutil.MockCluster`.
+- `sidecar.NewOAuth2ProxySidecarProvider` lost its `cookieSeed` parameter: the session cookie
+  secret is now read from a Secret via `secretKeyRef` (the client-credentials Secret's
+  `COOKIE_SECRET` key by default; relocate with `WithOAuth2ProxyCookieSecretRef`). Add that key to
+  the Secret, generating the value once with the new `sidecar.GenerateCookieSecret()`.
+  `sidecar.DeterministicCookieSecret` and `WithOAuth2ProxyCookieSecret` are removed — both produced
+  a value that ended up inlined in the PodSpec.
+- The oauth2-proxy provider now requires an explicit authorization policy. Pass
+  `WithOAuth2ProxyEmailDomains(...)` or `WithOAuth2ProxyAllowAllEmails()`; `Inject` and `Validate`
+  both fail without one. `OAUTH2_PROXY_WHITELIST_DOMAINS` is no longer emitted by default — declare
+  redirect targets with `WithOAuth2ProxyWhitelistDomains(...)`.
+
+### security
+
+- The oauth2-proxy session cookie secret is no longer inlined into the PodSpec as an env `value`.
+  It signs every session the proxy trusts, so anyone able to `get pod` could forge a session and
+  bypass authentication; it was additionally derived (via SHA-256) from a caller-supplied seed that
+  products naturally set to the CR's UID, making it reconstructible by anyone who could read the
+  CR. It is now referenced with `secretKeyRef` like the client credentials beside it, generated
+  from `crypto/rand`, and `Validate` fails the reconcile when the referenced key is absent instead
+  of letting the proxy crash-loop.
+- `OAUTH2_PROXY_EMAIL_DOMAINS` no longer defaults to `*`. Authenticating against an identity
+  provider is not authorization for the cluster: on a shared realm that default admitted every
+  account the IdP could issue a token for. `OAUTH2_PROXY_WHITELIST_DOMAINS` no longer defaults to
+  `*` either, which had made the post-login `rd` parameter an open redirect.
 
 ### features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,10 +75,11 @@ changes are listed below.**
   the Secret, generating the value once with the new `sidecar.GenerateCookieSecret()`.
   `sidecar.DeterministicCookieSecret` and `WithOAuth2ProxyCookieSecret` are removed — both produced
   a value that ended up inlined in the PodSpec.
-- The oauth2-proxy provider now requires an explicit authorization policy. Pass
+- The oauth2-proxy provider now requires exactly one explicit authorization policy. Pass
   `WithOAuth2ProxyEmailDomains(...)` or `WithOAuth2ProxyAllowAllEmails()`; `Inject` and `Validate`
-  both fail without one. `OAUTH2_PROXY_WHITELIST_DOMAINS` is no longer emitted by default — declare
-  redirect targets with `WithOAuth2ProxyWhitelistDomains(...)`.
+  both fail with neither, and with both (allow-all would otherwise win and silently discard the
+  domain list). `OAUTH2_PROXY_WHITELIST_DOMAINS` is no longer emitted by default — declare redirect
+  targets with `WithOAuth2ProxyWhitelistDomains(...)`.
 
 ### security
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -154,9 +154,11 @@ front of the product's HTTP port.
   - **Authorization**: authenticating against an IdP is not authorization for this cluster. On a
     shared realm, every account the IdP can issue a token for would otherwise reach the product, so
     the provider requires an explicit policy — `WithOAuth2ProxyEmailDomains(...)` to restrict
-    logins, or `WithOAuth2ProxyAllowAllEmails()` to admit everyone deliberately. Building a proxy
-    without either fails. Post-login redirects are likewise closed by default (the proxy's own host
-    only); `WithOAuth2ProxyWhitelistDomains(...)` widens that, one domain at a time.
+    logins, or `WithOAuth2ProxyAllowAllEmails()` to admit everyone deliberately. **Exactly one**:
+    building a proxy with neither fails, and so does building one with both, because "allow all"
+    would otherwise win and silently discard the domain list. Post-login redirects are likewise
+    closed by default (the proxy's own host only); `WithOAuth2ProxyWhitelistDomains(...)` widens
+    that, one domain at a time.
   - **Readiness**: the sidecar deliberately has no readiness probe. As a native sidecar it would
     otherwise gate the whole Pod's readiness, taking the product's non-auth ports out of every
     Service during an IdP outage.

--- a/docs/security.md
+++ b/docs/security.md
@@ -132,19 +132,31 @@ front of the product's HTTP port.
   - **Configuration source**: an `AuthenticationClass` with an `OIDCProvider`
     (`pkg/apis/authentication/v1alpha1`). The product resolves the class and passes the provider to
     `sidecar.NewOAuth2ProxySidecarProvider(oidcProvider, clientCredentialsSecret, upstreamPort,
-    cookieSeed, opts...)`.
+    opts...)`.
   - **Credential injection**: a **plain Kubernetes Secret** named by `clientCredentialsSecret`,
-    carrying the keys `CLIENT_ID` and `CLIENT_SECRET` (`sidecar.OIDCClientIDKey` /
-    `OIDCClientSecretKey`). They reach the sidecar as `OAUTH2_PROXY_CLIENT_ID` /
-    `OAUTH2_PROXY_CLIENT_SECRET` env vars via `secretKeyRef` — the credentials are **not** mounted
-    through the secret-operator CSI driver, and they are never written into a config file.
-    `Validate` fails the reconcile before the StatefulSet is applied if that Secret is missing.
+    carrying the keys `CLIENT_ID`, `CLIENT_SECRET` and `COOKIE_SECRET` (`sidecar.OIDCClientIDKey` /
+    `OIDCClientSecretKey` / `OIDCCookieSecretKey`). All three reach the sidecar as
+    `OAUTH2_PROXY_*` env vars via `secretKeyRef` — they are **not** mounted through the
+    secret-operator CSI driver, and they are never written into a config file or inlined into the
+    PodSpec. `Validate` fails the reconcile before the StatefulSet is applied if the Secret is
+    missing, or if it does not carry the cookie-secret key.
   - **Configuration of the proxy**: the provider sets the `OAUTH2_PROXY_*` env vars (issuer URL,
     scopes, provider hint, upstream, listen address, PKCE `S256`). The SDK does **not** inject JVM
     system properties or configure the product application's own OIDC module — a product that needs
     in-application OIDC generates that configuration itself.
-  - **Cookie secret**: derived deterministically from a caller-supplied seed (typically the CR's
-    UID) via `DeterministicCookieSecret`, so it does not churn pods across reconciles.
+  - **Cookie secret**: read from the Secret above (relocate it with
+    `WithOAuth2ProxyCookieSecretRef`). It is **never** derived from the CR and never inlined: this
+    value signs every session cookie the proxy subsequently trusts, so anything readable through
+    the API — a UID, a name, an env `value` in the PodSpec — would let a reader forge a session and
+    bypass authentication entirely. Generate it once with `sidecar.GenerateCookieSecret()` and
+    store it; the value must stay stable, or each reconcile would roll the pods and log every user
+    out.
+  - **Authorization**: authenticating against an IdP is not authorization for this cluster. On a
+    shared realm, every account the IdP can issue a token for would otherwise reach the product, so
+    the provider requires an explicit policy — `WithOAuth2ProxyEmailDomains(...)` to restrict
+    logins, or `WithOAuth2ProxyAllowAllEmails()` to admit everyone deliberately. Building a proxy
+    without either fails. Post-login redirects are likewise closed by default (the proxy's own host
+    only); `WithOAuth2ProxyWhitelistDomains(...)` widens that, one domain at a time.
   - **Readiness**: the sidecar deliberately has no readiness probe. As a native sidecar it would
     otherwise gate the whole Pod's readiness, taking the product's non-auth ports out of every
     Service during an IdP outage.

--- a/pkg/sidecar/oauth2_proxy.go
+++ b/pkg/sidecar/oauth2_proxy.go
@@ -104,7 +104,8 @@ func WithOAuth2ProxyCookieSecretRef(ref *corev1.SecretKeySelector) OAuth2ProxyOp
 // domains (OAUTH2_PROXY_EMAIL_DOMAINS). Authenticating against an identity provider is not the
 // same as being authorized for this cluster: on a shared IdP — a public provider, or a
 // corporate Keycloak carrying a customer realm — every account it can issue a token for would
-// otherwise reach the product. Either this or WithOAuth2ProxyAllowAllEmails is required.
+// otherwise reach the product. Exactly one of this and WithOAuth2ProxyAllowAllEmails is
+// required; setting both is an error rather than a silent widening.
 func WithOAuth2ProxyEmailDomains(domains ...string) OAuth2ProxyOption {
 	return func(p *OAuth2ProxySidecarProvider) { p.emailDomains = append(p.emailDomains, domains...) }
 }
@@ -112,7 +113,8 @@ func WithOAuth2ProxyEmailDomains(domains ...string) OAuth2ProxyOption {
 // WithOAuth2ProxyAllowAllEmails admits every account the identity provider authenticates
 // ("*"). This is the correct choice for an IdP realm dedicated to this cluster, and a serious
 // mistake for a shared one — it is spelled out as its own option so that it is a decision in
-// the product's code, greppable at review time, rather than a default nobody chose.
+// the product's code, greppable at review time, rather than a default nobody chose. Mutually
+// exclusive with WithOAuth2ProxyEmailDomains.
 func WithOAuth2ProxyAllowAllEmails() OAuth2ProxyOption {
 	return func(p *OAuth2ProxySidecarProvider) { p.allowAllEmails = true }
 }
@@ -206,9 +208,20 @@ func (p *OAuth2ProxySidecarProvider) Validate(ctx context.Context, c client.Clie
 	return nil
 }
 
-// validateAuthorization enforces that an authorization policy was chosen explicitly.
+// validateAuthorization enforces that exactly one authorization policy was chosen.
+//
+// Both directions are errors. Neither policy set would silently admit or reject depending on
+// oauth2-proxy's own defaults; both set would resolve to "*" and silently discard the domain
+// list, so a caller adding WithOAuth2ProxyEmailDomains to an existing
+// WithOAuth2ProxyAllowAllEmails call — the exact shape of "let me tighten this" — would change
+// nothing and be told nothing.
 func (p *OAuth2ProxySidecarProvider) validateAuthorization() error {
-	if len(p.emailDomains) == 0 && !p.allowAllEmails {
+	switch {
+	case len(p.emailDomains) > 0 && p.allowAllEmails:
+		return fmt.Errorf(
+			"oauth2-proxy: conflicting authorization policy; WithOAuth2ProxyEmailDomains(%s) and WithOAuth2ProxyAllowAllEmails are mutually exclusive — drop one, because admitting every account would silently override the domain list",
+			strings.Join(p.emailDomains, ", "))
+	case len(p.emailDomains) == 0 && !p.allowAllEmails:
 		return fmt.Errorf(
 			"oauth2-proxy: no authorization policy configured; pass WithOAuth2ProxyEmailDomains to restrict logins, or WithOAuth2ProxyAllowAllEmails to admit every account the identity provider authenticates")
 	}
@@ -389,8 +402,9 @@ func OAuth2ProxyProviderFor(providerHint string) string {
 	}
 }
 
-// emailDomainsValue renders OAUTH2_PROXY_EMAIL_DOMAINS. validateAuthorization has already
-// established that exactly one of the two sources is set.
+// emailDomainsValue renders OAUTH2_PROXY_EMAIL_DOMAINS. Both call sites run
+// validateAuthorization first, which rejects "neither set" and "both set", so exactly one of the
+// two branches below is reachable.
 func (p *OAuth2ProxySidecarProvider) emailDomainsValue() string {
 	if p.allowAllEmails {
 		return "*"

--- a/pkg/sidecar/oauth2_proxy.go
+++ b/pkg/sidecar/oauth2_proxy.go
@@ -18,7 +18,7 @@ package sidecar
 
 import (
 	"context"
-	"crypto/sha256"
+	"crypto/rand"
 	"encoding/base64"
 	"fmt"
 	"net/url"
@@ -46,6 +46,10 @@ const (
 	// must carry, matching the platform's AuthenticationClass OIDC documentation.
 	OIDCClientIDKey     = "CLIENT_ID"
 	OIDCClientSecretKey = "CLIENT_SECRET"
+	// OIDCCookieSecretKey is the key the session cookie secret is read from. It defaults to
+	// living in the same Secret as the client credentials, so a product wiring OIDC creates one
+	// Secret with three keys. Generate the value with GenerateCookieSecret.
+	OIDCCookieSecretKey = "COOKIE_SECRET"
 )
 
 // defaultOIDCScopes are requested when the AuthenticationClass declares no scopes.
@@ -63,7 +67,10 @@ type OAuth2ProxySidecarProvider struct {
 	oidcProvider            *authv1alpha1.OIDCProvider
 	clientCredentialsSecret string
 	extraScopes             []string
-	cookieSecret            string
+	cookieSecretRef         *corev1.SecretKeySelector
+	emailDomains            []string
+	allowAllEmails          bool
+	whitelistDomains        []string
 }
 
 // OAuth2ProxyOption customizes an OAuth2ProxySidecarProvider.
@@ -79,10 +86,45 @@ func WithOAuth2ProxyExtraScopes(scopes ...string) OAuth2ProxyOption {
 	return func(p *OAuth2ProxySidecarProvider) { p.extraScopes = append(p.extraScopes, scopes...) }
 }
 
-// WithOAuth2ProxyCookieSecret replaces the derived cookie secret with an explicit one
-// (e.g. sourced from a Secret by the product).
-func WithOAuth2ProxyCookieSecret(secret string) OAuth2ProxyOption {
-	return func(p *OAuth2ProxySidecarProvider) { p.cookieSecret = secret }
+// WithOAuth2ProxyCookieSecretRef points the session cookie secret at a different Secret and/or
+// key than the default (the client-credentials Secret's COOKIE_SECRET key). A nil ref is
+// ignored, keeping the default.
+//
+// The value is only ever referenced, never inlined: a cookie secret in the PodSpec is readable
+// by anyone who can `get pod`, and it signs the session cookies the proxy trusts.
+func WithOAuth2ProxyCookieSecretRef(ref *corev1.SecretKeySelector) OAuth2ProxyOption {
+	return func(p *OAuth2ProxySidecarProvider) {
+		if ref != nil {
+			p.cookieSecretRef = ref
+		}
+	}
+}
+
+// WithOAuth2ProxyEmailDomains restricts logins to accounts whose email is in one of these
+// domains (OAUTH2_PROXY_EMAIL_DOMAINS). Authenticating against an identity provider is not the
+// same as being authorized for this cluster: on a shared IdP — a public provider, or a
+// corporate Keycloak carrying a customer realm — every account it can issue a token for would
+// otherwise reach the product. Either this or WithOAuth2ProxyAllowAllEmails is required.
+func WithOAuth2ProxyEmailDomains(domains ...string) OAuth2ProxyOption {
+	return func(p *OAuth2ProxySidecarProvider) { p.emailDomains = append(p.emailDomains, domains...) }
+}
+
+// WithOAuth2ProxyAllowAllEmails admits every account the identity provider authenticates
+// ("*"). This is the correct choice for an IdP realm dedicated to this cluster, and a serious
+// mistake for a shared one — it is spelled out as its own option so that it is a decision in
+// the product's code, greppable at review time, rather than a default nobody chose.
+func WithOAuth2ProxyAllowAllEmails() OAuth2ProxyOption {
+	return func(p *OAuth2ProxySidecarProvider) { p.allowAllEmails = true }
+}
+
+// WithOAuth2ProxyWhitelistDomains permits post-login redirects to these domains
+// (OAUTH2_PROXY_WHITELIST_DOMAINS) in addition to the proxy's own host. Leave unset unless a
+// redirect off-host is actually needed: every entry widens what an attacker-supplied `rd`
+// parameter can point at.
+func WithOAuth2ProxyWhitelistDomains(domains ...string) OAuth2ProxyOption {
+	return func(p *OAuth2ProxySidecarProvider) {
+		p.whitelistDomains = append(p.whitelistDomains, domains...)
+	}
 }
 
 // WithOAuth2ProxyContainerName overrides the sidecar container name.
@@ -94,18 +136,24 @@ func WithOAuth2ProxyContainerName(name string) OAuth2ProxyOption {
 //
 // oidcProvider is the resolved AuthenticationClass OIDC provider (the product fetches the
 // class and asserts the provider type). clientCredentialsSecret names a Secret carrying
-// CLIENT_ID/CLIENT_SECRET. upstreamPort is the product container port the proxy forwards
-// to on localhost. cookieSeed must be stable per product instance across reconciles —
-// typically the CR's UID — so the derived session cookie secret does not churn pods; see
-// DeterministicCookieSecret.
-func NewOAuth2ProxySidecarProvider(oidcProvider *authv1alpha1.OIDCProvider, clientCredentialsSecret string, upstreamPort int32, cookieSeed string, opts ...OAuth2ProxyOption) *OAuth2ProxySidecarProvider {
+// CLIENT_ID/CLIENT_SECRET and, by default, the COOKIE_SECRET used to sign session cookies
+// (override the location with WithOAuth2ProxyCookieSecretRef; generate the value with
+// GenerateCookieSecret). upstreamPort is the product container port the proxy forwards to on
+// localhost.
+//
+// An authorization policy is mandatory: pass WithOAuth2ProxyEmailDomains or, deliberately,
+// WithOAuth2ProxyAllowAllEmails. Inject fails without one rather than admitting everybody.
+func NewOAuth2ProxySidecarProvider(oidcProvider *authv1alpha1.OIDCProvider, clientCredentialsSecret string, upstreamPort int32, opts ...OAuth2ProxyOption) *OAuth2ProxySidecarProvider {
 	p := &OAuth2ProxySidecarProvider{
 		name:                    OAuth2ProxySidecarName,
 		port:                    OAuth2ProxyPort,
 		upstreamPort:            upstreamPort,
 		oidcProvider:            oidcProvider,
 		clientCredentialsSecret: clientCredentialsSecret,
-		cookieSecret:            DeterministicCookieSecret(cookieSeed),
+		cookieSecretRef: &corev1.SecretKeySelector{
+			LocalObjectReference: corev1.LocalObjectReference{Name: clientCredentialsSecret},
+			Key:                  OIDCCookieSecretKey,
+		},
 	}
 	for _, opt := range opts {
 		opt(p)
@@ -126,13 +174,43 @@ func (p *OAuth2ProxySidecarProvider) OwnsImage() bool {
 	return true
 }
 
-// Validate validates that the client credentials Secret exists.
+// Validate validates that the client credentials Secret exists and that the Secret holding the
+// session cookie secret carries the referenced key.
+//
+// The key check is not pedantry: with the key absent the proxy starts with an empty
+// OAUTH2_PROXY_COOKIE_SECRET and refuses to serve, so the failure would otherwise surface as a
+// crash-looping container instead of an error naming the Secret and the key. This mirrors the
+// Vector provider, which likewise validates that its ConfigMap carries vector.yaml rather than
+// merely that the ConfigMap exists.
 func (p *OAuth2ProxySidecarProvider) Validate(ctx context.Context, c client.Client, namespace string) error {
 	if p.oidcProvider == nil {
 		return fmt.Errorf("oauth2-proxy: OIDC provider is required")
 	}
 	if err := ValidateSecretExists(ctx, c, namespace, p.clientCredentialsSecret); err != nil {
 		return fmt.Errorf("oauth2-proxy client credentials secret %q not found: %w", p.clientCredentialsSecret, err)
+	}
+	if err := p.validateAuthorization(); err != nil {
+		return err
+	}
+
+	ref := p.cookieSecretRef
+	cookieSecret := &corev1.Secret{}
+	if err := c.Get(ctx, client.ObjectKey{Namespace: namespace, Name: ref.Name}, cookieSecret); err != nil {
+		return fmt.Errorf("oauth2-proxy cookie secret %q not found: %w", ref.Name, err)
+	}
+	if _, ok := cookieSecret.Data[ref.Key]; !ok {
+		return fmt.Errorf(
+			"oauth2-proxy cookie secret %q has no %q key: the session cookie secret signs every session this proxy trusts, so it must be supplied out of band (see GenerateCookieSecret)",
+			ref.Name, ref.Key)
+	}
+	return nil
+}
+
+// validateAuthorization enforces that an authorization policy was chosen explicitly.
+func (p *OAuth2ProxySidecarProvider) validateAuthorization() error {
+	if len(p.emailDomains) == 0 && !p.allowAllEmails {
+		return fmt.Errorf(
+			"oauth2-proxy: no authorization policy configured; pass WithOAuth2ProxyEmailDomains to restrict logins, or WithOAuth2ProxyAllowAllEmails to admit every account the identity provider authenticates")
 	}
 	return nil
 }
@@ -143,6 +221,12 @@ func (p *OAuth2ProxySidecarProvider) Validate(ctx context.Context, c client.Clie
 func (p *OAuth2ProxySidecarProvider) Inject(podSpec *corev1.PodSpec, config *SidecarConfig) error {
 	if p.oidcProvider == nil {
 		return fmt.Errorf("oauth2-proxy: OIDC provider is required")
+	}
+	// Checked here as well as in Validate: Inject runs during BuildResources, before the
+	// reconciler's ValidateAll, and this check needs no API client. Failing at the earlier of
+	// the two points means a pod that admits everybody is never built in the first place.
+	if err := p.validateAuthorization(); err != nil {
+		return err
 	}
 	if config == nil {
 		config = &SidecarConfig{Enabled: true}
@@ -175,7 +259,18 @@ func (p *OAuth2ProxySidecarProvider) Inject(podSpec *corev1.PodSpec, config *Sid
 		Image:           image,
 		ImagePullPolicy: pullPolicy,
 		Env: []corev1.EnvVar{
-			{Name: "OAUTH2_PROXY_COOKIE_SECRET", Value: p.cookieSecret},
+			{
+				// Referenced, never inlined. This value signs every session cookie the proxy
+				// will subsequently trust, so an inline Value would put a full authentication
+				// bypass in the PodSpec, readable by anyone who can `get pod`.
+				Name: "OAUTH2_PROXY_COOKIE_SECRET",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						LocalObjectReference: corev1.LocalObjectReference{Name: p.cookieSecretRef.Name},
+						Key:                  p.cookieSecretRef.Key,
+					},
+				},
+			},
 			{
 				Name: "OAUTH2_PROXY_CLIENT_ID",
 				ValueFrom: &corev1.EnvVarSource{
@@ -203,9 +298,8 @@ func (p *OAuth2ProxySidecarProvider) Inject(podSpec *corev1.PodSpec, config *Sid
 			// dropped by browsers on http:// service URLs. Products terminating TLS in
 			// front override via SidecarConfig.EnvVars (applied with replace semantics below).
 			{Name: "OAUTH2_PROXY_COOKIE_SECURE", Value: "false"},
-			{Name: "OAUTH2_PROXY_WHITELIST_DOMAINS", Value: "*"},
 			{Name: "OAUTH2_PROXY_CODE_CHALLENGE_METHOD", Value: "S256"},
-			{Name: "OAUTH2_PROXY_EMAIL_DOMAINS", Value: "*"},
+			{Name: "OAUTH2_PROXY_EMAIL_DOMAINS", Value: p.emailDomainsValue()},
 		},
 		Ports: []corev1.ContainerPort{
 			{Name: OAuth2ProxyPortName, ContainerPort: port, Protocol: corev1.ProtocolTCP},
@@ -219,6 +313,16 @@ func (p *OAuth2ProxySidecarProvider) Inject(podSpec *corev1.PodSpec, config *Sid
 		// Deliberately no readiness probe: as a native sidecar, an unready oauth2-proxy
 		// would gate readiness of the WHOLE pod — an issuer (IdP) outage would take the
 		// product's non-auth ports out of every Service, not just the login flow.
+	}
+
+	// Emitted only when the product asked for off-host redirects. Unset, oauth2-proxy permits
+	// redirects to its own host only, which is the closed default; "*" would turn the `rd`
+	// parameter into an open redirect usable to bounce an authenticated user anywhere.
+	if len(p.whitelistDomains) > 0 {
+		container.Env = append(container.Env, corev1.EnvVar{
+			Name:  "OAUTH2_PROXY_WHITELIST_DOMAINS",
+			Value: strings.Join(p.whitelistDomains, ","),
+		})
 	}
 
 	if config.Resources != nil {
@@ -285,14 +389,32 @@ func OAuth2ProxyProviderFor(providerHint string) string {
 	}
 }
 
-// DeterministicCookieSecret derives a stable oauth2-proxy cookie secret from a seed
-// (typically the CR UID): the URL-safe, unpadded base64 of sha256(seed), which
-// oauth2-proxy's SecretBytes decodes to a 32-byte secret. URL-safe encoding is load-bearing:
-// oauth2-proxy attempts ONLY base64.URLEncoding — a standard-encoded value containing '+'
-// or '/' fails that decode and falls back to the raw 43/44-byte string, an invalid secret
-// length that crash-loops the proxy. Deriving instead of generating keeps reconciles
-// idempotent — a random secret would roll every pod on every reconcile.
-func DeterministicCookieSecret(seed string) string {
-	hash := sha256.Sum256([]byte(seed))
-	return base64.RawURLEncoding.EncodeToString(hash[:])
+// emailDomainsValue renders OAUTH2_PROXY_EMAIL_DOMAINS. validateAuthorization has already
+// established that exactly one of the two sources is set.
+func (p *OAuth2ProxySidecarProvider) emailDomainsValue() string {
+	if p.allowAllEmails {
+		return "*"
+	}
+	return strings.Join(p.emailDomains, ",")
+}
+
+// GenerateCookieSecret returns a fresh, cryptographically random oauth2-proxy cookie secret:
+// the URL-safe, unpadded base64 of 32 random bytes, which oauth2-proxy's SecretBytes decodes
+// back to a 32-byte key.
+//
+// URL-safe encoding is load-bearing: oauth2-proxy attempts ONLY base64.URLEncoding, so a
+// standard-encoded value containing '+' or '/' fails that decode and falls back to the raw
+// 43/44-byte string — an invalid key length that crash-loops the proxy.
+//
+// Call this once when creating the Secret, and store the result. Do NOT call it per reconcile:
+// the value must be stable, or every pass would produce a different session key, roll the pods
+// and log every user out. It is deliberately not derived from the CR (a UID, a name): anything
+// readable through the API is not a secret, and a derived value would be forgeable by anyone
+// who can read the CR.
+func GenerateCookieSecret() (string, error) {
+	buf := make([]byte, 32)
+	if _, err := rand.Read(buf); err != nil {
+		return "", fmt.Errorf("failed to generate an oauth2-proxy cookie secret: %w", err)
+	}
+	return base64.RawURLEncoding.EncodeToString(buf), nil
 }

--- a/pkg/sidecar/oauth2_proxy_test.go
+++ b/pkg/sidecar/oauth2_proxy_test.go
@@ -17,14 +17,18 @@ limitations under the License.
 package sidecar_test
 
 import (
+	"context"
 	"encoding/base64"
-	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	authv1alpha1 "github.com/zncdatadev/operator-go/pkg/apis/authentication/v1alpha1"
 	"github.com/zncdatadev/operator-go/pkg/sidecar"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func keycloakProvider() *authv1alpha1.OIDCProvider {
@@ -56,7 +60,7 @@ var _ = Describe("OAuth2ProxySidecarProvider", func() {
 
 	It("injects a native sidecar with the full OAUTH2_PROXY env set", func() {
 		provider := sidecar.NewOAuth2ProxySidecarProvider(
-			keycloakProvider(), "oidc-credentials", 18080, "cr-uid")
+			keycloakProvider(), "oidc-credentials", 18080, sidecar.WithOAuth2ProxyAllowAllEmails())
 
 		Expect(provider.Inject(podSpec, nil)).To(Succeed())
 
@@ -76,12 +80,24 @@ var _ = Describe("OAuth2ProxySidecarProvider", func() {
 		Expect(envs["OAUTH2_PROXY_HTTP_ADDRESS"].Value).To(Equal("0.0.0.0:4180"))
 		Expect(envs["OAUTH2_PROXY_COOKIE_SECURE"].Value).To(Equal("false"))
 		Expect(envs["OAUTH2_PROXY_CODE_CHALLENGE_METHOD"].Value).To(Equal("S256"))
-		Expect(envs["OAUTH2_PROXY_EMAIL_DOMAINS"].Value).To(Equal("*"))
-		Expect(envs["OAUTH2_PROXY_WHITELIST_DOMAINS"].Value).To(Equal("*"))
+		Expect(envs["OAUTH2_PROXY_EMAIL_DOMAINS"].Value).To(Equal("*"),
+			"this provider opted into WithOAuth2ProxyAllowAllEmails")
+
+		// Unset, oauth2-proxy permits redirects to its own host only. "*" would make the `rd`
+		// parameter an open redirect, so the key must be absent rather than permissive.
+		Expect(envs).NotTo(HaveKey("OAUTH2_PROXY_WHITELIST_DOMAINS"))
 
 		Expect(envs["OAUTH2_PROXY_CLIENT_ID"].ValueFrom.SecretKeyRef.Name).To(Equal("oidc-credentials"))
 		Expect(envs["OAUTH2_PROXY_CLIENT_ID"].ValueFrom.SecretKeyRef.Key).To(Equal("CLIENT_ID"))
 		Expect(envs["OAUTH2_PROXY_CLIENT_SECRET"].ValueFrom.SecretKeyRef.Key).To(Equal("CLIENT_SECRET"))
+
+		// The session cookie secret signs every session the proxy trusts. An inline Value would
+		// put a full authentication bypass in the PodSpec, readable with `get pod`.
+		cookie := envs["OAUTH2_PROXY_COOKIE_SECRET"]
+		Expect(cookie.Value).To(BeEmpty(), "the cookie secret must never be inlined")
+		Expect(cookie.ValueFrom).NotTo(BeNil())
+		Expect(cookie.ValueFrom.SecretKeyRef.Name).To(Equal("oidc-credentials"))
+		Expect(cookie.ValueFrom.SecretKeyRef.Key).To(Equal(sidecar.OIDCCookieSecretKey))
 
 		Expect(container.Ports).To(HaveLen(1))
 		Expect(container.Ports[0].ContainerPort).To(Equal(int32(4180)))
@@ -89,7 +105,7 @@ var _ = Describe("OAuth2ProxySidecarProvider", func() {
 
 	It("is idempotent", func() {
 		provider := sidecar.NewOAuth2ProxySidecarProvider(
-			keycloakProvider(), "oidc-credentials", 18080, "cr-uid")
+			keycloakProvider(), "oidc-credentials", 18080, sidecar.WithOAuth2ProxyAllowAllEmails())
 
 		Expect(provider.Inject(podSpec, nil)).To(Succeed())
 		Expect(provider.Inject(podSpec, nil)).To(Succeed())
@@ -98,7 +114,7 @@ var _ = Describe("OAuth2ProxySidecarProvider", func() {
 
 	It("appends extra scopes after the provider scopes", func() {
 		provider := sidecar.NewOAuth2ProxySidecarProvider(
-			keycloakProvider(), "oidc-credentials", 18080, "cr-uid",
+			keycloakProvider(), "oidc-credentials", 18080, sidecar.WithOAuth2ProxyAllowAllEmails(),
 			sidecar.WithOAuth2ProxyExtraScopes("groups"))
 
 		Expect(provider.Inject(podSpec, nil)).To(Succeed())
@@ -109,7 +125,7 @@ var _ = Describe("OAuth2ProxySidecarProvider", func() {
 	It("falls back to the default scopes when the provider declares none", func() {
 		oidc := keycloakProvider()
 		oidc.Scopes = nil
-		provider := sidecar.NewOAuth2ProxySidecarProvider(oidc, "oidc-credentials", 18080, "cr-uid")
+		provider := sidecar.NewOAuth2ProxySidecarProvider(oidc, "oidc-credentials", 18080, sidecar.WithOAuth2ProxyAllowAllEmails())
 
 		Expect(provider.Inject(podSpec, nil)).To(Succeed())
 		envs := envByName(&podSpec.InitContainers[0])
@@ -118,7 +134,7 @@ var _ = Describe("OAuth2ProxySidecarProvider", func() {
 
 	It("lets SidecarConfig.EnvVars override built-in defaults (replace semantics)", func() {
 		provider := sidecar.NewOAuth2ProxySidecarProvider(
-			keycloakProvider(), "oidc-credentials", 18080, "cr-uid")
+			keycloakProvider(), "oidc-credentials", 18080, sidecar.WithOAuth2ProxyAllowAllEmails())
 
 		Expect(provider.Inject(podSpec, &sidecar.SidecarConfig{
 			EnvVars: map[string]string{
@@ -141,7 +157,7 @@ var _ = Describe("OAuth2ProxySidecarProvider", func() {
 
 	It("keeps the declared port and HTTP_ADDRESS aligned under a SidecarConfig.Ports override", func() {
 		provider := sidecar.NewOAuth2ProxySidecarProvider(
-			keycloakProvider(), "oidc-credentials", 18080, "cr-uid")
+			keycloakProvider(), "oidc-credentials", 18080, sidecar.WithOAuth2ProxyAllowAllEmails())
 
 		Expect(provider.Inject(podSpec, &sidecar.SidecarConfig{
 			Ports: []corev1.ContainerPort{{Name: "auth", ContainerPort: 9999}},
@@ -157,7 +173,7 @@ var _ = Describe("OAuth2ProxySidecarProvider", func() {
 	It("keeps its pinned image when the manager propagates the product image", func() {
 		manager := sidecar.NewSidecarManager()
 		provider := sidecar.NewOAuth2ProxySidecarProvider(
-			keycloakProvider(), "oidc-credentials", 18080, "cr-uid")
+			keycloakProvider(), "oidc-credentials", 18080, sidecar.WithOAuth2ProxyAllowAllEmails())
 		manager.Register(provider, &sidecar.SidecarConfig{Enabled: true})
 
 		Expect(manager.SetProductImage("quay.io/zncdatadev/spark-k8s:3.5.5", corev1.PullIfNotPresent)).To(Succeed())
@@ -170,7 +186,7 @@ var _ = Describe("OAuth2ProxySidecarProvider", func() {
 
 	It("honors port and image overrides", func() {
 		provider := sidecar.NewOAuth2ProxySidecarProvider(
-			keycloakProvider(), "oidc-credentials", 8080, "cr-uid",
+			keycloakProvider(), "oidc-credentials", 8080, sidecar.WithOAuth2ProxyAllowAllEmails(),
 			sidecar.WithOAuth2ProxyPort(9999))
 
 		Expect(provider.Inject(podSpec, &sidecar.SidecarConfig{Image: "custom/oauth2-proxy:v0.0.1"})).To(Succeed())
@@ -216,33 +232,97 @@ var _ = Describe("OAuth2ProxyProviderFor", func() {
 	})
 })
 
-var _ = Describe("DeterministicCookieSecret", func() {
-	It("is stable and URL-safe-decodes to 32 bytes, as oauth2-proxy requires", func() {
-		first := sidecar.DeterministicCookieSecret("cr-uid")
-		second := sidecar.DeterministicCookieSecret("cr-uid")
-		Expect(first).To(Equal(second))
+var _ = Describe("GenerateCookieSecret", func() {
+	It("URL-safe-decodes to 32 bytes, as oauth2-proxy requires", func() {
+		secret, err := sidecar.GenerateCookieSecret()
+		Expect(err).NotTo(HaveOccurred())
 
 		// oauth2-proxy's SecretBytes attempts ONLY unpadded URL-safe base64; a value with
 		// '+' or '/' would fall back to the raw string (invalid length) and crash the proxy.
-		Expect(first).NotTo(ContainSubstring("+"))
-		Expect(first).NotTo(ContainSubstring("/"))
-		Expect(first).NotTo(ContainSubstring("="))
-		raw, err := base64.RawURLEncoding.DecodeString(first)
+		Expect(secret).NotTo(ContainSubstring("+"))
+		Expect(secret).NotTo(ContainSubstring("/"))
+		Expect(secret).NotTo(ContainSubstring("="))
+		raw, err := base64.RawURLEncoding.DecodeString(secret)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(raw).To(HaveLen(32))
 	})
 
-	It("stays URL-safe across many seeds", func() {
+	It("stays URL-safe across many draws", func() {
 		for i := 0; i < 256; i++ {
-			secret := sidecar.DeterministicCookieSecret(fmt.Sprintf("seed-%d", i))
-			_, err := base64.RawURLEncoding.DecodeString(secret)
-			Expect(err).NotTo(HaveOccurred(), "seed-%d", i)
+			secret, err := sidecar.GenerateCookieSecret()
+			Expect(err).NotTo(HaveOccurred(), "draw %d", i)
+			_, err = base64.RawURLEncoding.DecodeString(secret)
+			Expect(err).NotTo(HaveOccurred(), "draw %d", i)
 		}
 	})
 
-	It("differs per seed", func() {
-		Expect(sidecar.DeterministicCookieSecret("a")).NotTo(
-			Equal(sidecar.DeterministicCookieSecret("b")))
+	It("is random, not derived", func() {
+		// A value derived from the CR (UID, name) is forgeable by anyone who can read the CR,
+		// which is the whole reason the previous deterministic derivation was removed.
+		seen := map[string]struct{}{}
+		for i := 0; i < 64; i++ {
+			secret, err := sidecar.GenerateCookieSecret()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(seen).NotTo(HaveKey(secret), "draw %d repeated a previous secret", i)
+			seen[secret] = struct{}{}
+		}
+	})
+})
+
+var _ = Describe("OAuth2ProxySidecarProvider authorization policy", func() {
+	var podSpec *corev1.PodSpec
+
+	BeforeEach(func() {
+		podSpec = &corev1.PodSpec{Containers: []corev1.Container{{Name: "node"}}}
+	})
+
+	It("refuses to build a proxy with no authorization policy", func() {
+		// Authenticating against an IdP is not authorization for this cluster. Defaulting to "*"
+		// would admit every account the IdP can issue a token for — on a shared realm, that is
+		// everyone. The product has to say which it wants.
+		provider := sidecar.NewOAuth2ProxySidecarProvider(
+			keycloakProvider(), "oidc-credentials", 18080)
+
+		Expect(provider.Inject(podSpec, nil)).To(
+			MatchError(ContainSubstring("no authorization policy configured")))
+		Expect(podSpec.InitContainers).To(BeEmpty(), "no container may be built")
+	})
+
+	It("restricts logins to the declared email domains", func() {
+		provider := sidecar.NewOAuth2ProxySidecarProvider(
+			keycloakProvider(), "oidc-credentials", 18080,
+			sidecar.WithOAuth2ProxyEmailDomains("example.com", "corp.example.com"))
+
+		Expect(provider.Inject(podSpec, nil)).To(Succeed())
+		envs := envByName(&podSpec.InitContainers[0])
+		Expect(envs["OAUTH2_PROXY_EMAIL_DOMAINS"].Value).To(Equal("example.com,corp.example.com"))
+	})
+
+	It("emits the redirect whitelist only when domains are declared", func() {
+		provider := sidecar.NewOAuth2ProxySidecarProvider(
+			keycloakProvider(), "oidc-credentials", 18080,
+			sidecar.WithOAuth2ProxyAllowAllEmails(),
+			sidecar.WithOAuth2ProxyWhitelistDomains("app.example.com"))
+
+		Expect(provider.Inject(podSpec, nil)).To(Succeed())
+		envs := envByName(&podSpec.InitContainers[0])
+		Expect(envs["OAUTH2_PROXY_WHITELIST_DOMAINS"].Value).To(Equal("app.example.com"))
+	})
+
+	It("reads the cookie secret from an overridden Secret and key", func() {
+		provider := sidecar.NewOAuth2ProxySidecarProvider(
+			keycloakProvider(), "oidc-credentials", 18080,
+			sidecar.WithOAuth2ProxyAllowAllEmails(),
+			sidecar.WithOAuth2ProxyCookieSecretRef(&corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "session-keys"},
+				Key:                  "current",
+			}))
+
+		Expect(provider.Inject(podSpec, nil)).To(Succeed())
+		cookie := envByName(&podSpec.InitContainers[0])["OAUTH2_PROXY_COOKIE_SECRET"]
+		Expect(cookie.Value).To(BeEmpty())
+		Expect(cookie.ValueFrom.SecretKeyRef.Name).To(Equal("session-keys"))
+		Expect(cookie.ValueFrom.SecretKeyRef.Key).To(Equal("current"))
 	})
 })
 
@@ -250,7 +330,7 @@ var _ = Describe("OAuth2ProxySidecarProvider readiness coupling", func() {
 	It("injects no readiness probe (an unready native sidecar would gate the whole pod)", func() {
 		podSpec := &corev1.PodSpec{Containers: []corev1.Container{{Name: "node"}}}
 		provider := sidecar.NewOAuth2ProxySidecarProvider(
-			keycloakProvider(), "oidc-credentials", 18080, "cr-uid")
+			keycloakProvider(), "oidc-credentials", 18080, sidecar.WithOAuth2ProxyAllowAllEmails())
 
 		Expect(provider.Inject(podSpec, nil)).To(Succeed())
 		Expect(podSpec.InitContainers[0].ReadinessProbe).To(BeNil())
@@ -258,7 +338,73 @@ var _ = Describe("OAuth2ProxySidecarProvider readiness coupling", func() {
 
 	It("rejects injection without an OIDC provider", func() {
 		podSpec := &corev1.PodSpec{Containers: []corev1.Container{{Name: "node"}}}
-		provider := sidecar.NewOAuth2ProxySidecarProvider(nil, "oidc-credentials", 18080, "cr-uid")
+		provider := sidecar.NewOAuth2ProxySidecarProvider(nil, "oidc-credentials", 18080, sidecar.WithOAuth2ProxyAllowAllEmails())
 		Expect(provider.Inject(podSpec, nil)).To(MatchError(ContainSubstring("OIDC provider is required")))
+	})
+})
+
+var _ = Describe("OAuth2ProxySidecarProvider Validate", func() {
+	var ctx context.Context
+
+	BeforeEach(func() { ctx = context.Background() })
+
+	// newClient builds a fake client holding the client-credentials Secret with the given keys.
+	newClient := func(keys ...string) *fake.ClientBuilder {
+		scheme := runtime.NewScheme()
+		Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
+		data := map[string][]byte{}
+		for _, k := range keys {
+			data[k] = []byte("value")
+		}
+		return fake.NewClientBuilder().WithScheme(scheme).WithObjects(&corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{Name: "oidc-credentials", Namespace: "test-ns"},
+			Data:       data,
+		})
+	}
+
+	It("accepts a Secret carrying all three keys", func() {
+		c := newClient(sidecar.OIDCClientIDKey, sidecar.OIDCClientSecretKey, sidecar.OIDCCookieSecretKey).Build()
+		provider := sidecar.NewOAuth2ProxySidecarProvider(
+			keycloakProvider(), "oidc-credentials", 18080,
+			sidecar.WithOAuth2ProxyAllowAllEmails())
+
+		Expect(provider.Validate(ctx, c, "test-ns")).To(Succeed())
+	})
+
+	It("rejects a Secret missing the cookie secret key", func() {
+		// Without the key the proxy starts with an empty OAUTH2_PROXY_COOKIE_SECRET and refuses
+		// to serve. Caught here, the operator reports which Secret and which key; caught by the
+		// kubelet, it is an opaque crash loop.
+		c := newClient(sidecar.OIDCClientIDKey, sidecar.OIDCClientSecretKey).Build()
+		provider := sidecar.NewOAuth2ProxySidecarProvider(
+			keycloakProvider(), "oidc-credentials", 18080,
+			sidecar.WithOAuth2ProxyAllowAllEmails())
+
+		err := provider.Validate(ctx, c, "test-ns")
+		Expect(err).To(MatchError(ContainSubstring(sidecar.OIDCCookieSecretKey)))
+		Expect(err).To(MatchError(ContainSubstring("oidc-credentials")))
+	})
+
+	It("rejects a missing authorization policy", func() {
+		c := newClient(sidecar.OIDCClientIDKey, sidecar.OIDCClientSecretKey, sidecar.OIDCCookieSecretKey).Build()
+		provider := sidecar.NewOAuth2ProxySidecarProvider(
+			keycloakProvider(), "oidc-credentials", 18080)
+
+		Expect(provider.Validate(ctx, c, "test-ns")).To(
+			MatchError(ContainSubstring("no authorization policy configured")))
+	})
+
+	It("reports the overridden cookie Secret by name when it does not exist", func() {
+		c := newClient(sidecar.OIDCClientIDKey, sidecar.OIDCClientSecretKey).Build()
+		provider := sidecar.NewOAuth2ProxySidecarProvider(
+			keycloakProvider(), "oidc-credentials", 18080,
+			sidecar.WithOAuth2ProxyAllowAllEmails(),
+			sidecar.WithOAuth2ProxyCookieSecretRef(&corev1.SecretKeySelector{
+				LocalObjectReference: corev1.LocalObjectReference{Name: "session-keys"},
+				Key:                  "current",
+			}))
+
+		Expect(provider.Validate(ctx, c, "test-ns")).To(
+			MatchError(ContainSubstring(`cookie secret "session-keys" not found`)))
 	})
 })

--- a/pkg/sidecar/oauth2_proxy_test.go
+++ b/pkg/sidecar/oauth2_proxy_test.go
@@ -288,6 +288,20 @@ var _ = Describe("OAuth2ProxySidecarProvider authorization policy", func() {
 		Expect(podSpec.InitContainers).To(BeEmpty(), "no container may be built")
 	})
 
+	It("rejects a conflicting authorization policy", func() {
+		// "*" would win over the domain list, so a caller adding WithOAuth2ProxyEmailDomains to an
+		// existing WithOAuth2ProxyAllowAllEmails call — the exact shape of "let me tighten this" —
+		// would change nothing and be told nothing.
+		provider := sidecar.NewOAuth2ProxySidecarProvider(
+			keycloakProvider(), "oidc-credentials", 18080,
+			sidecar.WithOAuth2ProxyAllowAllEmails(),
+			sidecar.WithOAuth2ProxyEmailDomains("example.com"))
+
+		Expect(provider.Inject(podSpec, nil)).To(
+			MatchError(ContainSubstring("conflicting authorization policy")))
+		Expect(podSpec.InitContainers).To(BeEmpty(), "no container may be built")
+	})
+
 	It("restricts logins to the declared email domains", func() {
 		provider := sidecar.NewOAuth2ProxySidecarProvider(
 			keycloakProvider(), "oidc-credentials", 18080,


### PR DESCRIPTION
Four security defects in `pkg/sidecar/oauth2_proxy.go`, all in the same container spec. The fourth was found in review of this PR.

## 1. The session cookie secret was inlined into the PodSpec

```go
{Name: "OAUTH2_PROXY_COOKIE_SECRET", Value: p.cookieSecret},
```

— one line above `CLIENT_ID` and `CLIENT_SECRET`, which correctly used `secretKeyRef`.

That value signs every session cookie the proxy subsequently trusts, so **anyone able to `get pod` could mint a valid session and bypass authentication outright**. It was additionally derived as `sha256(seed)` from a caller-supplied seed that the doc comment told products to set to the CR's UID — making it reconstructible by anyone who could read the CR, not just the PodSpec.

Now referenced through `secretKeyRef` like its neighbours, defaulting to the client-credentials Secret's `COOKIE_SECRET` key.

`GenerateCookieSecret()` replaces `DeterministicCookieSecret()`: `crypto/rand`, called **once** when creating the Secret rather than per reconcile. The URL-safe unpadded base64 encoding is preserved and still tested — oauth2-proxy's `SecretBytes` attempts only `base64.URLEncoding`, so a `+` or `/` falls back to the raw string and crash-loops the proxy.

## 2. `OAUTH2_PROXY_EMAIL_DOMAINS` defaulted to `*`

Authenticating against an identity provider is not authorization for this cluster. On a shared realm — a public IdP, or a corporate Keycloak carrying a customer realm — **every account the IdP can issue a token for reached the product**.

An explicit policy is now required:

```go
sidecar.WithOAuth2ProxyEmailDomains("example.com")   // restrict
sidecar.WithOAuth2ProxyAllowAllEmails()              // deliberately admit everyone
```

`Inject` and `Validate` both refuse to build a proxy without one. The permissive behaviour is still fully available — it is now a decision in the product's code, greppable at review time, rather than a default nobody chose.

## 3. `OAUTH2_PROXY_WHITELIST_DOMAINS` defaulted to `*`

Which made the post-login `rd` parameter an open redirect. No longer emitted; unset, oauth2-proxy permits its own host only. `WithOAuth2ProxyWhitelistDomains(...)` widens that one domain at a time.

## 4. Setting both authorization options silently admitted everybody

Raised in review of this PR and fixed in 483f278. The first cut of §2 enforced that *some* policy was configured, but `emailDomainsValue` short-circuits on `allowAllEmails`, so with both options set the domain list was silently discarded.

The dangerous shape is precisely "let me tighten this": adding `WithOAuth2ProxyEmailDomains("corp.example.com")` next to an existing `WithOAuth2ProxyAllowAllEmails()` produced no change in behaviour and no diagnostic — a silent fail-open, the same class of defect this PR exists to remove.

`validateAuthorization` now rejects both directions. The code had also been contradicting itself: the comment on `emailDomainsValue` claimed `validateAuthorization` established "exactly one of the two sources is set" when it only established *at least* one. That statement is now true.

## Validation

`Validate` now also checks the referenced Secret carries the cookie key. Without it the proxy starts with an empty secret and refuses to serve, so the failure would otherwise surface as an opaque crash loop instead of an error naming the Secret and the key — the same reasoning the Vector provider already applies to `vector.yaml`.

## Tests

Every security assertion was **verified against a mutated implementation** — a test that passes with the fix reverted is not testing the fix:

| Mutation | Result |
|---|---|
| re-inline the cookie secret as a literal `Value` | 2 failures |
| disable the authorization gate | 2 failures |
| remove the conflicting-policy branch | 1 failure |

Package coverage 88.7% → 92.5%. `make lint` 0 issues, `make test` green, CI green on Kubernetes 1.31–1.35.

## Breaking change

`NewOAuth2ProxySidecarProvider` drops its `cookieSeed` parameter; `DeterministicCookieSecret` and `WithOAuth2ProxyCookieSecret` are removed; **exactly one** authorization option is now mandatory.

Downstream migration is one key: add `COOKIE_SECRET` to the Secret you already create for `CLIENT_ID`/`CLIENT_SECRET`, with a value from `sidecar.GenerateCookieSecret()`. Note this **invalidates existing sessions once** (the signing key changes), which is the intended outcome — the old key was public.

`CHANGELOG.md` and `docs/security.md` §2.3 updated.

Second in a series of small, independently reviewable fixes from the architecture review of `540711c`; follows #540.

🤖 Generated with [Claude Code](https://claude.com/claude-code)