### PR TITLE
fix(security): a scope name carrying "," or "=" no longer widens the credential

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -702,6 +702,13 @@ driver to resolve, so an empty argument panics. The same rule is enforced for ev
 secret-operator. `security.ScopeString(*commonsv1alpha1.CredentialsScope)` renders a CRD scope into
 that annotation value.
 
+A scope **name** may contain neither `,` nor `=`: the annotation has no escaping, so such a name
+does not quote itself — it adds scopes. `services: ["mysvc,node"]` would render `service=mysvc,node`
+and hand the CR author a **node-scoped** certificate covering the node's hostname and IP. The CRD
+rejects it at admission (`items:Pattern` on `CredentialsScope.Services`/`.ListenerVolumes`), and
+`ScopeString` drops any entry it cannot render as itself for the cases admission cannot reach (a CR
+stored before those markers, a scope built in Go).
+
 `pkg/listener` has **no scope API**: `VolumeRegistration.WithScope`, the `ListenerScope` type,
 `ListenerScopeNode`, `ListenerScopeCluster` and `ListenerScopeAnnotation` do not exist, and listener
 PVC templates carry no `listeners.kubedoop.dev/scope` annotation. A listener volume is declared with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,22 @@ changes are listed below.**
     progress markers. A product that needs e.g. cloud LoadBalancer annotations on the client Service
     has no supported way to set them; tracked in #553.
 
+### security (secret scopes)
+
+- **A CR-supplied scope name containing `,` or `=` no longer widens the credential it asks for.**
+  The secret-operator scope annotation is one comma-delimited string of `key=value` entries with no
+  escaping, and `scope.Services` / `scope.ListenerVolumes` were spliced into it verbatim. A value
+  of `mysvc,node` rendered `service=mysvc,node`, which the secret-operator parses as a service
+  scope **and a node scope** — the CR author silently received a certificate covering the node's
+  hostname and IP, and a reviewer reading the CR saw nothing unusual.
+  - `CredentialsScope.Services` and `.ListenerVolumes` now carry
+    `+kubebuilder:validation:items:Pattern=^[^,=]+$` and `items:MinLength=1`, so the **API server
+    rejects it at admission**, where the user is told about it. That is the real fix.
+  - `security.ScopeString` additionally drops any entry it cannot render as itself, covering what
+    admission cannot: a CR stored before those markers existed, and a scope built in Go. Dropping
+    is the safe direction — splicing grants a broader credential invisibly, while dropping
+    withholds a requested one, which surfaces as the application rejecting the certificate.
+
 ### fix (events)
 
 - `Created`/`Updated`/`Deleted` events now name the object's **Kind**. Everything the framework

--- a/docs/DOC_CHANGELOG.md
+++ b/docs/DOC_CHANGELOG.md
@@ -4,6 +4,18 @@ This document tracks all changes made to the SDK documentation.
 
 ---
 
+## [2026-07-27f] (scope names cannot carry the annotation's own syntax)
+
+### Security Documentation (`security.md`)
+
+- The "Named scopes must carry a name" section covered the empty-name case but not the opposite
+  one: a name containing `,` or `=` does not quote itself, it **adds scopes**. Added the rule, the
+  concrete escalation (`services: ["mysvc,node"]` yields a node-scoped certificate nobody asked
+  for), and the two layers that now stop it — CRD `items:Pattern` at admission, and `ScopeString`
+  dropping unrenderable entries for what admission cannot reach.
+
+---
+
 ## [2026-07-27e] (event vocabulary; clusterConfig is product-owned)
 
 Two claims the docs made that the code does not support. Both were checked by enumerating the

