### PR TITLE
fix(reconciler): reconcile roles best-effort instead of aborting on the first

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,7 +164,7 @@ customizable extension points. It is built from a `GenericReconcilerConfig[CR]` 
    does not declare
 5. PreReconcile Extensions (Hook)
 6. Validate declared dependencies (`GenericReconcilerConfig.Dependencies`)
-7. For Each Role:
+7. For Each Role (**best effort** — see below):
    - Role PreReconcile Extensions
    - For Each RoleGroup:
      - RoleGroup PreReconcile Extensions
@@ -181,6 +181,8 @@ customizable extension points. It is built from a `GenericReconcilerConfig[CR]` 
 11. Final Status Update, then requeue
 
 Each "Apply" is create-OR-UPDATE (issue #526): when the resource already exists, the live object is updated to the handler-built desired state every reconcile — labels are replaced wholesale, annotations are merged (foreign annotations survive), and spec/data is copied per kind while preserving Kubernetes immutable/allocated fields (StatefulSet `selector`/`serviceName`/`volumeClaimTemplates`/`podManagementPolicy`; Service `clusterIP(s)`/`ipFamilies` and allocated NodePorts). Arbitrary-GVK extras get a generic top-level field copy. See `copyDesiredState` in `pkg/reconciler/apply.go`. Changing an immutable field for an existing cluster requires a manual delete/recreate migration — and the framework now **says so**: when a handler's desired value for a preserved field differs from the live one, `applyResource` emits an `ImmutableFieldIgnored` Warning event on the CR naming the resource and the field paths. Preserving those fields silently is what let a storage resize be accepted, reported as `ReconcileComplete=True`, and never applied. Only a field the handler actually set is reported (an unset field is declining to have an opinion, not a change request), and among the Service's preserved fields only `clusterIP` is — the others are API-server allocations, so a difference there would be noise on every reconcile.
+
+**Role iteration is best-effort.** A failing role does not stop the others, and a failing role group does not stop its siblings, the role-level PDB, or the role's PostReconcile hook. Steps 8-10 (orphan cleanup, health, cluster PostReconcile) run regardless. Roles and role groups are independent workloads: aborting at the first failure meant one unparsable value on the alphabetically-first role indefinitely blocked the *deletion* of an unrelated role group, the health of every other role, and the discovery ConfigMap a product publishes from PostReconcile. The per-role errors are combined with `errors.Join` and returned once, so the cluster still goes `Degraded` and the workqueue still backs off. Iteration stays **sorted** so that aggregated message is byte-stable across cycles — an unstable message would defeat the no-op guard in `updateStatus` and make the controller reschedule itself forever. The single exception is a 429: a `*RateLimitError` aborts the pass immediately, because pushing the remaining roles through would only deepen the backlog.
 
 **Requeue cadence.** A successful reconcile returns `ctrl.Result{RequeueAfter: HealthCheckInterval}` (`DefaultHealthCheckInterval` = 120s; a negative value disables the periodic wakeup), or the cleaner's earliest pending wakeup when that is sooner — a remaining gray-delete deadline, or the drain poll interval of an orphan deletion in flight. Watches only cover the kinds the framework owns, so anything that changes without producing an event — a product `ServiceHealthCheck` probe, a grace period running out, a StatefulSet finishing its drain — depends on this timer.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -140,6 +140,15 @@ changes are listed below.**
 
 ### fix
 
+- Role and role group iteration is **best effort**: a failing role no longer aborts the whole
+  reconcile. Orphan cleanup, the health check and the cluster PostReconcile hook now run even when
+  a role failed, and the per-role errors are combined with `errors.Join` so the cluster still goes
+  Degraded and the workqueue still backs off. Previously one unparsable value on the
+  alphabetically-first role indefinitely blocked the deletion of an unrelated role group, the
+  health of every other role, and the discovery ConfigMap products publish from PostReconcile —
+  and because iteration was sorted, the same later roles were starved on every cycle. A 429 still
+  aborts the pass. The cleaner had already adopted this policy for the same situation; the hot
+  path now matches it.
 - An immutable field the apply path refuses to change now produces an `ImmutableFieldIgnored`
   Warning event on the CR, naming the resource and the field paths. Preserving
   `volumeClaimTemplates`, `selector`, `serviceName` and `podManagementPolicy` is correct — the

--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -511,16 +511,35 @@ func (r *GenericReconciler[CR]) reconcile(ctx context.Context, cr CR, stored cli
 		return ctrl.Result{}, NewReconcileError("DependencyValidation", "dependency validation failed", err)
 	}
 
-	// 3. Process each role
+	// 3. Process each role, BEST EFFORT: a role that fails does not stop the others, and does not
+	// stop the cleanup/health/PostReconcile steps below.
+	//
+	// Roles and role groups are independent workloads. Aborting the pass at the first failure meant
+	// one unparsable value on the alphabetically-first role indefinitely blocked the DELETION of an
+	// unrelated role group, the health of every other role, and the discovery ConfigMap a product
+	// publishes from PostReconcile — none of which had anything to do with the broken role.
+	// Sorting made that starvation deterministic rather than fixing it: the same later roles were
+	// starved every cycle.
+	//
+	// The cleaner already reasoned its way to this policy for the same situation (see
+	// cleaner.go, "aborting the whole pass here would let one wedged group keep every other orphan
+	// alive"). The framework held both policies and applied the wrong one to the hot path.
+	//
+	// The iteration stays sorted so the aggregated error — and therefore the Degraded message —
+	// is byte-stable across cycles; an unstable message would defeat the no-op guard in
+	// updateStatus and make the controller reschedule itself forever.
 	r.warnOnUnknownConfiguredRoles(ctx, cr, spec)
-	// Sorted, not map order: the first failing role aborts the cycle and its error text becomes
-	// the Degraded message. With map order, a cluster with several broken role groups reports a
-	// different one every cycle, so the status never settles and each write schedules the next
-	// reconcile.
+	var roleErrs []error
 	for _, roleName := range slices.Sorted(maps.Keys(spec.Roles)) {
 		roleSpec := spec.Roles[roleName]
 		if err := r.reconcileRole(ctx, cr, roleName, &roleSpec); err != nil {
-			return ctrl.Result{}, err
+			// Throttling is the one failure that must stop the pass: the API server is rejecting
+			// this operator's requests, so pushing the remaining roles through would only deepen
+			// the backlog.
+			if IsRateLimitError(err) {
+				return ctrl.Result{}, err
+			}
+			roleErrs = append(roleErrs, err)
 		}
 	}
 
@@ -550,14 +569,22 @@ func (r *GenericReconciler[CR]) reconcile(ctx context.Context, cr CR, stored cli
 		return ctrl.Result{}, NewReconcileError("PostReconcile", "extension hook failed", err)
 	}
 
-	// 7. Final status update
+	// 7. Report role failures, if any. Returning here — after cleanup, health and PostReconcile
+	// have all run — is what makes the iteration best-effort rather than merely tolerant: the
+	// caller sets Degraded and writes the status once, and the workqueue backs off. The status
+	// write is left to that path so a failing cycle does not write twice.
+	if len(roleErrs) > 0 {
+		return ctrl.Result{}, stderrors.Join(roleErrs...)
+	}
+
+	// 8. Final status update
 	status.SetReconcileComplete(true, v1alpha1.ReasonReconcileComplete, "Reconciliation completed successfully")
 
 	if err := r.updateStatus(ctx, cr, stored); err != nil {
 		return ctrl.Result{}, err
 	}
 
-	// 8. Schedule the next wakeup. Watches only cover the resources the framework owns, so
+	// 9. Schedule the next wakeup. Watches only cover the resources the framework owns, so
 	// anything that changes without producing an event — a ServiceHealthCheck probe, a
 	// gray-delete grace period running out — needs a timed requeue. Both sources collapse into
 	// a single RequeueAfter (the earliest one); zero means "no periodic wakeup".
@@ -631,34 +658,49 @@ func (r *GenericReconciler[CR]) reconcileRole(ctx context.Context, cr CR, roleNa
 		return NewReconcileError("RolePreReconcile", fmt.Sprintf("role %s extension hook failed", roleName), err)
 	}
 
-	// Process each role group.
+	// Process each role group, BEST EFFORT: role groups are independent StatefulSets, so one
+	// failing to build must not stop its siblings — nor the role-level PDB that covers all of
+	// them, nor the role's PostReconcile hook.
 	//
-	// Sorted, not map order, for the same reason the role loop is (see reconcile): the first
-	// failing group aborts the role and its error text becomes the Degraded message, so with map
-	// order a cluster with several broken groups reports a different one every cycle and the
-	// status never settles.
+	// Sorted, not map order, so the aggregated error text is byte-stable across cycles: an
+	// unstable Degraded message would defeat the no-op guard in updateStatus and make the
+	// controller reschedule itself forever.
 	//
 	// Note: groupSpec is deep copied because it may be modified during reconciliation.
 	// roleSpec is passed directly as read-only (used for configuration lookup only);
 	// it originates from spec.Roles which is re-fetched from the API server each reconcile,
 	// so any accidental modifications would not persist and would be corrected on next reconcile.
 	roleGroups := roleSpec.GetRoleGroups()
+	var errs []error
 	for _, groupName := range slices.Sorted(maps.Keys(roleGroups)) {
 		groupSpec := roleGroups[groupName]
 		groupSpecCopy := *groupSpec.DeepCopy()
 		if err := r.reconcileRoleGroup(ctx, cr, roleName, roleSpec, groupName, &groupSpecCopy); err != nil {
-			return err
+			// A 429 stops everything: see the role loop in reconcile.
+			if IsRateLimitError(err) {
+				return err
+			}
+			errs = append(errs, err)
 		}
 	}
 
 	// Reconcile the role-level PodDisruptionBudget (one per role, covering all its role groups).
+	// Still attempted when a group failed: the PDB protects the groups that ARE running, and it is
+	// derived from roleConfig, not from anything a failed group produced.
 	if err := r.reconcileRolePodDisruptionBudget(ctx, cr, roleName, roleSpec); err != nil {
-		return err
+		if IsRateLimitError(err) {
+			return err
+		}
+		errs = append(errs, err)
 	}
 
 	// Execute role PostReconcile extensions
 	if err := r.extensionRegistry.ExecuteRolePostReconcile(ctx, r.client, cr, roleName); err != nil {
-		return NewReconcileError("RolePostReconcile", fmt.Sprintf("role %s extension hook failed", roleName), err)
+		errs = append(errs, NewReconcileError("RolePostReconcile", fmt.Sprintf("role %s extension hook failed", roleName), err))
+	}
+
+	if len(errs) > 0 {
+		return stderrors.Join(errs...)
 	}
 
 	logger.V(1).Info("Role reconciled", "role", roleName)

--- a/pkg/reconciler/generic_reconciler_resilience_test.go
+++ b/pkg/reconciler/generic_reconciler_resilience_test.go
@@ -1249,3 +1249,147 @@ var _ = Describe("GenericReconciler deletion handling", func() {
 		Expect(after.Status.Conditions).To(HaveLen(len(before.Status.Conditions)))
 	})
 })
