### PR TITLE
fix(security): pair fsGroup with OnRootMismatch so it is applied once, not every start

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,29 @@ changes are listed below.**
     progress markers. A product that needs e.g. cloud LoadBalancer annotations on the client Service
     has no supported way to set them; tracked in #553.
 
+### fix (pod security)
+
+- **The framework's default pod security context now sets `fsGroupChangePolicy: OnRootMismatch`
+  alongside `fsGroup: 1001`.** Setting `fsGroup` without it means Kubernetes' own default of
+  `Always`, under which the kubelet walks the **entire** volume — chown'ing and chmod'ing every
+  file — before the container starts, on *every* start. For the workloads this SDK exists for that
+  is the difference between a pod starting in seconds and a pod sitting in `ContainerCreating` for
+  tens of minutes on every restart, rollout and node drain, with nothing in its events explaining
+  why: an HDFS DataNode or a Kafka broker data PVC holds millions of files.
+
+  `OnRootMismatch` recurses only when the volume root does not already carry the expected owner and
+  mode, which is true exactly once per freshly provisioned volume. The trade-off is deliberate:
+  ownership that drifts *inside* a volume whose root is still correct is not repaired — a repair
+  the framework never promised, and not worth paying for on every start. A product that wants it
+  back sets `fsGroupChangePolicy: Always` through `podOverrides`, which deep-merges per field and
+  so keeps the rest of the hardening.
+
+  The policy has no effect on ephemeral volumes (secret, configMap, emptyDir), so the config mount
+  and the shared log volume are unaffected either way.
+- `PodSecurityBuilder.WithFSGroupChangePolicy` exposes the field to callers assembling a context by
+  hand. Like its siblings it is opt-in: only the framework default pairs the two, so a hand-built
+  context is not given an opinion it did not state.
+
 ### fix (naming)
 
 - **A role group whose cluster and group names together exceed 63 bytes can now be created at

--- a/docs/DOC_CHANGELOG.md
+++ b/docs/DOC_CHANGELOG.md
@@ -4,6 +4,18 @@ This document tracks all changes made to the SDK documentation.
 
 ---
 
+## [2026-07-28b] (fsGroup no longer recurses the whole volume on every start)
+
+### Security Documentation (`security.md`)
+
+- Added `fsGroupChangePolicy: OnRootMismatch` to the default pod SecurityContext table, with the
+  reason it is paired with `fsGroup` at all: unset means Kubernetes' `Always`, i.e. a full
+  chown/chmod walk of the data volume before the container starts, on every start. Recorded the
+  deliberate trade-off (drift *inside* a volume with a correct root is not repaired), the
+  `podOverrides` escape hatch, and that the policy does not apply to ephemeral volume types.
+
+---
+
 ## [2026-07-28a] (identifiers derived from user names are bounded and validated)
 
 ### Framework Documentation (`AGENTS.md`, `pkg/reconciler/AGENTS.md`)

--- a/docs/security.md
+++ b/docs/security.md
@@ -249,8 +249,26 @@ builds. Sidecar containers carry whatever `SidecarConfig.SecurityContext` their 
 | `runAsUser` | `1001` | kubedoop images run as uid 1001 |
 | `runAsGroup` | `0` | OpenShift-compatible: OpenShift assigns an arbitrary uid but keeps gid 0, and kubedoop images are group-0 readable/writable |
 | `fsGroup` | `1001` | mounted volumes are chowned so the non-root process can write to them |
+| `fsGroupChangePolicy` | `OnRootMismatch` | apply that chown **once**, not on every pod start — see below |
 | `runAsNonRoot` | `true` | refuse to start as root |
 | `seccompProfile.type` | `RuntimeDefault` | apply the runtime's default seccomp profile |