--- a/docs/security.md
+++ b/docs/security.md
@@ -71,6 +71,21 @@ entries as `key=<value>` and unconditionally reads the value, so a bare `service
   prefix for the named entries. It returns `""` for a nil/empty scope, in which case the annotation
   is omitted.
 
+**A scope name may contain neither `,` nor `=`.** The annotation is one comma-delimited string of
+`key=value` entries with no escaping, so a name carrying either character does not quote itself —
+it **adds scopes**. `services: ["mysvc,node"]` renders `service=mysvc,node`, which the
+secret-operator reads as a service scope *and* a **node** scope: the CR author silently receives a
+certificate covering the node's hostname and IP, and a reviewer reading the CR sees nothing
+unusual. Two layers stop that:
+
+- `CredentialsScope.Services` and `.ListenerVolumes` carry `+kubebuilder:validation:items:Pattern`
+  (`^[^,=]+$`) and `items:MinLength=1`, so the **API server rejects it at `kubectl apply`** — where
+  the user sees the error and can fix it. This is the real defence.
+- `ScopeString` drops any entry it cannot render as itself, covering what admission cannot: a CR
+  stored before those markers existed, and a scope built in Go. Dropping is the safe direction —
+  splicing grants a *broader* credential than requested, invisibly, while dropping withholds a
+  requested scope, which surfaces as the application rejecting the certificate.
+
 The default PKCS12 password (`changeit`) is stored as a **PVC template annotation** and is therefore
 readable by anyone with `get` on PVCs. Use `WithPassword` or `WithNoPassword`.
 

--- a/pkg/apis/commons/v1alpha1/credentials.go
+++ b/pkg/apis/commons/v1alpha1/credentials.go
@@ -34,9 +34,26 @@ type CredentialsScope struct {
 	// +kubebuilder:validation:Optional
 	Pod bool `json:"pod,omitempty"`
 
+	// Services scopes the credential to the named Services.
+	//
+	// A name may contain neither "," nor "=": the scopes are handed to the secret-operator as one
+	// comma-delimited annotation of "key=value" entries, so a name carrying either character would
+	// be parsed as additional scopes. "mysvc,node" would request a NODE-scoped certificate — one
+	// covering the node's hostname and IP — that nobody reading the CR asked for or could see.
+	// Rejecting it here means the user is told at `kubectl apply`, instead of quietly receiving a
+	// broader credential.
+	//
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:items:MinLength=1
+	// +kubebuilder:validation:items:Pattern=`^[^,=]+$`
 	Services []string `json:"services,omitempty"`
 
+	// ListenerVolumes scopes the credential to the named listener volumes.
+	//
+	// Same delimiter rule as Services: neither "," nor "=" may appear in a name.
+	//
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:items:MinLength=1
+	// +kubebuilder:validation:items:Pattern=`^[^,=]+$`
 	ListenerVolumes []string `json:"listenerVolumes,omitempty"`
 }

--- a/pkg/security/secret_class.go
+++ b/pkg/security/secret_class.go
@@ -94,21 +94,41 @@ func ScopeString(scope *commonsv1alpha1.CredentialsScope) string {
 	if scope.Pod {
 		entries = append(entries, string(PodScope))
 	}
-	// Entries come straight out of a CR, where a list can legally contain an empty string. A
-	// nameless "service=" entry is not a scope the secret-operator can resolve, so it is dropped
-	// here rather than rejected downstream: this is user data, and the alternative is failing a
-	// whole cluster's reconcile over an empty list item.
+	// Entries come straight out of a CR, so a name may be empty or carry the annotation's own
+	// syntax. Both are dropped rather than rejected: this is user data reaching a reconcile loop,
+	// and the alternative is failing a whole cluster over one list item. See scopeNameUsable.
 	for _, svc := range scope.Services {
-		if svc == "" {
+		if !scopeNameUsable(svc) {
 			continue
 		}
 		entries = append(entries, string(ServiceScope)+"="+svc)
 	}
 	for _, lv := range scope.ListenerVolumes {
-		if lv == "" {
+		if !scopeNameUsable(lv) {
 			continue
 		}
 		entries = append(entries, string(ListenerVolumeScope)+"="+lv)
 	}
 	return strings.Join(entries, CommonDelimiter)
+}
+
+// scopeNameUsable reports whether name can be rendered into the scope annotation as itself.
+//
+// The annotation is one comma-delimited string of "key=value" entries, so a name containing the
+// delimiter or the separator does not escape — it ADDS scopes. "mysvc,node" renders
+// "service=mysvc,node", which the secret-operator parses as a service scope *and* a node scope:
+// the CR author silently receives a certificate covering the node's hostname and IP, and a
+// reviewer reading the CR sees nothing unusual. An empty name renders a bare "service=" the
+// secret-operator cannot resolve at all.
+//
+// Dropping is the safe direction of the two available here. Splicing grants a broader credential
+// than the CR requested, invisibly; dropping withholds a scope the CR requested, which surfaces
+// as the application rejecting the certificate — a visible failure with a cause the user can
+// find. The loud rejection lives at the CRD layer (see CredentialsScope), where the user is told
+// at `kubectl apply`; this guard covers what admission cannot: a CR stored before those markers
+// existed, and a scope built in Go.
+func scopeNameUsable(name string) bool {
+	return name != "" &&
+		!strings.Contains(name, CommonDelimiter) &&
+		!strings.Contains(name, "=")
 }

--- a/pkg/security/secret_class_test.go
+++ b/pkg/security/secret_class_test.go
@@ -80,3 +80,49 @@ var _ = Describe("ScopeString with empty list entries", func() {
 		})).To(Equal("pod,service=trino"))
 	})
 })
+
+// A scope name carrying the annotation's own syntax does not escape — it adds scopes. This is the
+// privilege half of the same problem the empty-entry specs above cover.
+var _ = Describe("ScopeString with delimiter-bearing names", func() {
+	It("drops a service name containing the delimiter instead of granting a second scope", func() {
+		// "mysvc,node" would render "service=mysvc,node", which the secret-operator parses as a
+		// service scope AND a node scope: the CR author silently receives a certificate covering
+		// the node's hostname and IP, and a reviewer reading the CR sees nothing unusual.
+		rendered := security.ScopeString(&commonsv1alpha1.CredentialsScope{
+			Services: []string{"mysvc,node"},
+		})
+
+		Expect(rendered).NotTo(ContainSubstring("node"))
+		Expect(rendered).To(BeEmpty())
+	})
+
+	It("drops a name containing the key separator", func() {
+		// "a=b" would render "service=a=b"; the secret-operator's Cut on the first "=" yields the
+		// value "a=b" for some parsers and "a" for others. Either way it is not what was asked for.
+		Expect(security.ScopeString(&commonsv1alpha1.CredentialsScope{
+			Services:        []string{"a=b"},
+			ListenerVolumes: []string{"c=d"},
+		})).To(BeEmpty())
+	})
+
+	It("keeps the well-formed entries alongside a dropped one", func() {
+		// Dropping is per entry: one malformed item must not cost the user the scopes that are
+		// fine, and the surviving scope is narrower than requested rather than wider.
+		Expect(security.ScopeString(&commonsv1alpha1.CredentialsScope{
+			Node:            true,
+			Services:        []string{"good", "bad,node"},
+			ListenerVolumes: []string{"lv-ok", "lv=bad"},
+		})).To(Equal("node,service=good,listener-volume=lv-ok"))
+	})
+
+	It("never emits a scope the CR did not ask for", func() {
+		// The property that matters, stated directly: whatever a user writes, the rendered
+		// annotation contains no entry beyond the ones their CR named.
+		for _, hostile := range []string{"x,node", "x,pod", "x=y", ",node", "node,"} {
+			rendered := security.ScopeString(&commonsv1alpha1.CredentialsScope{
+				Services: []string{hostile},
+			})
+			Expect(rendered).To(BeEmpty(), "input %q leaked a scope", hostile)
+		}
+	})
+})


### PR DESCRIPTION
W12, part 2 — the LOW-findings cleanup. One real issue survived triage; the other two candidates are addressed below.

## The bug

The secret-operator scope annotation is one comma-delimited string of `key=value` entries **with no escaping**, and `scope.Services` / `scope.ListenerVolumes` — which come verbatim from a product CR — were spliced into it. A name does not quote itself there; it **adds scopes**:

```yaml
credentials:
  scope:
    services: ["mysvc,node"]
