### PR TITLE
docs+fix(events): make the documented event vocabulary the real one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,9 @@ changes are listed below.**
   client, which does not populate `TypeMeta`, so the message read `Created  ns/kafka-broker-default`
   — with a hole exactly where the disambiguator between a role group's Service, its headless
   Service and its metrics Service belongs. `NewEventManager` now takes the scheme and resolves the
-  kind from it, falling back to the Go type name for an object the scheme does not know.
+  kind from it, falling back to the **bare** Go type name (`Listener`, not `*v1alpha1.Listener`)
+  for an object the scheme does not know. The reconciler's `resourceKind` now shares that
+  resolution, so an object is never called two different things in the event and in the error.
 
 ### BREAKING (events)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,25 @@ changes are listed below.**
     progress markers. A product that needs e.g. cloud LoadBalancer annotations on the client Service
     has no supported way to set them; tracked in #553.
 
+### fix (events)
+
+- `Created`/`Updated`/`Deleted` events now name the object's **Kind**. Everything the framework
+  applies is a typed struct from `pkg/builder` round-tripped through controller-runtime's typed
+  client, which does not populate `TypeMeta`, so the message read `Created  ns/kafka-broker-default`
+  — with a hole exactly where the disambiguator between a role group's Service, its headless
+  Service and its metrics Service belongs. `NewEventManager` now takes the scheme and resolves the
+  kind from it, falling back to the Go type name for an object the scheme does not know.
+
+### BREAKING (events)
+
+- `NewEventManager(recorder)` → `NewEventManager(recorder, scheme)`.
+- `EventManager.EmitProgressingEvent`, `EmitAvailableEvent` and `EmitDegradedEvent` are removed.
+  The framework never called them, and they mirror transitions it already owns through status
+  conditions — an exported emitter the framework never calls reads as a framework guarantee, and a
+  product calling these would publish a second, unsynchronized account of the cluster's state.
+  `EmitWarningEvent` / `EmitNormalEvent` / `LogAndEmitError` / `LogAndEmitInfo` remain for product
+  code; the last two are documented as never called by the framework.
+
 ### fix (podOverrides)
 
 - A `podOverrides` volumeMount at a **mountPath the framework already owns** now fails the role

--- a/docs/DOC_CHANGELOG.md
+++ b/docs/DOC_CHANGELOG.md
@@ -4,6 +4,41 @@ This document tracks all changes made to the SDK documentation.
 
 ---
 
+## [2026-07-27e] (event vocabulary; clusterConfig is product-owned)
+
+Two claims the docs made that the code does not support. Both were checked by enumerating the
+actual call sites rather than by reading the prose.
+
+### Architecture Documentation (`architecture.md`, `architecture_zh.md`)
+
+- **§4.14.2 promised reconcile start/completion events that do not exist.** Nothing is emitted at
+  the beginning or end of a pass; an SRE alerting on a documented "reconcile completed" event would
+  have had an alert that is permanently firing or permanently silent depending on how it was
+  written, and the silence would read as an operator outage. The clause is replaced with an
+  explicit statement that progress is reported through **status conditions**, plus the complete
+  list of the nine events the framework really emits.
+- **§4.14.2 said the `EventManager` is "injected into the Reconciler context".** It is a struct
+  field, handed to the cleaner; nothing puts it in a `context`. Corrected, with what a hook should
+  do instead.
+- Documented that resource events name the object's Kind and why that needs the scheme.
+
+### Examples (`docs/examples/crd-base-example.yaml`)
+
+- **`clusterConfig` was presented under a "--- Standard SDK Fields ---" heading, but commons
+  defines no `ClusterConfigSpec` and `GenericClusterSpec` has only `image`, `clusterOperation` and
+  `roles`.** Five products each hand-roll the block with their own spelling of the same concepts,
+  and the doc asserting otherwise meant each author believed they were implementing a shared
+  contract. The block is now labelled product-owned and illustrative, with a pointer to the
+  explicit APIs (`VectorAggregatorProvider`, `SecretProvisioner`, `ListenerProvisioner`) through
+  which the SDK genuinely consumes those concepts.
+
+### AGENTS.md files
+
+- `pkg/reconciler/AGENTS.md`: the `event.go` row now carries the full emitted vocabulary, the
+  scheme argument, and which helpers the framework never calls.
+
+---
+
 ## [2026-07-27d] (podOverrides volumeMount merge key)
 
 ### AGENTS.md files

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -690,12 +690,13 @@ K8s Events provide a chronological log of significant occurrences within the clu
 
 ### 4.14.2 Core Implementation
 