+
+var _ = Describe("GenericReconciler best-effort role iteration", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	// newSelectiveFailureReconciler builds a reconciler whose handler fails for the named role
+	// groups and succeeds for the rest.
+	newSelectiveFailureReconciler := func(fail map[string]bool) *reconciler.GenericReconciler[*testutil.MockCluster] {
+		handler := &reconciler.RoleGroupHandlerFuncs[*testutil.MockCluster]{
+			BuildResourcesFunc: func(_ context.Context, _ client.Client, _ *testutil.MockCluster, buildCtx *reconciler.RoleGroupBuildContext) (*reconciler.RoleGroupResources, error) {
+				if fail[buildCtx.RoleName+"/"+buildCtx.RoleGroupName] {
+					return nil, fmt.Errorf("handler refused role group %s/%s", buildCtx.RoleName, buildCtx.RoleGroupName)
+				}
+				return &reconciler.RoleGroupResources{
+					ConfigMap: testutil.NewTestConfigMap(buildCtx.ResourceName, buildCtx.ClusterNamespace),
+				}, nil
+			},
+		}
+		r, err := reconciler.NewGenericReconciler(&reconciler.GenericReconcilerConfig[*testutil.MockCluster]{
+			Client:           k8sClient,
+			Scheme:           testScheme,
+			Recorder:         recorder,
+			RoleGroupHandler: handler,
+			Prototype:        testutil.NewMockCluster("proto", testNamespace),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		return r
+	}
+
+	// newTwoRoleCR creates a CR with two roles, "alpha" (sorted first) and "omega".
+	newTwoRoleCR := func(name string) *testutil.MockCluster {
+		cr := testutil.NewMockCluster(name, testNamespace).
+			WithRoles(map[string]v1alpha1.RoleSpec{
+				"alpha": {RoleGroups: map[string]v1alpha1.RoleGroupSpec{"default": {Replicas: ptr.To(int32(1))}}},
+				"omega": {RoleGroups: map[string]v1alpha1.RoleGroupSpec{"default": {Replicas: ptr.To(int32(1))}}},
+			})
+		Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, cr)
+			for _, role := range []string{"alpha", "omega"} {
+				_ = k8sClient.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{
+					Name: reconciler.RoleGroupResourceName(name, role, "default"), Namespace: testNamespace}})
+			}
+		})
+		return cr
+	}
+
+	It("reconciles later roles even though an earlier one failed", func() {
+		// "alpha" sorts before "omega". Under fail-fast the sorted iteration made the starvation
+		// deterministic: omega was never reconciled, on any cycle, for as long as alpha was broken.
+		cr := newTwoRoleCR(uniqueCRName("best-effort-roles"))
+		r := newSelectiveFailureReconciler(map[string]bool{"alpha/default": true})
+
+		_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(cr)})
+		Expect(err).To(HaveOccurred(), "the failure is still reported")
+		Expect(err.Error()).To(ContainSubstring("alpha/default"))
+
+		omegaKey := types.NamespacedName{
+			Namespace: testNamespace,
+			Name:      reconciler.RoleGroupResourceName(cr.Name, "omega", "default"),
+		}
+		Expect(k8sClient.Get(ctx, omegaKey, &corev1.ConfigMap{})).To(Succeed(),
+			"omega is an independent workload and must converge regardless of alpha")
+	})
+
+	It("aggregates every failing role rather than reporting only the first", func() {
+		cr := newTwoRoleCR(uniqueCRName("best-effort-aggregate"))
+		r := newSelectiveFailureReconciler(map[string]bool{"alpha/default": true, "omega/default": true})
+
+		_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(cr)})
+		Expect(err).To(HaveOccurred())
+		// Both, so an operator fixing one does not discover the next only on the following cycle.
+		Expect(err.Error()).To(ContainSubstring("alpha/default"))
+		Expect(err.Error()).To(ContainSubstring("omega/default"))
+	})
+
+	It("produces a byte-stable error across cycles so the status can settle", func() {
+		// Sorted iteration is what makes this true. An unstable message would re-stamp the
+		// Degraded condition every pass, defeating the no-op guard in updateStatus and making the
+		// controller reschedule itself forever.
+		cr := newTwoRoleCR(uniqueCRName("best-effort-stable"))
+		r := newSelectiveFailureReconciler(map[string]bool{"alpha/default": true, "omega/default": true})
+
+		req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(cr)}
+		_, first := r.Reconcile(ctx, req)
+		_, second := r.Reconcile(ctx, req)
+		Expect(first).To(HaveOccurred())
+		Expect(second).To(HaveOccurred())
+		Expect(second.Error()).To(Equal(first.Error()))
+	})
+
+	It("still retires an orphaned role group when an unrelated role is broken", func() {
+		// The harm the review named: cleanup ran after the role loop, so one unparsable value on
+		// the alphabetically-first role indefinitely blocked the DELETION of a role group that had
+		// nothing to do with it.
+		name := uniqueCRName("best-effort-cleanup")
+		cr := testutil.NewMockCluster(name, testNamespace).
+			WithRoles(map[string]v1alpha1.RoleSpec{
+				"alpha": {RoleGroups: map[string]v1alpha1.RoleGroupSpec{"default": {Replicas: ptr.To(int32(1))}}},
+				"omega": {RoleGroups: map[string]v1alpha1.RoleGroupSpec{
+					"default": {Replicas: ptr.To(int32(1))},
+					"doomed":  {Replicas: ptr.To(int32(1))},
+				}},
+			})
+		Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+		doomedName := reconciler.RoleGroupResourceName(name, "omega", "doomed")
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, cr)
+			for _, n := range []string{
+				reconciler.RoleGroupResourceName(name, "alpha", "default"),
+				reconciler.RoleGroupResourceName(name, "omega", "default"),
+				doomedName,
+			} {
+				_ = k8sClient.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: n, Namespace: testNamespace}})
+			}
+		})
+
+		req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(cr)}
+		healthy := newSelectiveFailureReconciler(nil)
+		_, err := healthy.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+
+		doomedKey := types.NamespacedName{Namespace: testNamespace, Name: doomedName}
+		Expect(k8sClient.Get(ctx, doomedKey, &corev1.ConfigMap{})).To(Succeed())
+
+		// Now remove the group from the spec AND break an unrelated role.
+		live := &testutil.MockCluster{}
+		Expect(k8sClient.Get(ctx, req.NamespacedName, live)).To(Succeed())
+		omega := live.Spec.Roles["omega"]
+		delete(omega.RoleGroups, "doomed")
+		live.Spec.Roles["omega"] = omega
+		Expect(k8sClient.Update(ctx, live)).To(Succeed())
+
+		broken := newSelectiveFailureReconciler(map[string]bool{"alpha/default": true})
+		Eventually(func() error {
+			_, _ = broken.Reconcile(ctx, req)
+			return k8sClient.Get(ctx, doomedKey, &corev1.ConfigMap{})
+		}, 10*time.Second, 200*time.Millisecond).Should(MatchError(k8serrors.IsNotFound, "IsNotFound"),
+			"orphan cleanup must not be hostage to an unrelated role's failure")
+	})
+})