+
+`fsGroupChangePolicy` is paired with `fsGroup` deliberately. Kubernetes documents the field as
+"Valid values are `OnRootMismatch` and `Always`. If not specified, `Always` is used" — and `Always`
+means the kubelet walks the **entire** volume, chown'ing and chmod'ing every file, before the
+container starts. On a data PVC holding millions of files (an HDFS DataNode, a Kafka broker) that
+is tens of minutes to hours, repeated on every restart, every rollout and every node drain, while
+the pod sits in `ContainerCreating` with nothing in its events explaining why.
+
+`OnRootMismatch` performs the same recursion only when the volume's root directory does not already
+have the expected owner and mode — true exactly once, the first time a freshly provisioned volume is
+mounted. The trade-off is deliberate: ownership that drifts *inside* a volume whose root is still
+correct will not be repaired. That is a repair the framework never promised, and paying for it on
+every start of every stateful pod is the wrong price. A product that wants it back sets
+`fsGroupChangePolicy: Always` through `PodOverrides` (§3.3.2).
+
+The policy has no effect on ephemeral volume types (secret, configMap, emptyDir), so the config
+mount and the shared log volume behave identically either way; the data PVC is what it is about.
 
 **Container-level (`container.securityContext`):**
 

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -926,6 +926,10 @@ var _ = Describe("StatefulSet building", func() {
 		Expect(*podSpec.SecurityContext.RunAsNonRoot).To(BeTrue())
 		Expect(podSpec.SecurityContext.SeccompProfile).NotTo(BeNil())
 		Expect(podSpec.SecurityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+		// fsGroup without a change policy means Kubernetes' default of Always: the kubelet walks
+		// the whole data volume chown'ing every file before the container starts, on every start.
+		Expect(podSpec.SecurityContext.FSGroupChangePolicy).NotTo(BeNil())
+		Expect(*podSpec.SecurityContext.FSGroupChangePolicy).To(Equal(corev1.FSGroupChangeOnRootMismatch))
 
 		// Container-level default: uid 1001, gid 0, hardened (drop ALL caps, no privilege escalation).
 		Expect(podSpec.Containers).NotTo(BeEmpty())
@@ -2658,5 +2662,87 @@ var _ = Describe("Role group marker label key", func() {
 
 		// And it stays stable across calls, or the selector would differ between reconciles.
 		Expect(reconciler.RoleGroupMarkerLabelKey(longCluster, "worker", longGroup)).To(Equal(a))
+	})
+})
+
+var _ = Describe("fsGroup ownership recursion", func() {
+	// fsGroup makes the kubelet apply group ownership to every volume that supports it. Without a
+	// change policy Kubernetes uses Always, which recurses over the ENTIRE volume on every mount —
+	// on a data PVC holding millions of files that is tens of minutes of ContainerCreating on every
+	// single pod start. These specs pin the default and the escape hatch.
+	newHandler := func() *reconciler.BaseRoleGroupHandler[*testutil.MockCluster] {
+		h := reconciler.NewBaseRoleGroupHandler[*testutil.MockCluster]("product:1", testScheme)
+		// A data PVC is what the policy actually applies to; ephemeral volumes ignore it.
+		h.StorageMountPath = "/kubedoop/data"
+		return h
+	}
+
+	newBuildCtx := func(name string, overrides *corev1.PodTemplateSpec) *reconciler.RoleGroupBuildContext {
+		return &reconciler.RoleGroupBuildContext{
+			ClusterName:      name,
+			ClusterNamespace: testNamespace,
+			ClusterSpec:      &v1alpha1.GenericClusterSpec{},
+			RoleName:         "datanode",
+			RoleSpec:         &v1alpha1.RoleSpec{},
+			RoleGroupName:    "default",
+			RoleGroupSpec: v1alpha1.RoleGroupSpec{
+				Replicas: ptr.To(int32(1)),
+				Config: &v1alpha1.RoleGroupConfigSpec{
+					Resources: &v1alpha1.ResourcesSpec{
+						Storage: &v1alpha1.StorageResource{Capacity: ptr.To(resource.MustParse("1Gi"))},
+					},
+				},
+			},
+			MergedConfig: &config.MergedConfig{PodOverrides: overrides},
+			ResourceName: reconciler.RoleGroupResourceName(name, "datanode", "default"),
+		}
+	}
+
+	It("survives the API server on a StatefulSet that actually has a data PVC", func() {
+		// Building the field is not the same as it reaching the workload: it has to be a field the
+		// API server stores rather than prunes, on the object the kubelet will read.
+		cr := testutil.NewMockCluster("fsg-store", testNamespace)
+		resources, err := newHandler().BuildResources(context.Background(), k8sClient, cr,
+			newBuildCtx("fsg-store", nil))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.StatefulSet.Spec.VolumeClaimTemplates).NotTo(BeEmpty(),
+			"the fixture must carry a PVC, or the policy under test would not apply to anything")
+
+		Expect(k8sClient.Create(context.Background(), resources.StatefulSet)).To(Succeed())
+		DeferCleanup(func() {
+			Expect(client.IgnoreNotFound(k8sClient.Delete(context.Background(), resources.StatefulSet))).To(Succeed())
+		})
+
+		stored := &appsv1.StatefulSet{}
+		Expect(k8sClient.Get(context.Background(),
+			client.ObjectKeyFromObject(resources.StatefulSet), stored)).To(Succeed())
+		Expect(stored.Spec.Template.Spec.SecurityContext.FSGroupChangePolicy).NotTo(BeNil())
+		Expect(*stored.Spec.Template.Spec.SecurityContext.FSGroupChangePolicy).
+			To(Equal(corev1.FSGroupChangeOnRootMismatch))
+	})
+
+	It("lets a product take the recursion back with podOverrides", func() {
+		// OnRootMismatch trades one repair for a lot of startup time: it will not fix ownership
+		// that drifted deep inside a volume whose root is still correct. A product that wants that
+		// repair must be able to ask for it, and must keep the rest of the hardening while doing so.
+		resources, err := newHandler().BuildResources(context.Background(), k8sClient,
+			testutil.NewMockCluster("fsg-override", testNamespace),
+			newBuildCtx("fsg-override", &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					SecurityContext: &corev1.PodSecurityContext{
+						FSGroupChangePolicy: ptr.To(corev1.FSGroupChangeAlways),
+					},
+				},
+			}))
+		Expect(err).NotTo(HaveOccurred())
+
+		podSC := resources.StatefulSet.Spec.Template.Spec.SecurityContext
+		Expect(podSC.FSGroupChangePolicy).NotTo(BeNil())
+		Expect(*podSC.FSGroupChangePolicy).To(Equal(corev1.FSGroupChangeAlways))
+		// The fields the override did not mention survive the strategic merge.
+		Expect(podSC.FSGroup).NotTo(BeNil())
+		Expect(*podSC.FSGroup).To(Equal(int64(1001)))
+		Expect(podSC.RunAsNonRoot).NotTo(BeNil())
+		Expect(*podSC.RunAsNonRoot).To(BeTrue())
 	})
 })