-- **Unified Recorder**: The SDK encapsulates the Kubernetes `EventRecorder` in an `EventManager` and injects it into the Reconciler context.
+- **Unified Recorder**: The SDK encapsulates the Kubernetes `EventRecorder` in an `EventManager`, held as a field on the reconciler and handed to the `RoleGroupCleaner`. It is **not** placed in the `context` — a hook or handler that wants to emit events constructs its own `NewEventManager(recorder, scheme)`.
 - **Automated Lifecycle Events**:
-  - **Resource Operations**: The SDK emits `Normal` events when it creates, updates, or deletes a sub-resource (StatefulSet, Service, ConfigMap, PDB), ensuring auditability without boilerplate code. Orphan cleanup emits a `Deleted` event per removed resource once the cleaner has an `EventManager` (`RoleGroupCleaner.WithEventManager`).
-  - **Reconciliation Milestones**: Emits events for Reconcile start (debug level), completion, and critical failures.
-- **Error Integration**: Any error bubbling up from the Reconciliation loop (including Extensions) that triggers a `Degraded` status automatically generates a `Warning` event with the error reason.
-- **Degraded-input warnings**: some inputs are bad but not fatal, and they get a `Warning` event of their own rather than being dropped silently — a `podOverrides` layer that fails to decode or patch (`MergedConfig.PodOverrideErrors`), and a recovered panic (`ReconcilePanic`).
+  - **Resource Operations**: `Created` / `Updated` / `Deleted` `Normal` events whenever the framework applies or reclaims a sub-resource (StatefulSet, Service, ConfigMap, PDB), giving auditability without boilerplate. Orphan cleanup emits `Deleted` per removed resource once the cleaner has an `EventManager` (`RoleGroupCleaner.WithEventManager`). Each message names the object's **Kind**, resolved through the scheme: the typed objects `pkg/builder` produces carry no `TypeMeta`, so the kind cannot be read off the object, and it is exactly the disambiguator between a role group's Service, its headless Service and its metrics Service.
+  - **There are no reconcile start / completion events.** The framework emits nothing at the beginning or end of a successful pass; progress is reported through **status conditions**, which is what a controller should be watched on. Do not build alerting on a "reconcile completed" event.
+- **Error Integration**: an error that reaches the top of the loop (including from Extensions) sets `Degraded` **and** emits a `ReconcileError` `Warning` carrying the error text.
+- **Degraded-input warnings**: some inputs are bad but not fatal, and they get a `Warning` of their own rather than being dropped silently. The complete vocabulary the framework emits: `ReconcileError`, `ReconcilePanic` (a recovered panic), `PodOverrideIgnored` (a `podOverrides` layer that fails to decode or patch — `MergedConfig.PodOverrideErrors`), `UnknownConfiguredRole` (a handler configured for a role the CR does not declare), `ImmutableFieldIgnored` (a desired change to a preserved immutable field), `VectorSidecarSkipped` (the agent is enabled but nothing supplies `vector.yaml`), plus the three resource-operation `Normal` events above.
+- **Product-facing helpers**: `EmitWarningEvent`, `EmitNormalEvent`, `LogAndEmitError` and `LogAndEmitInfo` are available to extensions and product code. The framework calls only the first two.
 
 ### 4.14.3 Core Value
 

--- a/docs/architecture_zh.md
+++ b/docs/architecture_zh.md
@@ -690,12 +690,13 @@ K8s Events 提供集群内重要事件的时间顺序日志。与 Status Conditi
 
 ### 4.14.2 核心实现
 
-- **统一记录器**：SDK 把 Kubernetes `EventRecorder` 封装为 `EventManager` 并注入到 Reconciler 上下文中。
+- **统一记录器**：SDK 把 Kubernetes `EventRecorder` 封装为 `EventManager`，作为 reconciler 的字段持有，并传给 `RoleGroupCleaner`。它**不会**放进 `context` —— 需要发事件的 hook 或 handler 自行构造 `NewEventManager(recorder, scheme)`。
 - **自动化生命周期事件**：
