### PR TITLE
fix(naming): bound the label key derived from cluster and role group names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -280,6 +280,14 @@ selector is immutable, and `version` changes on every product upgrade. Upgrading
 into this label set rolls its pods once, because the pod template gains labels; the frozen selector
 keeps matching. See `pkg/reconciler/AGENTS.md` §15.
 
+The marker goes through `reconciler.RoleGroupMarkerLabelKey(cluster, role, group)`, which returns
+the natural `<cluster>-<group>` when that is a legal label key and `RoleGroupResourceName` when it
+is not. A label key's name part is capped at 63 bytes, and ordinary names overrun it — a
+43-character cluster plus a 21-character role group is 65 — at which point the API server rejects
+the StatefulSet, both Services and the PDB of that role group. Keeping the natural form wherever it
+is legal is what makes this safe for running clusters: the key is inside the immutable
+`.spec.selector`, so only combinations that could never have produced a StatefulSet may change.
+
 On top of that set the handler adds the **cluster CR's own labels**
 (`RoleGroupBuildContext.ClusterLabels`), applied *first* so the framework's identity labels win over
 a colliding key — which makes a colliding CR label inert rather than an error. This is the framework's
@@ -311,6 +319,17 @@ product-config/role/role-group overrides), `ResourceName` (`{cluster}-{role}-{gr
 with a hash suffix by `RoleGroupResourceName`), `ServiceAccountName` (the SA the reconciler
 resolved and ensured), `SidecarManager`, `VolumeProviders` (see §16) and
 `VectorAggregatorAddress`.
+
+**Role and role group names are constrained by the CRD, not by convention.** The keys of
+`spec.roles` and `spec.roles.<role>.roleGroups` must be lowercase RFC 1123 labels — a CEL
+`x-kubernetes-validations` rule on `GenericClusterSpec.Roles` and `RoleSpec.RoleGroups` rejects
+anything else at `kubectl apply`. They are not free-form: each becomes a segment of
+`<cluster>-<role>-<group>` and the value of an `app.kubernetes.io/*` label, so `Coordinator`,
+`my_role` and `a.b` all yield resource names the API server refuses. Without the rule that refusal
+surfaced mid-reconcile as a permanently `Degraded` role quoting a `metadata.name` the user never
+wrote. Both maps also carry a `maxProperties` bound (64 roles, 256 role groups): it exists because
+the CEL cost estimator has no other handle on a map — without it the API server rejects the rule at
+CRD creation time — and is set far above any real deployment.
 
 ### 5. Extension System
 Three levels of extensions for injecting custom logic, all generic over the product CR type:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,47 @@ changes are listed below.**
     progress markers. A product that needs e.g. cloud LoadBalancer annotations on the client Service
     has no supported way to set them; tracked in #553.
 
+### fix (naming)
+
+- **A role group whose cluster and group names together exceed 63 bytes can now be created at
+  all.** The framework stamps a marker label keyed `<cluster>-<group>`, and a label key's name part
+  is capped at 63 bytes. Two entirely ordinary big-data names overrun it — a 43-character cluster
+  plus a 21-character role group is 65 — and because the key lands in the StatefulSet's
+  `.spec.selector`, in both Services' selectors and in every pod template label set, the API server
+  rejected the StatefulSet, both Services *and* the PDB of that role group, quoting a label key the
+  user never wrote. The resource *name* built from the same two strings was already bounded by
+  `RoleGroupResourceName`; the framework had applied a limit it knew about to one of the two places
+  it applies.
+
+  `reconciler.RoleGroupMarkerLabelKey(cluster, role, group)` now produces the key: the natural
+  `<cluster>-<group>` whenever that is a legal label key, `RoleGroupResourceName` otherwise.
+  Preserving the natural form is load-bearing rather than cosmetic — `.spec.selector` is immutable,
+  so changing this key for a role group that already has a StatefulSet would leave the pod template
+  no longer matching the frozen selector and every later update rejected. Only combinations that
+  could never have produced a StatefulSet get the substitute, so **running clusters are
+  byte-for-byte unaffected**.
+- `RoleResourceName` is unchanged, and its doc comment now gives the real reason: a
+  PodDisruptionBudget name is validated as a DNS *subdomain* (253 bytes), not the 63-byte DNS label
+  that bounds a Service name. The previous comment justified the absence of truncation by comparing
+  against the role group name, which is itself truncated — right conclusion, wrong argument.
+
+### BREAKING (role and role group names)
+
+- The keys of `spec.roles` and `spec.roles.<role>.roleGroups` must now be **lowercase RFC 1123
+  labels**, enforced by a CEL `x-kubernetes-validations` rule on `GenericClusterSpec.Roles` and
+  `RoleSpec.RoleGroups`. Every product CRD picks this up on the next `make manifests`.
+
+  This only rejects what never worked: each key becomes a segment of `<cluster>-<role>-<group>` and
+  the value of an `app.kubernetes.io/*` label, so `Coordinator`, `my_role` and `a.b` have always
+  produced resource names the API server refuses. What changes is *when* the user hears about it —
+  at `kubectl apply`, in a message naming the rule, instead of halfway through a reconcile as a
+  permanently `Degraded` role quoting a `metadata.name` nobody wrote.
+- Both maps gained `maxProperties` (64 roles, 256 role groups per role). This is not a product
+  constraint but the CEL cost estimator's only handle on a map: without a declared bound it assumes
+  the theoretical worst case and the API server refuses the rule at CRD creation time with
+  "estimated rule cost exceeds budget by factor of more than 100x". The bounds sit far above any
+  real deployment.
+
 ### security (secret scopes)
 
 - **A CR-supplied scope name containing `,` or `=` no longer widens the credential it asks for.**

--- a/config/crd/bases/test.zncdata.dev_altmockclusters.yaml
+++ b/config/crd/bases/test.zncdata.dev_altmockclusters.yaml
@@ -542,12 +542,49 @@ spec:
                       description: |-
                         RoleGroups defines the role group configurations.
                         Each RoleGroup maps to a Kubernetes StatefulSet.
+
+                        Constrained for the same reason as the role name above: a role group name is a segment of
+                        "<cluster>-<role>-<group>" and the value of the app.kubernetes.io/role-group label, so a name
+                        that is not a lowercase RFC 1123 label yields resource names the API server refuses.
+
+                        MaxProperties bounds the CEL cost estimate, not the deployment — see the note on Roles.
+                        256 role groups in a single role is far past one per rack in a very large cluster.
+                      maxProperties: 256
                       type: object
+                      x-kubernetes-validations:
+                      - message: 'each role group name must be a lowercase RFC 1123
+                          label (lowercase alphanumerics and ''-'', starting and ending
+                          with an alphanumeric, at most 63 characters): role group
+                          names become part of the name and labels of every resource
+                          built for the group'
+                        rule: self.all(k, size(k) <= 63 && k.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'))
                   type: object
                 description: |-
                   Roles defines the role configurations for the cluster.
                   Each role represents a logical functional component (e.g., NameNode, DataNode).
+
+                  A role name is not free-form: it becomes a segment of the name of every resource built for
+                  the role ("<cluster>-<role>-<group>") and the value of the app.kubernetes.io/component
+                  label. A name that is not a lowercase RFC 1123 label therefore produces resource names the
+                  API server rejects — "Coordinator", "my_role" and "a.b" all fail on the StatefulSet's or the
+                  Service's metadata.name. Without this rule that rejection surfaces halfway through a
+                  reconcile, as a permanently Degraded role complaining about a field the user never wrote;
+                  with it, `kubectl apply` says so immediately.
+
+                  MaxProperties is not a product constraint — no product has 64 distinct roles — but the CEL
+                  cost estimator's only handle on a map. Without a declared bound it assumes the theoretical
+                  worst case and rejects the rule below at CRD creation time with "estimated rule cost exceeds
+                  budget by factor of more than 100x". The bound is set far above any real deployment so it
+                  never binds in practice, and low enough to leave a product's own CRD room in the per-schema
+                  budget it shares.
+                maxProperties: 64
                 type: object
+                x-kubernetes-validations:
+                - message: 'each role name must be a lowercase RFC 1123 label (lowercase
+                    alphanumerics and ''-'', starting and ending with an alphanumeric,
+                    at most 63 characters): role names become part of the name and
+                    labels of every resource built for the role'
+                  rule: self.all(k, size(k) <= 63 && k.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'))
             type: object
           status:
             description: |-

--- a/config/crd/bases/test.zncdata.dev_mockclusters.yaml
+++ b/config/crd/bases/test.zncdata.dev_mockclusters.yaml
@@ -529,12 +529,49 @@ spec:
                       description: |-
                         RoleGroups defines the role group configurations.
                         Each RoleGroup maps to a Kubernetes StatefulSet.
+
+                        Constrained for the same reason as the role name above: a role group name is a segment of
+                        "<cluster>-<role>-<group>" and the value of the app.kubernetes.io/role-group label, so a name
+                        that is not a lowercase RFC 1123 label yields resource names the API server refuses.
+
+                        MaxProperties bounds the CEL cost estimate, not the deployment — see the note on Roles.
+                        256 role groups in a single role is far past one per rack in a very large cluster.
+                      maxProperties: 256
                       type: object
+                      x-kubernetes-validations:
+                      - message: 'each role group name must be a lowercase RFC 1123
+                          label (lowercase alphanumerics and ''-'', starting and ending
+                          with an alphanumeric, at most 63 characters): role group
+                          names become part of the name and labels of every resource
+                          built for the group'
+                        rule: self.all(k, size(k) <= 63 && k.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'))
                   type: object
                 description: |-
                   Roles defines the role configurations for the cluster.
                   Each role represents a logical functional component (e.g., NameNode, DataNode).
+
+                  A role name is not free-form: it becomes a segment of the name of every resource built for
+                  the role ("<cluster>-<role>-<group>") and the value of the app.kubernetes.io/component
+                  label. A name that is not a lowercase RFC 1123 label therefore produces resource names the
+                  API server rejects — "Coordinator", "my_role" and "a.b" all fail on the StatefulSet's or the
+                  Service's metadata.name. Without this rule that rejection surfaces halfway through a
+                  reconcile, as a permanently Degraded role complaining about a field the user never wrote;
+                  with it, `kubectl apply` says so immediately.
+
+                  MaxProperties is not a product constraint — no product has 64 distinct roles — but the CEL
+                  cost estimator's only handle on a map. Without a declared bound it assumes the theoretical
+                  worst case and rejects the rule below at CRD creation time with "estimated rule cost exceeds
+                  budget by factor of more than 100x". The bound is set far above any real deployment so it
+                  never binds in practice, and low enough to leave a product's own CRD room in the per-schema
+                  budget it shares.
+                maxProperties: 64
                 type: object
+                x-kubernetes-validations:
+                - message: 'each role name must be a lowercase RFC 1123 label (lowercase
+                    alphanumerics and ''-'', starting and ending with an alphanumeric,
+                    at most 63 characters): role names become part of the name and
+                    labels of every resource built for the role'
+                  rule: self.all(k, size(k) <= 63 && k.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'))
             type: object
           status:
             description: |-

--- a/docs/DOC_CHANGELOG.md
+++ b/docs/DOC_CHANGELOG.md
@@ -4,6 +4,22 @@ This document tracks all changes made to the SDK documentation.
 
 ---
 
+## [2026-07-28a] (identifiers derived from user names are bounded and validated)
+
+### Framework Documentation (`AGENTS.md`, `pkg/reconciler/AGENTS.md`)
+
+- Documented that the role group marker label key goes through `RoleGroupMarkerLabelKey` rather
+  than being concatenated: `<cluster>-<group>` is a label *key* built from two free-form user
+  strings and overruns the 63-byte limit with ordinary names, at which point the API server rejects
+  the whole role group. Recorded why the natural form has to be preserved wherever it is legal —
+  the key sits inside the immutable `.spec.selector`, so only combinations that could never have
+  produced a StatefulSet may change.
+- Documented the new CRD constraint on role and role group names (lowercase RFC 1123 labels,
+  enforced by CEL at admission) and the `maxProperties` bounds that exist only so the CEL cost
+  estimator can size the rule.
+
+---
+
 ## [2026-07-27f] (scope names cannot carry the annotation's own syntax)
 
 ### Security Documentation (`security.md`)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -32,6 +32,10 @@ This document systematically expounds the design philosophy, architectural layer
 - **RoleGroup**
   - The physical unit of deployment and resource isolation under a Role. Each RoleGroup maps directly to a Kubernetes `StatefulSet` (and associated Service, ConfigMap, PDB). This allows a single Role to be partitioned into multiple groups with distinct hardware specifications (CPU/Memory), replica counts, or specialized configurations (e.g., a "high-performance" DataNode group vs. a "standard" group).
 
+- **Naming**
+  - Role and RoleGroup names are **identifiers, not labels**: the framework derives the name of every resource it builds (`<cluster>-<role>-<group>`), the value of several `app.kubernetes.io/*` labels, and a label *key* from them. They are therefore constrained to lowercase RFC 1123 labels and validated at admission, so a name that cannot become a Kubernetes identifier is rejected where the user can act on it rather than partway through a reconcile.
+  - Every identifier the framework derives must be **bounded**, because the user-supplied parts are not. A derived name is truncated with a hash suffix (`RoleGroupResourceName`); a derived label key falls back to that bounded name when the natural form would exceed the 63-byte limit (`RoleGroupMarkerLabelKey`). A derivation that lands inside an immutable field — the StatefulSet's `.spec.selector` — may only change its output for inputs that could never have produced that object in the first place, or existing clusters become unpatchable.
+
 - **SecretClass**
   - An object managed by `secret-operator`, enabling the injection of sensitive data (Certificates, Kerberos Keytabs, Passwords) into Pods via the Kubernetes CSI (Container Storage Interface). Workloads reference a `SecretClass` to mount volumes that are dynamically populated by specific security backends.
 

--- a/docs/architecture_zh.md
+++ b/docs/architecture_zh.md
@@ -32,6 +32,10 @@
 - **RoleGroup（角色组）**
   - 是 Role 下部署和资源隔离的物理单元。每个 RoleGroup 直接映射到一个 Kubernetes `StatefulSet`（以及关联的 Service、ConfigMap、PDB）。这允许将单个 Role 划分为多个具有不同硬件规格（CPU/Memory）、副本数量或特殊配置的组（例如"高性能" DataNode 组与"标准"组）。
 
+- **命名（Naming）**
+  - Role 与 RoleGroup 的名字是**标识符，不是标签文本**：框架用它们派生出所构建的每个资源的名字（`<cluster>-<role>-<group>`）、若干 `app.kubernetes.io/*` 标签的值，以及一个标签**键**。因此它们被约束为小写 RFC 1123 label 并在 admission 阶段校验——一个无法成为 Kubernetes 标识符的名字应当在用户能够改它的地方被拒绝，而不是在 reconcile 中途失败。
+  - 框架派生出的每个标识符都必须**有界**，因为用户提供的部分没有上界。派生的资源名以哈希后缀截断（`RoleGroupResourceName`）；派生的标签键在自然形式超过 63 字节限制时回退到该有界名字（`RoleGroupMarkerLabelKey`）。落在不可变字段里的派生——StatefulSet 的 `.spec.selector`——只允许对那些本来就无法创建出该对象的输入改变输出，否则存量集群将变得无法更新。
+
 - **SecretClass**
   - 由 `secret-operator` 管理的对象，通过 Kubernetes CSI (Container Storage Interface) 将敏感数据（Certificates、Kerberos Keytabs、Passwords）注入到 Pods 中。Workloads 引用 `SecretClass` 来挂载由特定安全后端动态填充的卷。
 

--- a/examples/trino-operator/config/crd/bases/trino.kubedoop.dev_trinoclusters.yaml
+++ b/examples/trino-operator/config/crd/bases/trino.kubedoop.dev_trinoclusters.yaml
@@ -546,7 +546,22 @@ spec:
                     description: |-
                       RoleGroups defines the role group configurations.
                       Each RoleGroup maps to a Kubernetes StatefulSet.
+
+                      Constrained for the same reason as the role name above: a role group name is a segment of
+                      "<cluster>-<role>-<group>" and the value of the app.kubernetes.io/role-group label, so a name
+                      that is not a lowercase RFC 1123 label yields resource names the API server refuses.
+
+                      MaxProperties bounds the CEL cost estimate, not the deployment — see the note on Roles.
+                      256 role groups in a single role is far past one per rack in a very large cluster.
+                    maxProperties: 256
                     type: object
+                    x-kubernetes-validations:
+                    - message: 'each role group name must be a lowercase RFC 1123
+                        label (lowercase alphanumerics and ''-'', starting and ending
+                        with an alphanumeric, at most 63 characters): role group names
+                        become part of the name and labels of every resource built
+                        for the group'
+                      rule: self.all(k, size(k) <= 63 && k.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'))
                 type: object
               image:
                 description: |-
@@ -1026,7 +1041,22 @@ spec:
                     description: |-
                       RoleGroups defines the role group configurations.
                       Each RoleGroup maps to a Kubernetes StatefulSet.
+
+                      Constrained for the same reason as the role name above: a role group name is a segment of
+                      "<cluster>-<role>-<group>" and the value of the app.kubernetes.io/role-group label, so a name
+                      that is not a lowercase RFC 1123 label yields resource names the API server refuses.
+
+                      MaxProperties bounds the CEL cost estimate, not the deployment — see the note on Roles.
+                      256 role groups in a single role is far past one per rack in a very large cluster.
+                    maxProperties: 256
                     type: object
+                    x-kubernetes-validations:
+                    - message: 'each role group name must be a lowercase RFC 1123
+                        label (lowercase alphanumerics and ''-'', starting and ending
+                        with an alphanumeric, at most 63 characters): role group names
+                        become part of the name and labels of every resource built
+                        for the group'
+                      rule: self.all(k, size(k) <= 63 && k.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'))
                 type: object
             type: object
           status:

--- a/pkg/apis/commons/v1alpha1/cluster_types.go
+++ b/pkg/apis/commons/v1alpha1/cluster_types.go
@@ -36,7 +36,25 @@ type GenericClusterSpec struct {
 
 	// Roles defines the role configurations for the cluster.
 	// Each role represents a logical functional component (e.g., NameNode, DataNode).
+	//
+	// A role name is not free-form: it becomes a segment of the name of every resource built for
+	// the role ("<cluster>-<role>-<group>") and the value of the app.kubernetes.io/component
+	// label. A name that is not a lowercase RFC 1123 label therefore produces resource names the
+	// API server rejects — "Coordinator", "my_role" and "a.b" all fail on the StatefulSet's or the
+	// Service's metadata.name. Without this rule that rejection surfaces halfway through a
+	// reconcile, as a permanently Degraded role complaining about a field the user never wrote;
+	// with it, `kubectl apply` says so immediately.
+	//
+	// MaxProperties is not a product constraint — no product has 64 distinct roles — but the CEL
+	// cost estimator's only handle on a map. Without a declared bound it assumes the theoretical
+	// worst case and rejects the rule below at CRD creation time with "estimated rule cost exceeds
+	// budget by factor of more than 100x". The bound is set far above any real deployment so it
+	// never binds in practice, and low enough to leave a product's own CRD room in the per-schema
+	// budget it shares.
+	//
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:MaxProperties=64
+	// +kubebuilder:validation:XValidation:rule=`self.all(k, size(k) <= 63 && k.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'))`,message=`each role name must be a lowercase RFC 1123 label (lowercase alphanumerics and '-', starting and ending with an alphanumeric, at most 63 characters): role names become part of the name and labels of every resource built for the role`
 	Roles map[string]RoleSpec `json:"roles,omitempty"`
 }
 
@@ -58,7 +76,17 @@ type RoleSpec struct {
 
 	// RoleGroups defines the role group configurations.
 	// Each RoleGroup maps to a Kubernetes StatefulSet.
+	//
+	// Constrained for the same reason as the role name above: a role group name is a segment of
+	// "<cluster>-<role>-<group>" and the value of the app.kubernetes.io/role-group label, so a name
+	// that is not a lowercase RFC 1123 label yields resource names the API server refuses.
+	//
+	// MaxProperties bounds the CEL cost estimate, not the deployment — see the note on Roles.
+	// 256 role groups in a single role is far past one per rack in a very large cluster.
+	//
 	// +kubebuilder:validation:Optional
+	// +kubebuilder:validation:MaxProperties=256
+	// +kubebuilder:validation:XValidation:rule=`self.all(k, size(k) <= 63 && k.matches('^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'))`,message=`each role group name must be a lowercase RFC 1123 label (lowercase alphanumerics and '-', starting and ending with an alphanumeric, at most 63 characters): role group names become part of the name and labels of every resource built for the group`
 	RoleGroups map[string]RoleGroupSpec `json:"roleGroups,omitempty"`
 
 	// ConfigOverrides allows customization of configuration files (e.g., XML, properties).

--- a/pkg/reconciler/AGENTS.md
+++ b/pkg/reconciler/AGENTS.md
@@ -195,6 +195,21 @@ There is no `reconciler.go`, `status.go` or `finalizer.go` in this package — s
     product upgrade, and the role group is already pinned by the `<cluster>-<group>` marker key.
     Upgrading an existing cluster into this label set rolls its pods once (the pod template gains
     labels) but leaves the frozen selector satisfied.
+
+    **The marker key is bounded by `RoleGroupMarkerLabelKey`, not concatenated.** A label key's name
+    part is capped at 63 bytes, and `<cluster>-<group>` is built from two free-form user strings: a
+    43-character cluster plus a 21-character role group is 65, at which point the API server rejects
+    the StatefulSet, both Services *and* the PDB of that role group, quoting a label key the user
+    never wrote. The resource *name* built from the same two strings was already bounded
+    (`RoleGroupResourceName`); this second derivation was not, so the framework applied a limit it
+    knew about to one of the two places it applies.
+
+    The helper returns the natural `<cluster>-<group>` whenever that is a legal label key, and
+    `RoleGroupResourceName` otherwise. Preserving the natural form is **load-bearing, not
+    cosmetic**: `.spec.selector` is immutable, so changing this key for a role group that already
+    has a StatefulSet would leave the pod template no longer matching the frozen selector and every
+    later update would be rejected. Only combinations that could never have produced a StatefulSet
+    get the substitute, which is what makes the change safe to roll out to running clusters.
 16. **There is exactly one label channel, and it is the cluster CR.** `buildLabels` layers, low to
     high: `buildCtx.ClusterLabels` (the CR's own, cloned per cycle) → the recommended set →
     `frameworkSelectorLabels` → the product's `LabelDomain` identity labels. Anything an operator's

--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -556,12 +556,17 @@ func (h *BaseRoleGroupHandler[CR]) identityLabels(buildCtx *RoleGroupBuildContex
 // stays that way: app.kubernetes.io/version changes on every product upgrade and role-group is
 // already covered by the marker key below, so neither may enter a selector that can never be
 // edited again.
+//
+// The marker key goes through RoleGroupMarkerLabelKey rather than being concatenated here, because
+// "<cluster>-<group>" is a label KEY built from two free-form user strings and overruns the 63-byte
+// limit with ordinary names — see that function for why the natural form has to be preserved
+// wherever it is legal.
 func (h *BaseRoleGroupHandler[CR]) frameworkSelectorLabels(buildCtx *RoleGroupBuildContext) map[string]string {
 	return map[string]string{
-		constant.LabelKubernetesInstance:                    buildCtx.ClusterName,
-		constant.LabelKubernetesComponent:                   buildCtx.RoleName,
-		constant.LabelKubernetesManagedBy:                   managedByValue,
-		buildCtx.ClusterName + "-" + buildCtx.RoleGroupName: valueTrue,
+		constant.LabelKubernetesInstance:  buildCtx.ClusterName,
+		constant.LabelKubernetesComponent: buildCtx.RoleName,
+		constant.LabelKubernetesManagedBy: managedByValue,
+		RoleGroupMarkerLabelKey(buildCtx.ClusterName, buildCtx.RoleName, buildCtx.RoleGroupName): valueTrue,
 	}
 }
 

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -2574,3 +2574,89 @@ var _ = Describe("Recommended label set", func() {
 		Expect(pdb.Spec.Selector.MatchLabels).NotTo(HaveKey(constant.LabelKubernetesName))
 	})
 })
+
+var _ = Describe("Role group marker label key", func() {
+	// The marker is a label KEY built from two free-form user strings ("<cluster>-<group>"), and it
+	// lands in the StatefulSet's immutable .spec.selector, in both Services' selectors and in every
+	// pod template label set. A label key's name part is capped at 63 bytes, which ordinary
+	// big-data names exceed: 43 + 1 + 21 below is 65.
+	const (
+		longCluster = "analytics-platform-production-trino-cluster"
+		longGroup   = "memory-optimized-pool"
+	)
+
+	newHandler := func() *reconciler.BaseRoleGroupHandler[*testutil.MockCluster] {
+		h := reconciler.NewBaseRoleGroupHandler[*testutil.MockCluster]("static-image:1", testScheme)
+		h.SetRoleServicePorts("worker", []corev1.ServicePort{{Name: "http", Port: 8080}})
+		return h
+	}
+
+	newBuildCtx := func(clusterName, roleName, groupName string) *reconciler.RoleGroupBuildContext {
+		return &reconciler.RoleGroupBuildContext{
+			ClusterName:      clusterName,
+			ClusterNamespace: testNamespace,
+			ClusterSpec:      &v1alpha1.GenericClusterSpec{},
+			RoleName:         roleName,
+			RoleSpec:         &v1alpha1.RoleSpec{},
+			RoleGroupName:    groupName,
+			RoleGroupSpec:    v1alpha1.RoleGroupSpec{Replicas: ptr.To(int32(1))},
+			MergedConfig:     &config.MergedConfig{},
+			ResourceName:     reconciler.RoleGroupResourceName(clusterName, roleName, groupName),
+		}
+	}
+
+	It("builds a role group the API server accepts when the natural key would overrun", func() {
+		// This is the whole point: not "the key is short" but "the role group can be created".
+		// With the natural key the API server rejects the StatefulSet, both Services and the PDB,
+		// quoting a label key the user never wrote.
+		Expect(len(longCluster+"-"+longGroup)).To(BeNumerically(">", 63),
+			"the fixture must actually overrun, or this spec proves nothing")
+
+		cr := testutil.NewMockCluster(longCluster, testNamespace)
+		resources, err := newHandler().BuildResources(context.Background(), k8sClient, cr,
+			newBuildCtx(longCluster, "worker", longGroup))
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(k8sClient.Create(context.Background(), resources.StatefulSet)).To(Succeed(),
+			"the API server must accept a role group whose cluster+group names exceed the label key limit")
+		DeferCleanup(func() {
+			Expect(client.IgnoreNotFound(k8sClient.Delete(context.Background(), resources.StatefulSet))).To(Succeed())
+		})
+
+		// The client Service carries the same selector, and the pod template the same key set.
+		for key := range resources.Service.Spec.Selector {
+			Expect(validation.IsQualifiedName(key)).To(BeEmpty(), "Service selector key %q", key)
+		}
+		for key := range resources.StatefulSet.Spec.Template.Labels {
+			Expect(validation.IsQualifiedName(key)).To(BeEmpty(), "pod template label key %q", key)
+		}
+	})
+
+	It("keeps the natural key byte-identical when it fits", func() {
+		// .spec.selector is immutable. A cluster created by an earlier framework version must find
+		// its selector unchanged, or the pod template stops matching the frozen selector and every
+		// later update is rejected — so the substitute may only ever apply to combinations that
+		// could not have produced a StatefulSet in the first place.
+		Expect(reconciler.RoleGroupMarkerLabelKey("trino", "worker", "default")).
+			To(Equal("trino-default"))
+
+		cr := testutil.NewMockCluster("trino", testNamespace)
+		resources, err := newHandler().BuildResources(context.Background(), k8sClient, cr,
+			newBuildCtx("trino", "worker", "default"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.StatefulSet.Spec.Selector.MatchLabels).To(HaveKeyWithValue("trino-default", "true"))
+	})
+
+	It("keeps two overrunning role groups of one role distinguishable", func() {
+		// The substitute must stay unique per role group: two groups sharing a marker would make
+		// each role group's Services select the other's pods as well.
+		a := reconciler.RoleGroupMarkerLabelKey(longCluster, "worker", longGroup)
+		b := reconciler.RoleGroupMarkerLabelKey(longCluster, "worker", longGroup+"-spot")
+		Expect(a).NotTo(Equal(b))
+		Expect(validation.IsQualifiedName(a)).To(BeEmpty())
+		Expect(validation.IsQualifiedName(b)).To(BeEmpty())
+
+		// And it stays stable across calls, or the selector would differ between reconciles.
+		Expect(reconciler.RoleGroupMarkerLabelKey(longCluster, "worker", longGroup)).To(Equal(a))
+	})
+})

--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -44,6 +44,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/ptr"
@@ -852,11 +853,47 @@ func RoleGroupResourceName(clusterName, roleName, groupName string) string {
 }
 
 // RoleResourceName returns the canonical resource name for a role-level resource:
-// "<cluster>-<role>". Used for resources that span all of a role's role groups, e.g. the
-// role's PodDisruptionBudget. It is always shorter than the corresponding role group name,
-// so no truncation is needed to stay within DNS limits.
+// "<cluster>-<role>". Used for resources that span all of a role's role groups — today only the
+// role's PodDisruptionBudget.
+//
+// Unlike RoleGroupResourceName this is deliberately NOT truncated, because the limit that applies
+// to it is a different one. A PodDisruptionBudget name is validated as a DNS *subdomain* (253
+// bytes), not as the 63-byte DNS label that bounds a Service name and a StatefulSet's
+// .spec.serviceName; "<cluster>-<role>" cannot realistically reach 253 when the cluster name is
+// itself capped at 253. Truncating here would only invent a hash suffix nobody needs and change
+// the name of every existing role PDB.
 func RoleResourceName(clusterName, roleName string) string {
 	return fmt.Sprintf("%s-%s", clusterName, roleName)
+}
+
+// RoleGroupMarkerLabelKey returns the label key that marks a resource as belonging to one specific
+// role group: "<cluster>-<group>", or a bounded substitute when that is not a legal label key.
+//
+// A label key's name part is limited to 63 bytes and to a restricted character set, and this key is
+// derived from two free-form user strings. Entirely ordinary big-data names blow through it — a
+// 43-character cluster plus a 21-character role group is 65 bytes — and because the key lands in
+// the StatefulSet's .spec.selector, in both Services' selectors and in every pod template label
+// set, the API server then rejects the whole role group, naming a label key the user never wrote.
+// The resource NAME built from the same two strings was already bounded (RoleGroupResourceName);
+// this second derivation was not, so the framework applied the limit it knew about to one of the
+// two places it applies.
+//
+// The natural form is kept whenever it is legal, and that is load-bearing rather than cosmetic:
+// .spec.selector is IMMUTABLE, so changing this key for a role group that already has a
+// StatefulSet would leave the pod template no longer matching the frozen selector and every
+// subsequent update would be rejected. Only combinations that could never have produced a
+// StatefulSet in the first place get the substitute — for those there is nothing to stay
+// compatible with, which is what makes this safe to roll out to running clusters.
+//
+// The substitute is RoleGroupResourceName: already bounded to maxRoleGroupNameLen, already unique
+// per role group, and already the framework's canonical identifier for one. Reusing it keeps a
+// single truncation algorithm in the codebase instead of a second one that has to agree with it.
+func RoleGroupMarkerLabelKey(clusterName, roleName, roleGroupName string) string {
+	key := clusterName + "-" + roleGroupName
+	if len(validation.IsQualifiedName(key)) == 0 {
+		return key
+	}
+	return RoleGroupResourceName(clusterName, roleName, roleGroupName)
 }
 
 // buildRoleGroupContext creates the build context for a role group.
@@ -1210,7 +1247,7 @@ func (r *GenericReconciler[CR]) reclaimRoleGroupPDB(ctx context.Context, buildCt
 		}
 		return err
 	}
-	if !isFrameworkRoleGroupPDB(pdb, buildCtx.ClusterName, buildCtx.RoleGroupName) {
+	if !isFrameworkRoleGroupPDB(pdb, buildCtx.ClusterName, buildCtx.RoleName, buildCtx.RoleGroupName) {
 		return nil
 	}
 	return r.cleaner.deletePDB(ctx, key.Namespace, key.Name, ownerUID, buildCtx.ClusterName)
@@ -1221,12 +1258,12 @@ func (r *GenericReconciler[CR]) reclaimRoleGroupPDB(ctx context.Context, buildCt
 // labels, which is the only fingerprint those objects carry: the framework's managed-by value plus
 // the role group marker label. Both are required — managed-by alone would also match the role-level
 // PDB of a differently named role group.
-func isFrameworkRoleGroupPDB(pdb *policyv1.PodDisruptionBudget, clusterName, roleGroupName string) bool {
+func isFrameworkRoleGroupPDB(pdb *policyv1.PodDisruptionBudget, clusterName, roleName, roleGroupName string) bool {
 	if pdb.Labels[LabelRoleGroupPodDisruptionBudget] == roleGroupName {
 		return true
 	}
 	return pdb.Labels["app.kubernetes.io/managed-by"] == managedByValue &&
-		pdb.Labels[clusterName+"-"+roleGroupName] == valueTrue
+		pdb.Labels[RoleGroupMarkerLabelKey(clusterName, roleName, roleGroupName)] == valueTrue
 }
 
 // reclaimMetricsService deletes the role group's metrics Service, but only when the live object

--- a/pkg/testutil/crd_schema_test.go
+++ b/pkg/testutil/crd_schema_test.go
@@ -192,3 +192,66 @@ var _ = Describe("Generated test CRD schema", func() {
 			"the framework default applies at consumption time")
 	})
 })
+
+// A role or role group name is not free-form: it becomes a segment of every resource name the
+// framework derives ("<cluster>-<role>-<group>") and the value of an app.kubernetes.io label.
+// Names that are not lowercase RFC 1123 labels produce resource names the API server refuses, and
+// before the CEL rules below that refusal only surfaced mid-reconcile — as a permanently Degraded
+// role quoting a metadata.name the user never wrote. These specs assert the rejection now happens
+// at admission, where the message reaches the person who can fix it.
+var _ = Describe("Role and role group name validation", func() {
+	const nameValidationNamespace = "default"
+
+	var counter int
+
+	// applyWithRole attempts to persist a cluster declaring exactly one role and one role group,
+	// and returns the API server's verdict.
+	applyWithRole := func(roleName, groupName string) error {
+		counter++
+		cr := testutil.NewMockCluster(fmt.Sprintf("names-%d", counter), nameValidationNamespace)
+		cr.Spec = v1alpha1.GenericClusterSpec{
+			Roles: map[string]v1alpha1.RoleSpec{
+				roleName: {RoleGroups: map[string]v1alpha1.RoleGroupSpec{groupName: {}}},
+			},
+		}
+		err := k8sClient.Create(ctx, cr)
+		if err == nil {
+			DeferCleanup(func() { _ = k8sClient.Delete(ctx, cr) })
+		}
+		return err
+	}
+
+	DescribeTable("rejects a role name that cannot become a resource name",
+		func(roleName string) {
+			err := applyWithRole(roleName, "default")
+			Expect(err).To(HaveOccurred(), "role name %q must be rejected at admission", roleName)
+			Expect(err.Error()).To(ContainSubstring("lowercase RFC 1123 label"),
+				"the message has to name the rule, not just the field")
+		},
+		Entry("uppercase", "Coordinator"),
+		Entry("underscore", "my_role"),
+		Entry("dot", "a.b"),
+		Entry("leading dash", "-worker"),
+		Entry("trailing dash", "worker-"),
+		Entry("empty", ""),
+	)
+
+	DescribeTable("rejects a role group name that cannot become a resource name",
+		func(groupName string) {
+			err := applyWithRole("worker", groupName)
+			Expect(err).To(HaveOccurred(), "role group name %q must be rejected at admission", groupName)
+			Expect(err.Error()).To(ContainSubstring("lowercase RFC 1123 label"))
+		},
+		Entry("uppercase", "Default"),
+		Entry("underscore", "high_mem"),
+		Entry("dot", "rack.a"),
+	)
+
+	It("accepts the names products actually use", func() {
+		// The rule must not be stricter than the resource names it protects: everything here has
+		// always worked and must keep working.
+		Expect(applyWithRole("namenode", "default")).To(Succeed())
+		Expect(applyWithRole("journal-node", "rack-a-1")).To(Succeed())
+		Expect(applyWithRole("s3", "0")).To(Succeed())
+	})
+})


### PR DESCRIPTION
A role group whose cluster and group names together exceed 63 bytes could not be created **at all**.

The framework stamps a marker label keyed `<cluster>-<group>`, and a label key's name part is capped at 63 bytes. Two entirely ordinary big-data names overrun it — a 43-character cluster plus a 21-character role group is 65 — and because that key lands in the StatefulSet's `.spec.selector`, in both Services' selectors and in every pod template label set, the API server rejected the StatefulSet, both Services **and** the PDB of that role group, quoting a label key the user never wrote:

```
StatefulSet.apps "analytics-platform-production-trino-cluster-w-044d85a3" is invalid:
  spec.selector.matchLabels: Invalid value:
  "analytics-platform-production-trino-cluster-memory-optimized-pool":
  name part must be no more than 63 bytes
```

The resource *name* built from the same two strings was already bounded by `RoleGroupResourceName` (note it truncated fine to 54 chars in the message above). The framework had applied a limit it knew about to one of the two places it applies.

## The fix

`RoleGroupMarkerLabelKey(cluster, role, group)` now produces the key: the natural `<cluster>-<group>` whenever that is a legal label key, and `RoleGroupResourceName` otherwise.

**Preserving the natural form is load-bearing, not cosmetic.** `.spec.selector` is immutable, so changing this key for a role group that already has a StatefulSet would leave the pod template no longer matching the frozen selector, and every later update would be rejected. Only combinations that could never have produced a StatefulSet get the substitute — for those there is nothing to stay compatible with. **Running clusters are byte-for-byte unaffected.**

## Role and role group names are now validated at admission

The keys of `spec.roles` and `spec.roles.<role>.roleGroups` must be lowercase RFC 1123 labels, enforced by a CEL rule on `GenericClusterSpec.Roles` and `RoleSpec.RoleGroups`.

This only rejects **what never worked**: each key becomes a segment of `<cluster>-<role>-<group>` and the value of an `app.kubernetes.io/*` label, so `Coordinator`, `my_role` and `a.b` have always produced resource names the API server refuses. What changes is *when* the user hears about it — at `kubectl apply`, in a message naming the rule, instead of halfway through a reconcile as a permanently `Degraded` role quoting a `metadata.name` nobody wrote.

Both maps also gained `maxProperties` (64 roles, 256 role groups per role). That is **not** a product constraint but the CEL cost estimator's only handle on a map — without a declared bound the API server refuses the rule at CRD creation time with `estimated rule cost exceeds budget by factor of more than 100x`. The bounds sit far above any real deployment, and I measured the ceiling (1024 also fits) before picking numbers, so this is chosen for headroom rather than to squeeze under the budget.

## One reported finding retracted

The review that prompted this PR also flagged the un-truncated `RoleResourceName` as a second instance of the same bug. **It is not**, and I retract it. A PodDisruptionBudget name is validated as a DNS *subdomain* (253 bytes), not the 63-byte DNS label that bounds a Service name; a real API server accepts the 73-character name I claimed was rejected:

```
[PROBE] PDB name len=73
[PROBE] PodDisruptionBudget create -> <nil>
```

I had used `IsDNS1035Label` where the API server uses `NameIsDNSSubdomain`. The code is unchanged; only the doc comment moved, since it reached the right conclusion by the wrong route (it compared against the role group name, which is itself truncated).

## Verification

Every claim was checked against a real API server through envtest rather than derived from the validation helpers — which is how the retraction above surfaced.

Mutation testing on each guarantee:

| mutation | result |
|---|---|
| `RoleGroupMarkerLabelKey` → plain concatenation | 2/3 new specs fail, on the API server's own rejection |
| `RoleGroupMarkerLabelKey` → always substitute | the byte-identical compatibility spec fails, **plus 3 pre-existing selector-stability specs** |
| CEL rule → drop the pattern, keep the length check | 9/10 new admission specs fail |

`make lint`, `make test`, `make verify-generate` and the examples module's own `make test` all pass.

## Downstream impact

Every product CRD picks up the CEL rule and `maxProperties` on its next `make manifests` (the trino example's CRD is regenerated in this PR). Products whose CRs use a non-conforming role name will be rejected on the next apply — but such a cluster has never had working resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)