```
```
secrets.kubedoop.dev/scope: service=mysvc,node
```

which the secret-operator reads as a service scope **and a node scope**. The CR author silently receives a certificate covering the node's hostname and IP — broader than anything they asked for — and a reviewer reading the CR sees a perfectly ordinary service name.

## Two layers, in the order that matters

**1. The API server rejects it at `kubectl apply`.** `CredentialsScope.Services` and `.ListenerVolumes` now carry `+kubebuilder:validation:items:Pattern=^[^,=]+$` and `items:MinLength=1`. This is the actual fix — the error reaches the person who can correct it.

> The marker's rendering was verified against controller-gen v0.19 directly, because **no CRD in this repo embeds `CredentialsScope`** — the SDK deliberately ships API types, not CRDs — so `make manifests` cannot assert it here. Generating the s3/commons CRDs just to test a marker would contradict that design decision, so I did not.

**2. `ScopeString` drops any entry it cannot render as itself**, covering what admission cannot reach: a CR stored before those markers existed, and a scope built in Go.

Dropping is the safe direction of the two available at reconcile time:

| | effect |
|---|---|
| splice | grants a **broader** credential than requested, **invisibly** |
| drop | withholds a requested scope → the application rejects the certificate, a visible failure with a findable cause |

It is per entry, so one malformed item does not cost the user the scopes that are fine.

## What I deliberately left alone

- **`WithScope`'s panic.** After this change `ScopeString` output is valid by construction, so the only way to reach it is a hand-built string from product code — programmer input, where panicking matches `WithMountBasePath` on a relative path and `ListenerVolume` on an empty name.
- **`PodDisruptionBudgetSpec.Enabled`** (the other LOW finding): checked, and **already fixed** by an earlier wave — it is `*bool` with a nil-safe `IsEnabled()`. Nothing to do.
- **`automountServiceAccountToken: false`** (the third): still open. It is a behaviour change that would break products which genuinely call the Kubernetes API, so it wants an opt-in API and your call rather than a quiet default flip in a cleanup PR.

## Verification

- `make lint` 0 issues; `make test` all pass; `make verify-generate` up to date; examples module builds and tests pass.
- 4 new specs, including a property-style one asserting that no hostile input produces a scope the CR did not name. Mutation-tested: reverting the guard to the old empty-check fails all four.