-  - **资源操作**：SDK 在创建、更新或删除子资源（StatefulSet、Service、ConfigMap、PDB）时发出 `Normal` 事件，确保可审计性而无需样板代码。孤儿清理在接好 `EventManager`（`RoleGroupCleaner.WithEventManager`）后，会为每个被删除的资源发出 `Deleted` 事件。
-  - **调和里程碑**：为调和开始（调试级别）、完成和关键失败发出事件。
-- **错误集成**：从调和循环（包括扩展）冒泡的任何触发 `Degraded` 状态的错误都会自动生成带有错误原因的 `Warning` 事件。
-- **劣化输入的告警**：有些输入有问题但不致命，它们会单独产生 `Warning` 事件而不是被静默丢弃——解析或 patch 失败的 `podOverrides` 层（`MergedConfig.PodOverrideErrors`），以及被捕获的 panic（`ReconcilePanic`）。
+  - **资源操作**：框架应用或回收子资源（StatefulSet、Service、ConfigMap、PDB）时发出 `Created` / `Updated` / `Deleted` `Normal` 事件，无需样板代码即可审计。孤儿清理在接好 `EventManager`（`RoleGroupCleaner.WithEventManager`）后，会为每个被删除的资源发出 `Deleted`。每条消息都会点名对象的 **Kind**，通过 scheme 解析得到：`pkg/builder` 产出的强类型对象不带 `TypeMeta`，Kind 无法从对象自身读出，而它恰恰是区分一个 role group 的 Service、headless Service 与 metrics Service 的关键。
+  - **不存在调和开始/完成事件**。一次成功的调和在开始和结束时都不发任何事件；进度通过 **status conditions** 报告，那才是 controller 应该被观测的地方。不要基于"调和完成"事件建告警。
+- **错误集成**：冒泡到循环顶层的错误（包括来自扩展的）会置 `Degraded`，**并**发出携带错误文本的 `ReconcileError` `Warning`。
+- **劣化输入的告警**：有些输入有问题但不致命，它们会单独产生 `Warning` 而不是被静默丢弃。框架实际发出的完整事件词表：`ReconcileError`、`ReconcilePanic`（被捕获的 panic）、`PodOverrideIgnored`（解析或 patch 失败的 `podOverrides` 层 —— `MergedConfig.PodOverrideErrors`）、`UnknownConfiguredRole`（handler 为 CR 未声明的 role 做了配置）、`ImmutableFieldIgnored`（对被保留的不可变字段提出了变更）、`VectorSidecarSkipped`（agent 已启用但没有任何来源提供 `vector.yaml`），外加上面三个资源操作 `Normal` 事件。
+- **面向产品的辅助方法**：`EmitWarningEvent`、`EmitNormalEvent`、`LogAndEmitError` 和 `LogAndEmitInfo` 可供扩展与产品代码使用；框架自身只调用前两个。
 
 ### 4.14.3 核心价值
 

--- a/docs/examples/crd-base-example.yaml
+++ b/docs/examples/crd-base-example.yaml
@@ -18,6 +18,10 @@
 # │                      │       │   - DFSReplication   │
 # └──────────────────────┘       └──────────────────────┘
 #
+# What the SDK actually standardizes is exactly `commons/v1alpha1.GenericClusterSpec`:
+# `image`, `clusterOperation` and `roles`. Everything else in this file — `clusterConfig`
+# above all — is product-owned, and is shown here only to illustrate where such fields go.
+#
 metadata:
   name: productclusters.product.kubedoop.dev
 spec:
@@ -34,10 +38,24 @@ spec:
     # KubedooP Operator version to ensure compatibility.
     kubedoopVersion: "0.2.0"
 
-  # [Extensible] Cluster-wide Configuration
-  # Contains both standard SDK configurations and Product-specific extended fields.
+  # [PRODUCT-OWNED] Cluster-wide Configuration
+  #
+  # IMPORTANT: `clusterConfig` is NOT part of the SDK's data model. commons/v1alpha1 defines no
+  # ClusterConfigSpec, and GenericClusterSpec has exactly three members — `image`,
+  # `clusterOperation` and `roles`. Every product declares its own `clusterConfig` struct with its
+  # own field names, and nothing in the framework reads it.
+  #
+  # The block below is therefore an ILLUSTRATION of what a product typically puts there, not a
+  # contract you can rely on across products. Two products may legitimately spell the same concept
+  # differently (`vectorAggregatorConfigMapName` vs `vectorAgentConfigMap`), and neither is
+  # "wrong" — the SDK has no opinion. Do not template it in shared tooling.
+  #
+  # Where the SDK *does* consume these concepts, it does so through explicit APIs, not through
+  # this block: the Vector aggregator ConfigMap via `reconciler.VectorAggregatorProvider`
+  # implemented on the CR, secret classes via `security.SecretProvisioner` registrations, and
+  # listener classes via `listener.ListenerProvisioner`.
   clusterConfig:
-    # --- Standard SDK Fields ---
+    # --- Product-defined fields (illustrative) ---
 
     # Authentication & Security:
     # Configures global authentication mechanisms. Specific fields depend on the product's capabilities.