### PR DESCRIPTION
## The problem

Roles and role groups are **independent workloads**, but the loop returned on the first failure:

```go
for _, roleName := range slices.Sorted(maps.Keys(spec.Roles)) {
    if err := r.reconcileRole(ctx, cr, roleName, &roleSpec); err != nil {
        return ctrl.Result{}, err
    }
}
```

And everything *after* the loop went with it — orphan cleanup, the health check, and the cluster PostReconcile hook where products publish their discovery ConfigMap.

So one unparsable `gracefulShutdownTimeout` on the alphabetically-first role:

- indefinitely blocked the **deletion** of a role group that had nothing to do with it,
- stopped every other role's health from being reported,
- left the discovery ConfigMap stale.

### Sorting made it worse, not better

The sort was added earlier to keep the `Degraded` message stable. But it turned the starvation **deterministic**: the same later roles were skipped on every single cycle for as long as an earlier one stayed broken, instead of each getting an occasional turn under map iteration.

### The framework already knew better

`cleaner.go` argues, for exactly this situation:

> "aborting the whole pass here would let one wedged group keep every other orphan alive"

The teardown path had better fault isolation than the build path. The framework held both policies and applied the wrong one to the hot path.

## The change

Both loops collect failures and continue. Per-role errors are combined with `errors.Join` and returned **once**, after cleanup/health/PostReconcile have run — so the cluster still goes `Degraded` and the workqueue still backs off exactly as before. The status write is left to the caller's error path, so a failing cycle does not write status twice.

