### PR TITLE
refactor(reconciler)!: drop ExtraLabels/ExtraAnnotations, leaving one label channel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,7 +203,7 @@ passed the expiry recorded in `restarter.kubedoop.dev/expires-at.<...>`.
 The label goes on **`StatefulSet.metadata.labels`**, which is where the restarter's watch predicate
 and its `client.MatchingLabels` list both read it — a pod-template label does not enable anything,
 so `podOverrides` is not a way in. The framework's own channel is the **cluster CR's labels**: the
-reconciler passes `maps.Clone(cr.GetLabels())` as `RoleGroupBuildContext.ClusterLabels`, and
+reconciler passes a writable clone of `cr.GetLabels()` as `RoleGroupBuildContext.ClusterLabels`, and
 `BaseRoleGroupHandler` merges them into every built resource's metadata (and pod template), so
 `kubectl label <cluster-cr> restarter.kubedoop.dev/enable=true` reaches the StatefulSet metadata the
 restarter watches. Opting in is a **deployment** decision by whoever runs the cluster, not something
@@ -275,6 +275,21 @@ managed-by and the `<cluster>-<group>` marker (or the product's `LabelDomain` id
 selector is immutable, and `version` changes on every product upgrade. Upgrading an existing cluster
 into this label set rolls its pods once, because the pod template gains labels; the frozen selector
 keeps matching. See `pkg/reconciler/AGENTS.md` §14.
+
+On top of that set the handler adds the **cluster CR's own labels**
+(`RoleGroupBuildContext.ClusterLabels`), applied *first* so the framework's identity labels win over
+a colliding key — which makes a colliding CR label inert rather than an error. This is the framework's
+**only** label channel: whatever an operator's user wants on the workloads, including platform
+opt-ins the SDK does not own such as `restarter.kubedoop.dev/enable`, is set by labelling the CR.
+`BaseRoleGroupHandler.ExtraLabels` and `ExtraAnnotations` no longer exist — they put a deployment-time
+decision in a compile-time field, and `ExtraLabels` mostly existed to supply the recommended labels
+the framework now emits itself.
+
+**The framework sets no annotations on the resources it builds**, and the CR's annotations are
+deliberately not propagated the way its labels are: that map carries
+`kubectl.kubernetes.io/last-applied-configuration` and the cleaner's `orphan.zncdata.dev/*` progress
+markers. A product needing e.g. cloud LoadBalancer annotations on the client Service has no
+supported way to set them today — tracked in zncdatadev/operator-go#553.
 
 `RoleGroupHandlerFuncs` is a function adapter for simple handlers that don't need a full struct.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,21 @@ changes are listed below.**
   a later role-level input now needs no further signature change. Handlers that override the method
   (it is detected through a method-set interface, so an override is a supported extension point)
   update their signature to match.
+- `BaseRoleGroupHandler.ExtraLabels` and `BaseRoleGroupHandler.ExtraAnnotations` are removed, along
+  with the `validateExtraLabels` build-time check they needed. Both were compile-time fields on a
+  handler — a decision frozen when the operator is *built* — for something decided when a cluster is
+  *deployed*. Labels move to the **cluster CR**: the reconciler already propagates
+  `RoleGroupBuildContext.ClusterLabels` into every built resource's metadata and pod template, which
+  is also the only route to the `StatefulSet.metadata.labels` that commons-operator's restarter
+  watches. `ExtraLabels` largely existed to supply the three recommended labels the framework was
+  not emitting, which it now does (see the label-set entry under *features* above).
+  - `DiscoveryConfigMapOptions.ExtraLabels` / `WithDiscoveryExtraLabels` are a **different**,
+    per-call API for one ConfigMap and are unaffected.
+  - **Annotations get no replacement.** The framework now sets none on the resources it builds, and
+    the CR's annotations are deliberately not propagated the way its labels are — that map holds
+    `kubectl.kubernetes.io/last-applied-configuration` and the cleaner's own `orphan.zncdata.dev/*`
+    progress markers. A product that needs e.g. cloud LoadBalancer annotations on the client Service
+    has no supported way to set them; tracked in #553.
 
 ### security
 

--- a/docs/DOC_CHANGELOG.md
+++ b/docs/DOC_CHANGELOG.md
@@ -4,6 +4,23 @@ This document tracks all changes made to the SDK documentation.
 
 ---
 
+## [2026-07-27b] (one label channel: ExtraLabels/ExtraAnnotations removed)
+
+### AGENTS.md files
+
+- Root `AGENTS.md` §3: the **Labels** paragraph now states that the cluster CR is the framework's
+  only label channel, that CR labels are applied *first* so a colliding key is inert rather than an
+  error, and that the framework sets **no** annotations — with the reason the CR's annotations are
+  not propagated the way its labels are (`kubectl.kubernetes.io/last-applied-configuration` and the
+  cleaner's `orphan.zncdata.dev/*` markers live there) and a pointer to
+  zncdatadev/operator-go#553 for the Service-annotation gap that leaves open.
+- `pkg/reconciler/AGENTS.md` §13 rewritten: the `ExtraLabels` selector-collision *rejection* is
+  replaced by the ordering that makes the collision impossible, and the old rule is kept as the
+  explanation of why a check was once needed. New §15 documents the single channel and the
+  annotation gap.
+
+---
+
 ## [2026-07-27] (restarter contract re-verified against commons-operator; recommended label set)
 
 The restarter opt-in was documented from the SDK's side only, and got the audience wrong. Every

--- a/pkg/reconciler/AGENTS.md
+++ b/pkg/reconciler/AGENTS.md
@@ -136,11 +136,14 @@ There is no `reconciler.go`, `status.go` or `finalizer.go` in this package — s
     rolling file appender on it — the Vector provider owns the shared log volume, so without the
     sidecar an appender would write to an unmounted path.
 13. **Framework-owned selector labels:** the StatefulSet/Service/PDB selectors are derived from the
-    cluster/role/role group names alone (or the product's `LabelDomain` identity labels). An
-    `ExtraLabels` entry that collides with a selector key and disagrees with its value fails the
-    build, naming the key: the builder re-writes selector keys into the pod template after the
-    labels, so it could never take effect, and on an object created under the older, wider selector
-    it would make every update fail.
+    cluster/role/role group names alone (or the product's `LabelDomain` identity labels). A CR
+    label that collides with a selector key is **inert**, not an error: `buildLabels` applies the
+    CR's labels first and the framework's identity labels over them, so the selector and the pod
+    template can never end up disagreeing. (The predecessor of this rule was a build-time rejection
+    of a colliding `BaseRoleGroupHandler.ExtraLabels` entry, which was needed because `ExtraLabels`
+    was applied *last* and therefore won in the label map while the builder re-wrote the selector
+    keys into the pod template afterwards. Ordering removes the failure mode instead of detecting
+    it.)
 14. **The recommended label set is metadata, and wider than the selector.** Every resource the
     framework builds carries the six keys declared in `pkg/constant/label.go`
     (`constant.LabelKubernetes*`), on both the object metadata and the pod template:
@@ -165,6 +168,23 @@ There is no `reconciler.go`, `status.go` or `finalizer.go` in this package — s
     product upgrade, and the role group is already pinned by the `<cluster>-<group>` marker key.
     Upgrading an existing cluster into this label set rolls its pods once (the pod template gains
     labels) but leaves the frozen selector satisfied.
+15. **There is exactly one label channel, and it is the cluster CR.** `buildLabels` layers, low to
+    high: `buildCtx.ClusterLabels` (the CR's own, cloned per cycle) → the recommended set →
+    `frameworkSelectorLabels` → the product's `LabelDomain` identity labels. Anything an operator's
+    *user* wants on the workloads — above all the platform opt-ins the SDK does not own, such as
+    `restarter.kubedoop.dev/enable` — is set by labelling the CR.
+
+    `BaseRoleGroupHandler.ExtraLabels` and `ExtraAnnotations` are **gone**. They were compile-time
+    fields on a handler, i.e. a decision frozen when the operator was built, for something decided
+    when a cluster is deployed; and `ExtraLabels` specifically existed to paper over the three
+    recommended labels the framework was not emitting (§14), which it now does.
+
+    **Annotations have no replacement channel: the framework sets none on the resources it builds.**
+    The CR's annotations are deliberately *not* propagated the way its labels are — that map holds
+    `kubectl.kubernetes.io/last-applied-configuration` and the cleaner's own
+    `orphan.zncdata.dev/*` progress markers, neither of which belongs on a ConfigMap. A product
+    needing e.g. cloud LoadBalancer annotations on the client Service has no supported way to set
+    them today; see zncdatadev/operator-go#553.
 
 ## Reconcile Flow
 

--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"maps"
 	"slices"
-	"strings"
 	"time"
 
 	"github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
@@ -95,12 +94,6 @@ type BaseRoleGroupHandler[CR common.ClusterInterface] struct {
 
 	// Scheme is the runtime scheme for ownership setup.
 	Scheme *runtime.Scheme
-
-	// Product-specific labels to add to all resources.
-	ExtraLabels map[string]string
-
-	// Product-specific annotations to add to all resources.
-	ExtraAnnotations map[string]string
 
 	// StorageMountPath, when non-empty, opts the role group into a data PVC. The base
 	// StatefulSet then gets a VolumeClaimTemplate built from RoleGroupConfig.Resources.Storage
@@ -205,8 +198,6 @@ func NewBaseRoleGroupHandler[CR common.ClusterInterface](image string, scheme *r
 		RoleMainContainerName: make(map[string]string),
 		RoleLoggingContainers: make(map[string][]productlogging.ContainerLogging),
 		Scheme:                scheme,
-		ExtraLabels:           make(map[string]string),
-		ExtraAnnotations:      make(map[string]string),
 	}
 }
 
@@ -292,12 +283,6 @@ func (h *BaseRoleGroupHandler[CR]) BuildResources(
 		if err := sidecarMgr.SetProductImage(image, pullPolicy); err != nil {
 			return nil, fmt.Errorf("failed to set product image on sidecars: %w", err)
 		}
-	}
-
-	// An ExtraLabel that collides with a selector key can never take effect, and on an existing
-	// StatefulSet it makes every update fail. Reject it before anything is built.
-	if err := h.validateExtraLabels(buildCtx); err != nil {
-		return nil, err
 	}
 
 	// Build labels
@@ -517,12 +502,13 @@ func (h *BaseRoleGroupHandler[CR]) recommendedLabels(
 }
 
 // buildLabels creates the descriptive labels for resources. It is a superset of
-// buildSelectorLabels: the CR's own labels and the product's ExtraLabels are metadata (and pod
-// template) only, never selectors.
+// buildSelectorLabels: the CR's own labels are metadata (and pod template) only, never selectors.
 func (h *BaseRoleGroupHandler[CR]) buildLabels(buildCtx *RoleGroupBuildContext) map[string]string {
 	labels := make(map[string]string)
 
-	// Add cluster labels
+	// The CR's own labels, which is how an operator's user propagates a label to the workloads —
+	// including the platform opt-ins the framework does not own, e.g.
+	// restarter.kubedoop.dev/enable.
 	for k, v := range buildCtx.ClusterLabels {
 		labels[k] = v
 	}
@@ -543,11 +529,6 @@ func (h *BaseRoleGroupHandler[CR]) buildLabels(buildCtx *RoleGroupBuildContext) 
 		labels[k] = v
 	}
 
-	// Add extra labels
-	for k, v := range h.ExtraLabels {
-		labels[k] = v
-	}
-
 	return labels
 }
 
@@ -565,10 +546,10 @@ func (h *BaseRoleGroupHandler[CR]) identityLabels(buildCtx *RoleGroupBuildContex
 
 // frameworkSelectorLabels returns the framework-owned identity labels of a role group. They are
 // derived exclusively from the cluster/role/role group names, never from buildCtx.ClusterLabels or
-// h.ExtraLabels: a StatefulSet's .spec.selector is immutable after creation, so a user-mutable
-// label inside it would freeze at its creation-time value and every later edit of that label would
-// leave the live object unmatchable — and, because the pod template keeps carrying the current
-// value, permanently unpatchable.
+// buildCtx.ClusterLabels: a StatefulSet's .spec.selector is immutable after creation, so a
+// user-mutable label inside it would freeze at its creation-time value and every later edit of that
+// label would leave the live object unmatchable — and, because the pod template keeps carrying the
+// current value, permanently unpatchable.
 //
 // This is a strict subset of the recommended set that recommendedLabels stamps on metadata, and
 // stays that way: app.kubernetes.io/version changes on every product upgrade and role-group is
@@ -599,50 +580,6 @@ func (h *BaseRoleGroupHandler[CR]) buildSelectorLabels(buildCtx *RoleGroupBuildC
 // matching selectors for resources they add themselves (e.g. a metrics Service).
 func (h *BaseRoleGroupHandler[CR]) SelectorLabels(buildCtx *RoleGroupBuildContext) map[string]string {
 	return h.buildSelectorLabels(buildCtx)
-}
-
-// validateExtraLabels rejects an ExtraLabel whose key is a selector key but whose value differs
-// from the selector's. Such a label is silently ineffective and actively harmful:
-//
-//   - buildLabels applies ExtraLabels last, but the StatefulSet builder re-writes the selector
-//     keys into the pod template AFTER the labels, so the product's value never reaches the pod.
-//   - The .spec.selector of a live StatefulSet is immutable. A cluster created while the selector
-//     still included the ExtraLabels carries the product's value there forever, and the pod
-//     template the framework now builds no longer satisfies it — every update is rejected by the
-//     API server, with nothing in the object to explain why.
-//
-// A collision that agrees with the selector value changes nothing and is allowed, so a product
-// restating e.g. app.kubernetes.io/managed-by keeps working.
-func (h *BaseRoleGroupHandler[CR]) validateExtraLabels(buildCtx *RoleGroupBuildContext) error {
-	selector := h.buildSelectorLabels(buildCtx)
-
-	var collisions []string
-	for key, value := range h.ExtraLabels {
-		if selectorValue, isSelector := selector[key]; isSelector && selectorValue != value {
-			collisions = append(collisions, fmt.Sprintf("%s (selector value %q, ExtraLabels value %q)",
-				key, selectorValue, value))
-		}
-	}
-	if len(collisions) == 0 {
-		return nil
-	}
-
-	slices.Sort(collisions)
-	return fmt.Errorf(
-		"ExtraLabels collide with the selector labels of role %q group %q: %s; a selector label is framework-owned and cannot be overridden",
-		buildCtx.RoleName, buildCtx.RoleGroupName, strings.Join(collisions, ", "))
-}
-
-// buildAnnotations creates the annotations for resources.
-func (h *BaseRoleGroupHandler[CR]) buildAnnotations(_ *RoleGroupBuildContext) map[string]string {
-	annotations := make(map[string]string)
-
-	// Add extra annotations
-	for k, v := range h.ExtraAnnotations {
-		annotations[k] = v
-	}
-
-	return annotations
 }
 
 // configMountPath returns the directory where the config ConfigMap is mounted, defaulting
@@ -706,7 +643,6 @@ func (h *BaseRoleGroupHandler[CR]) buildConfigMap(buildCtx *RoleGroupBuildContex
 
 	cm := builder.NewConfigMapBuilder(buildCtx.ResourceName, buildCtx.ClusterNamespace).
 		WithLabels(labels).
-		WithAnnotations(h.buildAnnotations(buildCtx)).
 		WithConfigFiles(data).
 		Build()
 
@@ -724,7 +660,6 @@ func (h *BaseRoleGroupHandler[CR]) buildConfigMap(buildCtx *RoleGroupBuildContex
 func (h *BaseRoleGroupHandler[CR]) buildHeadlessService(buildCtx *RoleGroupBuildContext, labels map[string]string) *corev1.Service {
 	return builder.NewHeadlessServiceBuilder(buildCtx.ResourceName+"-headless", buildCtx.ClusterNamespace).
 		WithLabels(labels).
-		WithAnnotations(h.buildAnnotations(buildCtx)).
 		WithSelector(h.buildSelectorLabels(buildCtx)).
 		WithPublishNotReadyAddresses(h.PublishNotReadyAddresses).
 		WithPorts(h.servicePorts(buildCtx.RoleName, buildCtx.RoleGroupName)).
@@ -735,7 +670,6 @@ func (h *BaseRoleGroupHandler[CR]) buildHeadlessService(buildCtx *RoleGroupBuild
 func (h *BaseRoleGroupHandler[CR]) buildService(buildCtx *RoleGroupBuildContext, labels map[string]string, ports []corev1.ServicePort) *corev1.Service {
 	return builder.NewServiceBuilder(buildCtx.ResourceName, buildCtx.ClusterNamespace).
 		WithLabels(labels).
-		WithAnnotations(h.buildAnnotations(buildCtx)).
 		WithSelector(h.buildSelectorLabels(buildCtx)).
 		WithPorts(ports).
 		Build()
@@ -768,7 +702,6 @@ func (h *BaseRoleGroupHandler[CR]) buildStatefulSet(
 	image, pullPolicy := h.containerImage(buildCtx, buildCtx.RoleName)
 	stsBuilder.WithLabels(labels).
 		WithSelectorLabels(h.buildSelectorLabels(buildCtx)).
-		WithAnnotations(h.buildAnnotations(buildCtx)).
 		WithReplicas(replicas).
 		WithImage(image, pullPolicy).
 		WithConfig(buildCtx.MergedConfig).
@@ -965,7 +898,6 @@ func (h *BaseRoleGroupHandler[CR]) BuildRolePodDisruptionBudget(
 	b := builder.NewPDBBuilder(
 		RoleResourceName(buildCtx.ClusterName, buildCtx.RoleName), buildCtx.ClusterNamespace).
 		WithLabels(h.buildRoleLabels(buildCtx)).
-		WithAnnotations(h.ExtraAnnotations).
 		WithSelector(h.buildRoleSelectorLabels(buildCtx.ClusterName, buildCtx.RoleName)).
 		WithSpec(roleConfig.PodDisruptionBudget)
 
@@ -1022,10 +954,6 @@ func (h *BaseRoleGroupHandler[CR]) buildRoleLabels(buildCtx *RoleBuildContext) m
 	}
 
 	for k, v := range h.roleIdentityLabels(buildCtx.ClusterName, buildCtx.RoleName) {
-		labels[k] = v
-	}
-
-	for k, v := range h.ExtraLabels {
 		labels[k] = v
 	}
 

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -92,8 +92,6 @@ var _ = Describe("BaseRoleGroupHandler", func() {
 			Expect(handler.RoleImages).NotTo(BeNil())
 			Expect(handler.RoleContainerPorts).NotTo(BeNil())
 			Expect(handler.RoleServicePorts).NotTo(BeNil())
-			Expect(handler.ExtraLabels).NotTo(BeNil())
-			Expect(handler.ExtraAnnotations).NotTo(BeNil())
 		})
 
 		It("should set the scheme correctly", func() {
@@ -239,8 +237,11 @@ var _ = Describe("BaseRoleGroupHandler", func() {
 			Expect(resources.PodDisruptionBudget).To(BeNil())
 		})
 
-		It("should include extra labels in all resources", func() {
-			handler.ExtraLabels["custom-label"] = "custom-value"
+		It("should propagate the CR's own labels to all resources", func() {
+			// The cluster CR's labels are the framework's one label channel: an operator's user
+			// labels the CR and every built resource carries it, which is how a platform opt-in
+			// like restarter.kubedoop.dev/enable reaches the StatefulSet metadata.
+			buildCtx.ClusterLabels["custom-label"] = "custom-value"
 			handler.SetRoleServicePorts("test-role", []corev1.ServicePort{
 				{Name: "http", Port: 8080},
 			})
@@ -252,10 +253,17 @@ var _ = Describe("BaseRoleGroupHandler", func() {
 			Expect(resources.HeadlessService.Labels["custom-label"]).To(Equal("custom-value"))
 			Expect(resources.Service.Labels["custom-label"]).To(Equal("custom-value"))
 			Expect(resources.StatefulSet.Labels["custom-label"]).To(Equal("custom-value"))
+			// The StatefulSet's own metadata is what the restarter's watch predicate reads, but
+			// the pod template carries it too.
+			Expect(resources.StatefulSet.Spec.Template.Labels["custom-label"]).To(Equal("custom-value"))
 		})
 
-		It("should include extra annotations in all resources", func() {
-			handler.ExtraAnnotations["custom-annotation"] = "annotation-value"
+		It("should build resources with no annotations of its own", func() {
+			// The framework sets no annotations on the resources it builds. Nothing sensible can
+			// be propagated wholesale from the CR (kubectl's last-applied blob, and the cleaner's
+			// own orphan.zncdata.dev/* progress markers, both live there), and a compile-time
+			// handler field is the wrong layer for what is a deployment decision. Service
+			// annotations specifically are tracked in zncdatadev/operator-go#553.
 			handler.SetRoleServicePorts("test-role", []corev1.ServicePort{
 				{Name: "http", Port: 8080},
 			})
@@ -263,10 +271,10 @@ var _ = Describe("BaseRoleGroupHandler", func() {
 			resources, err := handler.BuildResources(ctx, k8sClient, mockCR, buildCtx)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(resources.ConfigMap.Annotations["custom-annotation"]).To(Equal("annotation-value"))
-			Expect(resources.HeadlessService.Annotations["custom-annotation"]).To(Equal("annotation-value"))
-			Expect(resources.Service.Annotations["custom-annotation"]).To(Equal("annotation-value"))
-			Expect(resources.StatefulSet.Annotations["custom-annotation"]).To(Equal("annotation-value"))
+			Expect(resources.ConfigMap.Annotations).To(BeEmpty())
+			Expect(resources.HeadlessService.Annotations).To(BeEmpty())
+			Expect(resources.Service.Annotations).To(BeEmpty())
+			Expect(resources.StatefulSet.Annotations).To(BeEmpty())
 		})
 
 		It("should build ConfigMap with config files", func() {
@@ -1221,8 +1229,9 @@ var _ = Describe("BaseRoleGroupHandler extra labels and annotations", func() {
 		}
 	})
 
-	It("should include extra labels in all resources", func() {
-		handler.ExtraLabels = map[string]string{"custom-label": "custom-value", "team": "platform"}
+	It("should carry every CR label onto all resources", func() {
+		buildCtx.ClusterLabels["custom-label"] = "custom-value"
+		buildCtx.ClusterLabels["team"] = "platform"
 
 		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
 		Expect(err).NotTo(HaveOccurred())
@@ -1230,14 +1239,6 @@ var _ = Describe("BaseRoleGroupHandler extra labels and annotations", func() {
 		Expect(resources.ConfigMap.Labels).To(HaveKey("team"))
 		Expect(resources.StatefulSet.Labels).To(HaveKey("custom-label"))
 		Expect(resources.HeadlessService.Labels).To(HaveKey("custom-label"))
-	})
-
-	It("should include extra annotations in resources", func() {
-		handler.ExtraAnnotations = map[string]string{"custom-annotation": "annotation-value"}
-
-		resources, err := handler.BuildResources(context.Background(), nil, nil, buildCtx)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(resources.ConfigMap.Annotations).To(HaveKey("custom-annotation"))
 	})
 
 	It("should merge cluster labels with standard labels", func() {
@@ -2019,13 +2020,12 @@ var _ = Describe("Selector label stability", func() {
 
 	BeforeEach(func() {
 		handler = reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("img:1", testScheme)
-		handler.ExtraLabels["team"] = "platform"
 		mockCR = testutil.NewMockCluster("test-cluster", "default")
 	})
 
 	It("builds the selector from framework-owned labels only", func() {
 		resources, err := handler.BuildResources(context.Background(), k8sClient, mockCR,
-			newBuildCtx(map[string]string{"env": "prod"}))
+			newBuildCtx(map[string]string{"env": "prod", "team": "platform"}))
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(resources.StatefulSet.Spec.Selector.MatchLabels).To(Equal(map[string]string{
@@ -2035,9 +2035,9 @@ var _ = Describe("Selector label stability", func() {
 			"test-cluster-default":         "true",
 		}))
 
-		// The CR and extra labels stay on the pod template: StatefulSets created before the
-		// selector was narrowed froze them into their immutable selector, so dropping them from
-		// the template would leave those objects unmatchable.
+		// The CR's labels stay on the pod template: StatefulSets created before the selector was
+		// narrowed froze them into their immutable selector, so dropping them from the template
+		// would leave those objects unmatchable.
 		Expect(resources.StatefulSet.Spec.Template.Labels).To(HaveKeyWithValue("env", "prod"))
 		Expect(resources.StatefulSet.Spec.Template.Labels).To(HaveKeyWithValue("team", "platform"))
 	})
@@ -2060,12 +2060,12 @@ var _ = Describe("Selector label stability", func() {
 	})
 
 	It("keeps satisfying the selector a StatefulSet froze under the previous label scheme", func() {
-		clusterLabels := map[string]string{"env": "prod"}
+		clusterLabels := map[string]string{"env": "prod", "team": "platform"}
 		buildCtx := newBuildCtx(clusterLabels)
 
 		// The selector the previous framework version wrote into .spec.selector: the FULL
-		// descriptive label set (cluster labels, then the framework identity labels, then
-		// ExtraLabels). It is immutable on the live object, so every pod template this version
+		// descriptive label set (cluster labels, then the framework identity labels, then the
+		// product's own). It is immutable on the live object, so every pod template this version
 		// builds must still match it or the API server rejects every update.
 		legacySelector := map[string]string{
 			"env":                          "prod",
@@ -2083,26 +2083,45 @@ var _ = Describe("Selector label stability", func() {
 			Matches(k8slabels.Set(resources.StatefulSet.Spec.Template.Labels))).To(BeTrue())
 	})
 
-	It("fails the build when an ExtraLabel collides with a selector label", func() {
-		// The builder re-writes the selector keys into the pod template AFTER the labels, so this
-		// value can never take effect — and on a StatefulSet created while the selector still
-		// carried it, the frozen selector demands "platform" while the template now says "server",
-		// which makes every update fail with nothing on the object to explain why.
-		handler.ExtraLabels["app.kubernetes.io/component"] = "platform"
+	It("lets a framework label win over a CR label that collides with it", func() {
+		// This is what replaces the ExtraLabels collision check. A CR label is applied FIRST and
+		// the framework's identity labels overwrite it, so a colliding CR label is inert: the
+		// selector and the pod template still agree on the framework's value, and no live object
+		// can end up demanding a value its template no longer carries.
+		//
+		// ExtraLabels was applied LAST and therefore won in the label map, while the builder
+		// re-wrote the selector keys into the pod template afterwards — which is exactly the
+		// mismatch that needed a build-time rejection. Ordering makes it impossible instead.
+		handler.SetRoleServicePorts("server", []corev1.ServicePort{{Name: "http", Port: 8080}})
 
-		_, err := handler.BuildResources(context.Background(), k8sClient, mockCR,
-			newBuildCtx(map[string]string{"env": "prod"}))
-		Expect(err).To(HaveOccurred())
-		Expect(err.Error()).To(ContainSubstring("app.kubernetes.io/component"))
-		Expect(err.Error()).To(ContainSubstring("ExtraLabels collide with the selector labels"))
-	})
-
-	It("allows an ExtraLabel that restates a selector label's own value", func() {
-		handler.ExtraLabels["app.kubernetes.io/managed-by"] = "operator-go"
-
-		_, err := handler.BuildResources(context.Background(), k8sClient, mockCR,
-			newBuildCtx(map[string]string{"env": "prod"}))
+		resources, err := handler.BuildResources(context.Background(), k8sClient, mockCR,
+			newBuildCtx(map[string]string{
+				"app.kubernetes.io/component":  "hijacked",
+				"app.kubernetes.io/managed-by": "someone-else",
+				"env":                          "prod",
+			}))
 		Expect(err).NotTo(HaveOccurred())
+
+		// The ConfigMap and Services are the load-bearing assertions: they carry buildLabels'
+		// output verbatim. The StatefulSet builder re-asserts the selector keys into the
+		// StatefulSet's own labels and pod template on its way out, so checking only those would
+		// pass even with the ordering reversed — and would leave the ConfigMap and Services
+		// disagreeing with the workload about which role they belong to.
+		for _, labels := range []map[string]string{
+			resources.ConfigMap.Labels,
+			resources.HeadlessService.Labels,
+			resources.Service.Labels,
+			resources.StatefulSet.Labels,
+			resources.StatefulSet.Spec.Template.Labels,
+			resources.StatefulSet.Spec.Selector.MatchLabels,
+		} {
+			Expect(labels).To(HaveKeyWithValue("app.kubernetes.io/component", "server"))
+			Expect(labels).To(HaveKeyWithValue("app.kubernetes.io/managed-by", "operator-go"))
+		}
+		// A non-colliding CR label is untouched.
+		Expect(resources.StatefulSet.Labels).To(HaveKeyWithValue("env", "prod"))
+		Expect(k8slabels.SelectorFromSet(resources.StatefulSet.Spec.Selector.MatchLabels).
+			Matches(k8slabels.Set(resources.StatefulSet.Spec.Template.Labels))).To(BeTrue())
 	})
 })
 

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -1210,7 +1210,7 @@ var _ = Describe("ConfigGenerator integration", func() {
 	})
 })
 
-var _ = Describe("BaseRoleGroupHandler extra labels and annotations", func() {
+var _ = Describe("BaseRoleGroupHandler CR label propagation", func() {
 	var handler *reconciler.BaseRoleGroupHandler[common.ClusterInterface]
 	var buildCtx *reconciler.RoleGroupBuildContext
 


### PR DESCRIPTION
Step 2 of 2, following #554.

## Why these fields were wrong

Both were compile-time fields on a handler — a decision frozen when the operator is *built* — for something decided when a cluster is *deployed*.

The clearest case is `restarter.kubedoop.dev/enable`: whether a workload rolls when its ConfigMap changes is the cluster operator's call, per cluster. Encoding it in the operator binary means every cluster that operator manages gets the same answer.

`ExtraLabels` also largely existed to fill a hole the framework has since closed. Three of the six recommended labels the SDK declares were never emitted; #554 fixed that, so a product wanting `app.kubernetes.io/name` no longer has to add it by hand.

## What replaces it

The channel that was always there: **the cluster CR's labels**. The reconciler clones them into `RoleGroupBuildContext.ClusterLabels` and the base handler merges them into every built resource's metadata and pod template — which is also the only route to the `StatefulSet.metadata.labels` that commons-operator's restarter watch predicate reads.

```bash
kubectl label trinocluster/my-cluster restarter.kubedoop.dev/enable=true
```

## `validateExtraLabels` is removed, not replaced

It existed because `ExtraLabels` was applied **last** in `buildLabels` and therefore won in the label map, while the StatefulSet builder re-writes the selector keys into the pod template *afterwards*. A colliding entry silently never took effect, and on an object created under the older, wider selector it made every update fail.

CR labels are applied **first** and the framework's identity labels overwrite them, so a colliding CR label is simply inert. The failure mode is removed rather than detected — the 31-line check has nothing left to catch.

The old collision specs are re-targeted at that ordering rather than deleted.

> **A note on that spec, because mutation testing caught a real gap.** The assertion covers the **ConfigMap and Services**, not just the StatefulSet. The StatefulSet builder re-asserts selector keys into its own labels and pod template on the way out, so a StatefulSet-only assertion passes *even with the ordering reversed*. My first version of the spec did exactly that and survived the mutation. Reversed, the ConfigMap and Services would have ended up disagreeing with the workload about which role they belong to.

## Annotations get no replacement — the one real capability loss

The framework now sets **no** annotations on the resources it builds.

Propagating the CR's annotations the way its labels are propagated is not the answer: that map holds `kubectl.kubernetes.io/last-applied-configuration` and the cleaner's own `orphan.zncdata.dev/*` progress markers, neither of which belongs on a ConfigMap.

So a product needing e.g. cloud LoadBalancer annotations on the client Service has no supported way to set them today. That gap is #553, which wants a designed API rather than a catch-all handler field. Stated plainly here rather than glossed over.

## BREAKING

- `BaseRoleGroupHandler.ExtraLabels` removed → label the cluster CR.
- `BaseRoleGroupHandler.ExtraAnnotations` removed → no replacement (#553).
- `DiscoveryConfigMapOptions.ExtraLabels` / `WithDiscoveryExtraLabels` are a **different**, per-call API for one ConfigMap and are **unaffected**.

## Verification

- `make lint` 0 issues; `make test` all pass; `make verify-generate` up to date; examples module builds and tests pass.
- Mutation-tested: reversing the `buildLabels` layer order fails the collision spec; removing the CR-label merge fails 6 specs.