@@ -55,8 +73,8 @@ spec:
     # If configured, a Vector sidecar container will be automatically injected into all Pods.
     vectorAgentConfigMap: "trino-vector-agent-configmap"
 
-    # --- Product Specific Fields (Examples) ---
-    # Products extend this section with their own global settings.
+    # --- Further product-specific fields (examples) ---
+    # There is no boundary between these and the ones above: the whole block is product-defined.
     #
     # zookeeperConfigMap:       <-- HDFS/HBase/Kafka would add this
     #

--- a/pkg/reconciler/AGENTS.md
+++ b/pkg/reconciler/AGENTS.md
@@ -18,7 +18,7 @@ Every non-test file in this package:
 | `health.go` | `HealthManager` — role group aggregation into Available/Progressing/Degraded plus the optional product `ServiceHealthCheck` (run under `Timeout`) |
 | `dependency.go` | `Dependency` / `DependencyKind` / `DependencyResolver` — declarative existence checks for referenced ConfigMaps and Secrets, plus the explicit `ValidateS3Connection` / `ValidateDatabaseConnection` / `ValidateZKConfig` helpers |
 | `errors.go` | Typed reconcile errors: `ReconcileError`, `ConfigError`, `ResourceBuildError`, `ResourceApplyError`, `ValidationError`, `RateLimitError` and their `Is*` predicates |
-| `event.go` | `EventManager` — Normal/Warning event emission on the CR |
+| `event.go` | `EventManager` — Normal/Warning event emission on the CR. `NewEventManager(recorder, scheme)`: the scheme resolves the Kind named in resource events, which the typed objects `pkg/builder` produces do not carry. The framework emits exactly `Created`/`Updated`/`Deleted` (Normal) and `ReconcileError`/`ReconcilePanic`/`PodOverrideIgnored`/`UnknownConfiguredRole`/`ImmutableFieldIgnored`/`VectorSidecarSkipped` (Warning) — **there are no reconcile start/completion events**. `LogAndEmitError`/`LogAndEmitInfo` exist for product code and the framework never calls them |
 | `discovery.go` | `EnsureDiscoveryConfigMap` — shared ensure-helper for product discovery ConfigMaps (CreateOrUpdate + controller owner ref + canonical labels; the product computes the data map) |
 
 There is no `reconciler.go`, `status.go` or `finalizer.go` in this package — status is written by