Iteration **stays sorted**, now for its real reason: the aggregated message must be byte-stable across cycles, or it would re-stamp the `Degraded` condition every pass, defeat the no-op guard in `updateStatus`, and make the controller reschedule itself forever. There is a spec asserting that property.

### Two deliberate exceptions

- **A 429 still aborts the pass.** The API server is rejecting this operator's requests; pushing the remaining roles through would only deepen the backlog. `*RateLimitError` short-circuits at both levels.
- **The role-level PDB is still attempted when a group failed.** It protects the groups that *are* running, and it is derived from `roleConfig` — not from anything the failed group produced.

## Tests

Four new specs, covering the harms the review named directly:

| Spec | Asserts |
|---|---|
| reconciles later roles even though an earlier one failed | `omega` converges while `alpha` is broken |
| aggregates every failing role | both appear in one error, so fixing one doesn't reveal the next a cycle later |
| byte-stable error across cycles | the status can settle |
| still retires an orphaned role group when an unrelated role is broken | the cleanup harm specifically |

**Verified against a mutated implementation**: reverting the role loop to fail-fast fails 3 of the 4 (the stability one passes either way, which is correct — fail-fast is trivially stable).

`make lint` 0 issues, `make test` green.

## Compatibility

No API change. The observable difference for a downstream operator: a cluster with one broken role now converges its other roles, and reports **all** failures in the `Degraded` message rather than the first. An operator that relied on "the first error is the only error" in alerting will see more text.

Seventh in the series from the architecture review of `540711c`; follows #540, #541, #542, #543, #544, #545. This closes the fourth and last of the review's root causes that is a pure control-flow fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)