--- a/pkg/security/pod_security.go
+++ b/pkg/security/pod_security.go
@@ -217,8 +217,16 @@ func (b *PodSecurityBuilder) BuildPodSecurityContext() *corev1.PodSecurityContex
 //   - SeccompProfile: RuntimeDefault
 //
 // This is the single default the framework applies by default in the base role-group handler.
-// A product that needs different settings replaces the whole security context (no deep merge)
-// via MergedConfig.PodOverrides — see the base handler's WithSecurityContext docs.
+// MergedConfig.PodOverrides customizes it and DEEP-MERGES PER FIELD (strategic merge patch), so an
+// override stating only one field keeps the rest of the hardening — and must therefore explicitly
+// restate any default it wants to change. An image that has to run as root sets both
+// `runAsUser: 0` and `runAsNonRoot: false`; setting only the first inherits `runAsNonRoot: true`
+// and the kubelet refuses to start the container. See the base handler's WithSecurityContext docs
+// and docs/security.md §3.3.2.
+//
+// Wholesale replacement is a different mechanism: SidecarConfig.SecurityContext replaces a
+// sidecar's context outright, and BaseRoleGroupHandler.WithSecurityContext replaces this default
+// for every role group.
 func (b *PodSecurityBuilder) BuildDefaultSecurityContext() *corev1.SecurityContext {
 	return &corev1.SecurityContext{
 		RunAsUser:                ptr.To(DefaultRunAsUser),
@@ -245,8 +253,10 @@ func (b *PodSecurityBuilder) BuildDefaultSecurityContext() *corev1.SecurityConte
 //   - SeccompProfile: RuntimeDefault
 //
 // This is the single default the framework applies by default in the base role-group handler.
-// A product that needs a different identity replaces the whole pod security context (no deep
-// merge) via MergedConfig.PodOverrides.
+// MergedConfig.PodOverrides customizes it and DEEP-MERGES PER FIELD (strategic merge patch): an
+// override stating only `fsGroupChangePolicy: Always` gets the recursion back while keeping
+// fsGroup, the identity and the seccomp profile. That field-level merge is what makes the escape
+// hatch on DefaultFSGroupChangePolicy usable at all. See docs/security.md §3.3.2.
 func (b *PodSecurityBuilder) BuildDefaultPodSecurityContext() *corev1.PodSecurityContext {
 	return &corev1.PodSecurityContext{
 		RunAsUser:           ptr.To(DefaultRunAsUser),

--- a/pkg/security/pod_security.go
+++ b/pkg/security/pod_security.go
@@ -35,11 +35,36 @@ const (
 	DefaultFSGroup int64 = 1001
 )
 
+// DefaultFSGroupChangePolicy is the ownership-recursion policy the framework applies alongside
+// DefaultFSGroup.
+//
+// Setting fsGroup without it is a startup-time trap for exactly the workloads this SDK exists for.
+// Kubernetes documents the field as: "Valid values are OnRootMismatch and Always. If not
+// specified, Always is used." Always means the kubelet walks the ENTIRE volume on every mount,
+// chown'ing and chmod'ing each file before the container starts. On an HDFS DataNode or a Kafka
+// broker whose data PVC holds millions of files that is tens of minutes to hours — repeated on
+// every restart, every rollout, every node drain — while the pod sits in ContainerCreating with
+// nothing in its events explaining why.
+//
+// OnRootMismatch performs the same recursion only when the volume's ROOT directory does not
+// already have the expected owner and mode, which is true exactly once: the first time a freshly
+// provisioned volume is mounted. Every later mount is a single stat.
+//
+// The trade-off is real and deliberate: if something changes ownership deep inside the volume
+// while the root stays correct, OnRootMismatch will not repair it. That is a repair the framework
+// never promised, and paying for it on every start of every stateful pod is the wrong price.
+//
+// The policy has no effect on ephemeral volume types (secret, configMap, emptyDir), so the config
+// mount and the shared log volume behave identically either way — the data PVC is what this is
+// about.
+const DefaultFSGroupChangePolicy = corev1.FSGroupChangeOnRootMismatch
+
 // PodSecurityBuilder builds secure pod security contexts.
 type PodSecurityBuilder struct {
 	runAsUser                *int64
 	runAsGroup               *int64
 	fsGroup                  *int64
+	fsGroupChangePolicy      *corev1.PodFSGroupChangePolicy
 	runAsNonRoot             *bool
 	seccompProfile           *corev1.SeccompProfile
 	readOnlyRootFS           *bool
@@ -67,6 +92,15 @@ func (b *PodSecurityBuilder) WithRunAsGroup(gid int64) *PodSecurityBuilder {
 // WithFSGroup sets the filesystem group ID.
 func (b *PodSecurityBuilder) WithFSGroup(gid int64) *PodSecurityBuilder {
 	b.fsGroup = &gid
+	return b
+}
+
+// WithFSGroupChangePolicy sets how the kubelet applies fsGroup ownership to a volume: Always
+// (recurse on every mount) or OnRootMismatch (recurse only when the volume root's owner and mode
+// are not already correct). Leaving it unset means Kubernetes' own default, which is Always — see
+// DefaultFSGroupChangePolicy for why that is the wrong default for a stateful workload.
+func (b *PodSecurityBuilder) WithFSGroupChangePolicy(policy corev1.PodFSGroupChangePolicy) *PodSecurityBuilder {
+	b.fsGroupChangePolicy = &policy
 	return b
 }
 
@@ -163,6 +197,9 @@ func (b *PodSecurityBuilder) BuildPodSecurityContext() *corev1.PodSecurityContex
 	if b.fsGroup != nil {
 		ctx.FSGroup = b.fsGroup
 	}
+	if b.fsGroupChangePolicy != nil {
+		ctx.FSGroupChangePolicy = b.fsGroupChangePolicy
+	}
 	if b.seccompProfile != nil {
 		ctx.SeccompProfile = b.seccompProfile
 	}
@@ -202,6 +239,8 @@ func (b *PodSecurityBuilder) BuildDefaultSecurityContext() *corev1.SecurityConte
 //   - RunAsUser: 1001
 //   - RunAsGroup: 0                — OpenShift-compatible group 0
 //   - FSGroup: 1001               — so mounted volumes are writable by uid 1001
+//   - FSGroupChangePolicy: OnRootMismatch — so applying that group does not walk the whole
+//     volume on every start (see DefaultFSGroupChangePolicy)
 //   - RunAsNonRoot: true
 //   - SeccompProfile: RuntimeDefault
 //
@@ -210,22 +249,27 @@ func (b *PodSecurityBuilder) BuildDefaultSecurityContext() *corev1.SecurityConte
 // merge) via MergedConfig.PodOverrides.
 func (b *PodSecurityBuilder) BuildDefaultPodSecurityContext() *corev1.PodSecurityContext {
 	return &corev1.PodSecurityContext{
-		RunAsUser:    ptr.To(DefaultRunAsUser),
-		RunAsGroup:   ptr.To(DefaultRunAsGroup),
-		RunAsNonRoot: ptr.To(true),
-		FSGroup:      ptr.To(DefaultFSGroup),
+		RunAsUser:           ptr.To(DefaultRunAsUser),
+		RunAsGroup:          ptr.To(DefaultRunAsGroup),
+		RunAsNonRoot:        ptr.To(true),
+		FSGroup:             ptr.To(DefaultFSGroup),
+		FSGroupChangePolicy: ptr.To(DefaultFSGroupChangePolicy),
 		SeccompProfile: &corev1.SeccompProfile{
 			Type: corev1.SeccompProfileTypeRuntimeDefault,
 		},
 	}
 }
 
-// DefaultPodSecurityBuilder returns a builder with secure defaults.
+// DefaultPodSecurityBuilder returns a builder with secure defaults. It must stay in step with
+// BuildDefaultSecurityContext / BuildDefaultPodSecurityContext: the two are separate paths to the
+// same "framework default", and a field present in one but not the other is a difference nobody
+// chose.
 func DefaultPodSecurityBuilder() *PodSecurityBuilder {
 	return NewPodSecurityBuilder().
 		WithRunAsUser(DefaultRunAsUser).
 		WithRunAsGroup(DefaultRunAsGroup).
 		WithFSGroup(DefaultFSGroup).
+		WithFSGroupChangePolicy(DefaultFSGroupChangePolicy).
 		WithRunAsNonRoot(true).
 		WithDroppedCapabilities("ALL").
 		WithAllowPrivilegeEscalation(false).

--- a/pkg/security/pod_security_test.go
+++ b/pkg/security/pod_security_test.go
@@ -199,3 +199,34 @@ var _ = Describe("PodSecurityBuilder", func() {
 		})
 	})
 })
+
+var _ = Describe("fsGroup ownership recursion policy", func() {
+	It("keeps the two paths to 'the framework default' identical", func() {
+		// DefaultPodSecurityBuilder().BuildPodSecurityContext() and
+		// BuildDefaultPodSecurityContext() are two separate expressions of the same thing. A field
+		// added to one and forgotten in the other is a difference nobody chose — which is exactly
+		// how fsGroup came to be set without a change policy on both paths at once.
+		Expect(security.DefaultPodSecurityBuilder().BuildPodSecurityContext()).
+			To(Equal(security.NewPodSecurityBuilder().BuildDefaultPodSecurityContext()))
+	})
+
+	It("pairs fsGroup with a change policy, because unset means Always", func() {
+		// Kubernetes: "Valid values are OnRootMismatch and Always. If not specified, Always is
+		// used." Always makes the kubelet chown every file on the volume before the container
+		// starts, on EVERY start — minutes to hours for a data PVC with millions of files.
+		ctx := security.NewPodSecurityBuilder().BuildDefaultPodSecurityContext()
+		Expect(ctx.FSGroup).NotTo(BeNil(), "the policy only matters because fsGroup is set")
+		Expect(ctx.FSGroupChangePolicy).NotTo(BeNil())
+		Expect(*ctx.FSGroupChangePolicy).To(Equal(corev1.FSGroupChangeOnRootMismatch))
+	})
+
+	It("leaves the policy unset unless a caller asks for one", func() {
+		// The generic builder stays opt-in like its siblings: only the framework default pairs the
+		// two, so a caller assembling a context by hand is not given an opinion it did not state.
+		Expect(security.NewPodSecurityBuilder().WithFSGroup(1000).
+			BuildPodSecurityContext().FSGroupChangePolicy).To(BeNil())
+		Expect(*security.NewPodSecurityBuilder().
+			WithFSGroupChangePolicy(corev1.FSGroupChangeAlways).
+			BuildPodSecurityContext().FSGroupChangePolicy).To(Equal(corev1.FSGroupChangeAlways))
+	})
+})


### PR DESCRIPTION
The framework's default pod security context sets `fsGroup: 1001` and left `fsGroupChangePolicy` unset. Kubernetes documents that field as:

> Valid values are `OnRootMismatch` and `Always`. **If not specified, `Always` is used.**

`Always` means the kubelet walks the **entire** volume — chown'ing and chmod'ing every file — before the container starts, and does it again on *every* start.

For the workloads this SDK exists for that is not a micro-optimisation. An HDFS DataNode or a Kafka broker data PVC holds millions of files, so the pod sits in `ContainerCreating` for tens of minutes to hours on **every restart, every rollout and every node drain**, with nothing in its events explaining why. It is one of the more painful things to diagnose in a big-data cluster on Kubernetes, because the symptom (slow start) looks like storage being slow.

## The change

One field on the framework default:

```go
FSGroupChangePolicy: ptr.To(DefaultFSGroupChangePolicy), // OnRootMismatch
```

`OnRootMismatch` performs the same recursion only when the volume's root directory does not already have the expected owner and mode — true exactly once, the first time a freshly provisioned volume is mounted. Every later mount is a single `stat`.

**Existing clusters benefit immediately and need no migration**: their volume roots already carry gid 1001 from the previous `Always` passes, so the very next pod start skips the walk.

## The trade-off, stated

`OnRootMismatch` will not repair ownership that drifts *inside* a volume whose root is still correct. That is deliberate rather than overlooked — it is a repair the framework never promised, and paying for it on every start of every stateful pod is the wrong price. A product that wants it back:

```yaml
podOverrides:
  spec:
    securityContext:
      fsGroupChangePolicy: Always
```

Security contexts deep-merge per field, so that keeps the rest of the hardening. There is a spec pinning exactly this.

The policy has **no effect on ephemeral volume types** (secret, configMap, emptyDir), so the config mount and the shared log volume behave identically either way — the data PVC is what this is about.

`PodSecurityBuilder.WithFSGroupChangePolicy` exposes the field to callers assembling a context by hand. Like its siblings it stays opt-in: only the framework default pairs the two, so a hand-built context is not handed an opinion it did not state.

## Verification

The premise was checked against the upstream field documentation in `k8s.io/api@v0.35.4` rather than assumed — that is where the "If not specified, Always is used" wording and the ephemeral-volume exemption both come from.

The built StatefulSet is created in envtest **with a real `VolumeClaimTemplate`**, so the field is proven to survive the API server on the object the kubelet actually reads, rather than only proven to be set on a Go struct. The spec asserts the fixture has a PVC at all, so it cannot silently degrade into testing nothing.

Mutation testing:

| mutation | result |
|---|---|
| remove the policy from `BuildDefaultPodSecurityContext` | 2/3 reconciler specs fail |
| remove it from `DefaultPodSecurityBuilder` only, leaving the other default path | the drift guard fails — it asserts the two expressions of "the framework default" are identical |

That second one is the guard that would have caught this class of bug in the first place: `DefaultPodSecurityBuilder().BuildPodSecurityContext()` and `BuildDefaultPodSecurityContext()` are two separate spellings of the same thing, and a field added to one and forgotten in the other is a difference nobody chose.

`make lint`, `make test`, `make verify-generate` and the examples module's own `make test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)