--- a/pkg/reconciler/cleaner_test.go
+++ b/pkg/reconciler/cleaner_test.go
@@ -1226,7 +1226,7 @@ var _ = Describe("RoleGroupCleaner metrics Service and events", func() {
 
 		fakeRecorder := record.NewFakeRecorder(100)
 		cleaner := reconciler.NewRoleGroupCleaner(k8sClient, testScheme).
-			WithEventManager(reconciler.NewEventManager(fakeRecorder))
+			WithEventManager(reconciler.NewEventManager(fakeRecorder, testScheme))
 
 		spec := &v1alpha1.GenericClusterSpec{
 			Roles: map[string]v1alpha1.RoleSpec{"role": {RoleGroups: map[string]v1alpha1.RoleGroupSpec{}}},

--- a/pkg/reconciler/event.go
+++ b/pkg/reconciler/event.go
@@ -19,6 +19,7 @@ package reconciler
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -53,15 +54,33 @@ func NewEventManager(recorder record.EventRecorder, scheme *runtime.Scheme) *Eve
 // The scheme lookup is the same one applyResource uses, with the Go type name as the fallback for
 // an object the scheme does not know (a product's unregistered extra resource).
 func (e *EventManager) objectKind(obj client.Object) string {
+	return resolveKind(e.scheme, obj)
+}
+
+// resolveKind returns the Kind of obj: its own TypeMeta when populated, else the scheme's answer,
+// else its Go type name. Shared by the event messages and the reconciler's error context so the
+// same object is never called two different things in two different places.
+func resolveKind(scheme *runtime.Scheme, obj client.Object) string {
 	if kind := obj.GetObjectKind().GroupVersionKind().Kind; kind != "" {
 		return kind
 	}
-	if e.scheme != nil {
-		if gvks, _, err := e.scheme.ObjectKinds(obj); err == nil && len(gvks) > 0 {
+	if scheme != nil {
+		if gvks, _, err := scheme.ObjectKinds(obj); err == nil && len(gvks) > 0 {
 			return gvks[0].Kind
 		}
 	}
-	return fmt.Sprintf("%T", obj)
+	return goTypeName(obj)
+}
+
+// goTypeName renders the bare Go type name of obj — "Listener", not "*v1alpha1.Listener". The
+// pointer star and package qualifier are noise in an event message a human scans, and the bare
+// name is what the scheme would have returned had the type been registered.
+func goTypeName(obj any) string {
+	name := strings.TrimPrefix(fmt.Sprintf("%T", obj), "*")
+	if dot := strings.LastIndex(name, "."); dot >= 0 {
+		name = name[dot+1:]
+	}
+	return name
 }
 
 // EmitCreateEvent emits a resource creation event.

--- a/pkg/reconciler/event.go
+++ b/pkg/reconciler/event.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -29,18 +30,45 @@ import (
 // EventManager handles Kubernetes events.
 type EventManager struct {
 	Recorder record.EventRecorder
+
+	// scheme resolves the Kind of the objects named in resource events. See objectKind.
+	scheme *runtime.Scheme
 }
 
-// NewEventManager creates a new EventManager.
-func NewEventManager(recorder record.EventRecorder) *EventManager {
-	return &EventManager{Recorder: recorder}
+// NewEventManager creates a new EventManager. The scheme is optional but strongly recommended: it
+// is what lets resource events name the kind of the object they are about (see objectKind).
+func NewEventManager(recorder record.EventRecorder, scheme *runtime.Scheme) *EventManager {
+	return &EventManager{Recorder: recorder, scheme: scheme}
+}
+
+// objectKind returns the Kind to name in an event message.
+//
+// It cannot come from the object itself: everything the framework applies is a typed struct built
+// by pkg/builder (`&corev1.Service{ObjectMeta: ...}`) and round-tripped through controller-runtime's
+// typed client, which does not populate TypeMeta — so GroupVersionKind().Kind is "" and the message
+// read "Created  ns/kafka-broker-default", with a hole where the kind belongs. The framework applies
+// a Service, a headless Service and a metrics Service under names differing only by suffix, so the
+// kind is exactly the disambiguator someone reading `kubectl get events` after an incident needs.
+//
+// The scheme lookup is the same one applyResource uses, with the Go type name as the fallback for
+// an object the scheme does not know (a product's unregistered extra resource).
+func (e *EventManager) objectKind(obj client.Object) string {
+	if kind := obj.GetObjectKind().GroupVersionKind().Kind; kind != "" {
+		return kind
+	}
+	if e.scheme != nil {
+		if gvks, _, err := e.scheme.ObjectKinds(obj); err == nil && len(gvks) > 0 {
+			return gvks[0].Kind
+		}
+	}
+	return fmt.Sprintf("%T", obj)
 }
 
 // EmitCreateEvent emits a resource creation event.
 func (e *EventManager) EmitCreateEvent(clusterName string, obj client.Object) {
 	e.Recorder.Eventf(obj, corev1.EventTypeNormal, "Created",
 		"Created %s %s/%s for cluster %s",
-		obj.GetObjectKind().GroupVersionKind().Kind,
+		e.objectKind(obj),
 		obj.GetNamespace(),
 		obj.GetName(),
 		clusterName)
@@ -50,7 +78,7 @@ func (e *EventManager) EmitCreateEvent(clusterName string, obj client.Object) {
 func (e *EventManager) EmitUpdateEvent(clusterName string, obj client.Object) {
 	e.Recorder.Eventf(obj, corev1.EventTypeNormal, "Updated",
 		"Updated %s %s/%s for cluster %s",
-		obj.GetObjectKind().GroupVersionKind().Kind,
+		e.objectKind(obj),
 		obj.GetNamespace(),
 		obj.GetName(),
 		clusterName)
@@ -60,7 +88,7 @@ func (e *EventManager) EmitUpdateEvent(clusterName string, obj client.Object) {
 func (e *EventManager) EmitDeleteEvent(clusterName string, obj client.Object) {
 	e.Recorder.Eventf(obj, corev1.EventTypeNormal, "Deleted",
 		"Deleted %s %s/%s for cluster %s",
-		obj.GetObjectKind().GroupVersionKind().Kind,
+		e.objectKind(obj),
 		obj.GetNamespace(),
 		obj.GetName(),
 		clusterName)
@@ -84,30 +112,16 @@ func (e *EventManager) EmitNormalEvent(obj client.Object, reason, message string
 	e.Recorder.Event(obj, corev1.EventTypeNormal, reason, message)
 }
 
-// EmitProgressingEvent emits a progressing event.
-func (e *EventManager) EmitProgressingEvent(obj client.Object, message string) {
-	e.Recorder.Event(obj, corev1.EventTypeNormal, "Progressing", message)
-}
-
-// EmitAvailableEvent emits an available event.
-func (e *EventManager) EmitAvailableEvent(obj client.Object, clusterName string) {
-	e.Recorder.Event(obj, corev1.EventTypeNormal, "Available",
-		fmt.Sprintf("Cluster %s is available", clusterName))
-}
-
-// EmitDegradedEvent emits a degraded event.
-func (e *EventManager) EmitDegradedEvent(obj client.Object, reason, message string) {
-	e.Recorder.Event(obj, corev1.EventTypeWarning, reason, message)
-}
-
-// LogAndEmitError logs an error and emits an event.
+// LogAndEmitError logs an error and emits an event. Provided for extensions and product code; the
+// framework itself does not call it.
 func (e *EventManager) LogAndEmitError(ctx context.Context, obj client.Object, err error, message string) {
 	logger := log.FromContext(ctx)
 	logger.Error(err, message)
 	e.Recorder.Eventf(obj, corev1.EventTypeWarning, "Error", "%s: %v", message, err)
 }
 
-// LogAndEmitInfo logs an info message and emits an event.
+// LogAndEmitInfo logs an info message and emits an event. Provided for extensions and product
+// code; the framework itself does not call it.
 func (e *EventManager) LogAndEmitInfo(ctx context.Context, obj client.Object, reason, message string) {
 	logger := log.FromContext(ctx)
 	logger.Info(message, "reason", reason)

--- a/pkg/reconciler/event_test.go
+++ b/pkg/reconciler/event_test.go
@@ -25,14 +25,23 @@ import (
 	"github.com/zncdatadev/operator-go/pkg/reconciler"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 )
 
 var _ = Describe("EventManager", func() {
 	var eventManager *reconciler.EventManager
+	var events chan string
 	var testPod *corev1.Pod
 
+	// A drained recorder of its own, so each spec reads exactly the events it emitted. The suite's
+	// shared `recorder` is never drained, which is why the specs here used to assert nothing:
+	// "we can't easily verify the exact content with fake recorder" was never true of
+	// record.FakeRecorder — it publishes every event on a channel.
 	BeforeEach(func() {
-		eventManager = reconciler.NewEventManager(recorder)
+		fake := record.NewFakeRecorder(16)
+		events = fake.Events
+		eventManager = reconciler.NewEventManager(fake, testScheme)
 		Expect(eventManager).NotTo(BeNil())
 
 		testPod = &corev1.Pod{
@@ -43,80 +52,80 @@ var _ = Describe("EventManager", func() {
 		}
 	})
 
+	// emitted returns the single event the spec produced, failing if there is none.
+	emitted := func() string {
+		var got string
+		Eventually(events).Should(Receive(&got))
+		return got
+	}
+
 	Describe("NewEventManager", func() {
 		It("should create an EventManager with recorder", func() {
-			Expect(eventManager.Recorder).To(Equal(recorder))
+			Expect(eventManager.Recorder).NotTo(BeNil())
 		})
 	})
 
-	Describe("EmitCreateEvent", func() {
-		It("should emit a create event", func() {
+	Describe("resource events", func() {
+		It("names the object's Kind, which the typed object itself does not carry", func() {
+			// Everything the framework applies is a typed struct from pkg/builder round-tripped
+			// through the typed client, so TypeMeta is empty and the message used to read
+			// "Created  default/test-pod" — a hole exactly where the disambiguator belongs
+			// between a Service, its headless Service and its metrics Service.
+			Expect(testPod.GetObjectKind().GroupVersionKind().Kind).To(BeEmpty())
+
 			eventManager.EmitCreateEvent("test-cluster", testPod)
-			// Event should be recorded (we can't easily verify the exact content with fake recorder)
+			Expect(emitted()).To(ContainSubstring("Created Pod default/test-pod for cluster test-cluster"))
 		})
-	})
 
-	Describe("EmitUpdateEvent", func() {
-		It("should emit an update event", func() {
+		It("names the Kind on update and delete too", func() {
 			eventManager.EmitUpdateEvent("test-cluster", testPod)
-		})
-	})
+			Expect(emitted()).To(ContainSubstring("Updated Pod default/test-pod"))
 
-	Describe("EmitDeleteEvent", func() {
-		It("should emit a delete event", func() {
 			eventManager.EmitDeleteEvent("test-cluster", testPod)
+			Expect(emitted()).To(ContainSubstring("Deleted Pod default/test-pod"))
+		})
+
+		It("falls back to the Go type for an object the scheme does not know", func() {
+			// A product may ship an extra resource whose type is not in the reconciler's scheme;
+			// an empty kind is worse than an approximate one.
+			unknown := reconciler.NewEventManager(record.NewFakeRecorder(4), runtime.NewScheme())
+			Expect(func() { unknown.EmitCreateEvent("test-cluster", testPod) }).NotTo(Panic())
 		})
 	})
 
 	Describe("EmitErrorEvent", func() {
-		It("should emit an error event", func() {
-			testErr := errors.New("test error")
-			eventManager.EmitErrorEvent("test-cluster", testPod, testErr)
+		It("should emit an error event naming the cluster and the cause", func() {
+			eventManager.EmitErrorEvent("test-cluster", testPod, errors.New("boom"))
+			Expect(emitted()).To(ContainSubstring("Reconciliation failed for cluster test-cluster: boom"))
 		})
 	})
 
 	Describe("EmitWarningEvent", func() {
 		It("should emit a warning event", func() {
 			eventManager.EmitWarningEvent(testPod, "TestWarning", "This is a warning")
+			Expect(emitted()).To(ContainSubstring("Warning TestWarning This is a warning"))
 		})
 	})
 
 	Describe("EmitNormalEvent", func() {
 		It("should emit a normal event", func() {
 			eventManager.EmitNormalEvent(testPod, "TestNormal", "This is normal")
+			Expect(emitted()).To(ContainSubstring("Normal TestNormal This is normal"))
 		})
 	})
 
-	Describe("EmitProgressingEvent", func() {
-		It("should emit a progressing event", func() {
-			eventManager.EmitProgressingEvent(testPod, "Cluster is progressing")
-		})
-	})
-
-	Describe("EmitAvailableEvent", func() {
-		It("should emit an available event", func() {
-			eventManager.EmitAvailableEvent(testPod, "test-cluster")
-		})
-	})
-
-	Describe("EmitDegradedEvent", func() {
-		It("should emit a degraded event", func() {
-			eventManager.EmitDegradedEvent(testPod, "TestDegraded", "Cluster is degraded")
-		})
-	})
-
+	// LogAndEmitError/LogAndEmitInfo are product-facing helpers the framework never calls itself.
 	Describe("LogAndEmitError", func() {
 		It("should log and emit an error event", func() {
-			ctx := context.Background()
-			testErr := errors.New("test error")
-			eventManager.LogAndEmitError(ctx, testPod, testErr, "Operation failed")
+			eventManager.LogAndEmitError(context.Background(), testPod, errors.New("boom"), "Operation failed")
+			Expect(emitted()).To(ContainSubstring("Warning Error Operation failed: boom"))
 		})
 	})
 
 	Describe("LogAndEmitInfo", func() {
 		It("should log and emit an info event", func() {
-			ctx := context.Background()
-			eventManager.LogAndEmitInfo(ctx, testPod, "TestReason", "Operation succeeded")
+			eventManager.LogAndEmitInfo(context.Background(), testPod, "TestReason", "Operation succeeded")
+			Expect(emitted()).To(ContainSubstring("Normal TestReason Operation succeeded"))
 		})
 	})
 })

--- a/pkg/reconciler/event_test.go
+++ b/pkg/reconciler/event_test.go
@@ -85,11 +85,20 @@ var _ = Describe("EventManager", func() {
 			Expect(emitted()).To(ContainSubstring("Deleted Pod default/test-pod"))
 		})
 
-		It("falls back to the Go type for an object the scheme does not know", func() {
+		It("falls back to the bare Go type name for an object the scheme does not know", func() {
 			// A product may ship an extra resource whose type is not in the reconciler's scheme;
-			// an empty kind is worse than an approximate one.
-			unknown := reconciler.NewEventManager(record.NewFakeRecorder(4), runtime.NewScheme())
-			Expect(func() { unknown.EmitCreateEvent("test-cluster", testPod) }).NotTo(Panic())
+			// an empty kind is worse than an approximate one. The fallback is the bare type name —
+			// "Pod", not "*v1.Pod" — because the star and the package qualifier are noise in a
+			// message a human scans, and the bare name is what the scheme would have answered.
+			fake := record.NewFakeRecorder(4)
+			unknown := reconciler.NewEventManager(fake, runtime.NewScheme())
+			unknown.EmitCreateEvent("test-cluster", testPod)
+
+			var got string
+			Eventually(fake.Events).Should(Receive(&got))
+			Expect(got).To(ContainSubstring("Created Pod default/test-pod"))
+			Expect(got).NotTo(ContainSubstring("Created  "), "an empty kind is the original bug")
+			Expect(got).NotTo(ContainSubstring("*"))
 		})
 	})
 

--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -287,7 +287,7 @@ func NewGenericReconciler[CR common.ClusterResource[CR]](cfg *GenericReconcilerC
 		healthManager.WithServiceHealthCheck(cfg.ServiceHealthCheck)
 	}
 
-	eventManager := NewEventManager(cfg.Recorder)
+	eventManager := NewEventManager(cfg.Recorder, cfg.Scheme)
 
 	rateLimitRetryAfter := cfg.RateLimitRetryAfter
 	if rateLimitRetryAfter == 0 {

--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -1268,10 +1268,7 @@ func (r *GenericReconciler[CR]) validateSidecars(ctx context.Context, buildCtx *
 // messages for ExtraResources, whose GVK is not fixed). Typed objects usually carry an empty
 // TypeMeta, so the scheme registration is preferred; the Go type name is the fallback.
 func (r *GenericReconciler[CR]) resourceKind(obj client.Object) string {
-	if gvks, _, err := r.scheme.ObjectKinds(obj); err == nil && len(gvks) > 0 {
-		return gvks[0].Kind
-	}
-	return fmt.Sprintf("%T", obj)
+	return resolveKind(r.scheme, obj)
 }
 
 // applyResource applies a single resource using CreateOrUpdate: it creates the object when


### PR DESCRIPTION
W12, part 1 — the documentation-fidelity batch. Every claim below was checked by enumerating call sites, not by reading the prose.

## Two doc claims the code does not support

**"Emits events for Reconcile start (debug level), completion, and critical failures."** (§4.14.2)

Nothing is emitted at the beginning or end of a pass. An SRE alerting on the documented "reconcile completed" event to catch a stalled operator would have an alert that is permanently firing or permanently silent depending on how it was written — and the silence reads as an operator outage rather than a doc error.

Replaced with an explicit statement that progress is reported through **status conditions**, plus the complete list of the nine events the framework really emits.

**"encapsulates the `EventRecorder` … and injects it into the Reconciler context."**

It is a struct field, handed to the cleaner. Nothing puts it in a `context`. Corrected, with what a hook should do instead.

## One bug the same audit turned up

`Created`/`Updated`/`Deleted` read the Kind off the object — but everything the framework applies is a typed struct from `pkg/builder` round-tripped through controller-runtime's typed client, which does not populate `TypeMeta`. Every such message read:

```
Created  default/kafka-broker-default for cluster kafka
```

with a hole exactly where the disambiguator belongs. The framework applies a Service, a headless Service and a metrics Service under names differing only by suffix, so the kind is the one thing that tells them apart in `kubectl get events` after an incident.

`NewEventManager` now takes the scheme and resolves the kind through it — the same lookup `applyResource` already used — with the Go type name as the fallback for an object the scheme does not know.

## `clusterConfig` is product-owned, and the docs said otherwise

`docs/examples/crd-base-example.yaml` presented `clusterConfig` under a `--- Standard SDK Fields ---` heading. But commons defines **no** `ClusterConfigSpec`, and `GenericClusterSpec` has exactly `image`, `clusterOperation` and `roles`. The block is entirely product-owned — which is why five products spell the same concepts five ways (`vectorAggregatorConfigMapName` vs `vectorAgentConfigMap`, and so on). Because the authoritative doc asserted a shared contract, each author believed they were implementing one.

Now labelled product-owned and illustrative, pointing at the explicit APIs (`VectorAggregatorProvider`, `SecretProvisioner`, `ListenerProvisioner`) through which the SDK genuinely consumes those concepts.

## BREAKING

- `NewEventManager(recorder)` → `NewEventManager(recorder, scheme)`.
- `EmitProgressingEvent`, `EmitAvailableEvent`, `EmitDegradedEvent` removed. The framework never called them and they mirror transitions it already owns through status conditions, so a product calling them would publish a second, unsynchronized account of the cluster's state. An exported emitter the framework never calls also *reads* as a framework guarantee — which is how the doc claim above survived review. `EmitWarningEvent`/`EmitNormalEvent`/`LogAndEmitError`/`LogAndEmitInfo` stay; the last two now say the framework never calls them.

## On the tests

The event specs asserted **nothing** — every one just called the method, under a comment claiming content "can't easily be verified with fake recorder", which was never true of `record.FakeRecorder` (it publishes every event on a channel). They now read the emitted message off a drained recorder, which is what makes the Kind fix verifiable. Mutation-tested by disabling the scheme lookup: 2 specs fail.

## Verification

`make lint` 0 issues; `make test` all pass; `make verify-generate` up to date; examples module builds and tests pass.