### PR TITLE
feat(reconciler)!: decouple ProductName from image resolution, and resolve images at reconcile time

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -252,7 +252,31 @@ handler.SetRoleContainerPorts("coordinator", ports)
 handler.SetRoleServicePorts("coordinator", svcPorts)
 ```
 
-`ProductName` is what opts a handler into CR-driven images: with it set, `spec.image` is resolved per role group through `ImageSpec.GetImage(ProductName)`; left empty, the handler's static `Image` (and any per-role override) is used and `spec.image` is ignored.
+**`ProductName` names the product; `ImageDefaults` supplies the image.** They used to be one
+switch, and because the image half could not express the kubedoop tag convention, a product that
+wanted `app.kubernetes.io/name` had to give up all of it.
+
+```go
+handler.ProductName = "trino"                 // app.kubernetes.io/name AND the repo path segment
+handler.ImageDefaults = commonsv1alpha1.ImageSpec{
+    Repo:            "quay.io/zncdatadev",
+    ProductVersion:  "476",
+    KubedoopVersion: version.BuildVersion,      // the operator's own build version
+}
+```
+
+`ImageSpec.ResolveImage(productName, defaults)` folds the two layers per field, user first, so a CR
+stating only `productVersion` still yields a valid `…:476-kubedoop0.2.0` reference. `ImageDefaults`
+is read **every reconcile**, which is what a webhook cannot do: webhook defaults are persisted at
+admission and never recomputed, freezing `kubedoopVersion` at whatever operator version first
+admitted the CR (§10 and `docs/architecture.md` §2.6).
+
+An unresolvable `spec.image` **fails the role group**, naming the missing field, instead of silently
+falling back to the handler's static image and running a version nobody asked for. With
+`ProductName` empty the handler resolves nothing from the CR beyond `spec.image.custom` — the shape
+a product uses when it resolves images itself — and that path never errors.
+`app.kubernetes.io/version` follows the **resolved** version, so it is present whenever the image
+came from `ImageDefaults` too.
 
 `BaseRoleGroupHandler` also implements `reconciler.RoleNameProvider`:
 ```go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,45 @@ changes are listed below.**
     progress markers. A product that needs e.g. cloud LoadBalancer annotations on the client Service
     has no supported way to set them; tracked in #553.
 
+### BREAKING (image resolution)
+
+- **`BaseRoleGroupHandler.ProductName` no longer decides whether `spec.image` is read** (#569). It
+  now only names the product: the `app.kubernetes.io/name` value and the repository path segment.
+  The new **`BaseRoleGroupHandler.ImageDefaults`** (a `commonsv1alpha1.ImageSpec`) supplies whatever
+  `spec.image` leaves empty, evaluated **every reconcile**.
+- **New: `ImageSpec.ResolveImage(productName string, defaults ImageSpec) (string, error)`**, plus
+  `ResolvedProductVersion(defaults)` and `ResolvedPullPolicy(defaults)`. `GetImage` is retained and
+  now delegates to `ResolveImage`, so the two cannot disagree.
+- **Why this could not stay in a webhook.** Kubedoop publishes product images only with the
+  `-kubedoop<version>` suffix, whose natural value is the operator's own build version — a
+  reconcile-time fact. Webhook defaults are persisted into the spec at admission and never
+  recomputed, so a cluster admitted by operator 0.1.0 kept asking for `-kubedoop0.1.0` images
+  forever. `ImageDefaults` is read per reconcile, so an operator upgrade moves existing clusters
+  onto the co-released image.
+- **What was broken.** `GetImage` appended the `-kubedoop` suffix only when the *user* wrote
+  `kubedoopVersion`, so a CR stating just `productVersion` produced `quay.io/…/hive:4.0.1` — a tag
+  that does not exist. And when `repo` or `productVersion` was empty it returned `""`, after which
+  the handler silently ran its static image: the user's `productVersion` discarded with no error, no
+  event and no status change. Three migrated operators worked around this by hand-rolling image
+  resolution, and two of them consequently emit no `app.kubernetes.io/version` at all.
+- **An unresolvable `spec.image` now fails the role group**, naming the missing field. Running a
+  version nobody asked for is not a safe default for a stateful product — the same call as
+  `config.affinity`. With `ProductName` empty nothing is resolved from the CR beyond
+  `spec.image.custom`, and that path never errors, so operators that resolve images themselves are
+  unaffected.
+- `spec.image.custom` is now honoured even when `ProductName` is empty; it used to be ignored, so a
+  user pinning an image on such an operator was silently overruled.
+- `app.kubernetes.io/version` follows the **resolved** version, so it is emitted when the version
+  came from `ImageDefaults` too. A `custom` reference still publishes the user's own
+  `productVersion` when they stated one — `custom` replaces the *reference*, and that field remains
+  their declaration of which version it is.
+- `ImageSpec.GetPullPolicy()` is now nil-safe. `spec.image` is an optional pointer, and it began
+  reaching that method as nil once a nil spec could still resolve to a real image.
+- **Adopters**: set `ProductName` + `ImageDefaults` and delete the hand-rolled resolver; drop the
+  image branch of any defaulting webhook. `examples/trino-operator` is migrated in this change and
+  is the reference. Rendered YAML gains `app.kubernetes.io/version` on the pod template (one rolling
+  update); `.spec.selector` is untouched.
+
 ### features (CRD default guard)
 
 - **`testutil.HaveNoInheritedConfigDefaults()` and `testutil.FindInheritedConfigDefaults()`** export

--- a/docs/DOC_CHANGELOG.md
+++ b/docs/DOC_CHANGELOG.md
@@ -4,6 +4,27 @@ This document tracks all changes made to the SDK documentation.
 
 ---
 
+## [2026-08-02d] (image resolution moves to reconcile time)
+
+### Core Architecture (`architecture.md`)
+
+- §2.6 now carries the case that shows why the webhook/reconcile split matters, and that image
+  resolution was on the wrong side of it: the `-kubedoop<version>` suffix's natural value is the
+  operator's own build version, which a webhook freezes into the spec at admission. Documents the
+  two-layer fold (user `spec.image` over `handler.ImageDefaults`), that `ProductName` no longer
+  gates whether `spec.image` is read, and that an unresolvable image is now an error rather than a
+  silent fall back.
+- Closes the gap #569 named: `ProductName`, `ImageDefaults` and the resolution precedence had **no**
+  mention in the authoritative document at all.
+
+### Framework Documentation (`AGENTS.md`)
+
+- §3 replaces the "ProductName opts a handler into CR-driven images" sentence with the two fields
+  and their precedence, the reason `ImageDefaults` cannot be a webhook's job, and the
+  ProductName-less path that never errors.
+
+---
+
 ## [2026-08-02c] (the no-CRD-default-inside-config rule becomes checkable)
 
 ### Core Architecture (`architecture.md`)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,6 +145,28 @@ The SDK distinguishes **two different mechanisms** by which a product supplies v
 | **Upgrade propagation** | No — frozen into the Spec at admission time | **Yes** — recomputed with the current operator each reconcile |
 | **Derived-from-live-state** | Freezes / goes stale | **Recomputed every reconcile** |
 
+**Image resolution is the case that shows why the split matters, and it was on the wrong side.**
+Kubedoop product images are published only with the `-kubedoop<version>` suffix, and the natural
+value of that suffix is the **operator's own build version** — a reconcile-time fact that moves when
+the operator binary is upgraded. Defaulting it in a webhook persists it into the spec at admission,
+so a cluster admitted by operator 0.1.0 keeps asking for `-kubedoop0.1.0` images forever and an
+operator upgrade cannot move it onto the co-released image. `BaseRoleGroupHandler.ImageDefaults` is
+therefore evaluated on every reconcile, and `ImageSpec.ResolveImage(productName, defaults)` folds it
+under whatever the user wrote:
+
+| layer | source | when |
+| --- | --- | --- |
+| user | `spec.image` | whatever the CR states, per field |
+| product | `handler.ImageDefaults` | every reconcile |
+
+`ProductName` no longer decides *whether* `spec.image` is read — it supplies the product name, which
+is both the `app.kubernetes.io/name` value and the repository path segment. Coupling the two meant a
+product that wanted the labels had to accept an image path that could not express the tag
+convention, and three migrated operators consequently hand-rolled image resolution and dropped
+`app.kubernetes.io/version` entirely. An unresolvable `spec.image` is now an **error** rather than a
+silent fall back to the handler's static image: running a version nobody asked for is not a safe
+default for a stateful product (the same call as `config.affinity` above).
+
 - **`ProductDefaulter`** is the right place for stable, user-facing **typed Spec defaults** (see §4.3). The value becomes part of the user's persisted Spec and is visible via `kubectl get`.
 - **`ProductConfig`** is the right place for **product-intrinsic and derived config-file content** — e.g. a ZooKeeper connection string built from the actual resources, a quorum peer list from pod ordinals, or a JVM heap sized from the role group's resources. It is *config generation, not defaulting*: computing it at reconcile time (rather than freezing it into the Spec at admission) means an operator upgrade **recomputes** the configuration for existing clusters, and values derived from mutable state stay fresh. It is injected as the lowest merge layer (§2.5), so user overrides still win.
 

--- a/examples/trino-operator/internal/constants/constants.go
+++ b/examples/trino-operator/internal/constants/constants.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package constants
 
+import (
+	commonsv1alpha1 "github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
+)
+
 // Image constants
 const (
 	// DefaultImageRepo is the default container image repository
@@ -79,3 +83,17 @@ const (
 	// DefaultWorkerMaxMemory is the default max heap memory for workers
 	DefaultWorkerMaxMemory = "4G"
 )
+
+// ImageDefaults is what spec.image leaves empty, and the single source both the handler and the
+// validating webhook read — so the validator can never reject a spec the handler would resolve.
+//
+// It is a function rather than a var because KubedoopVersion is the operator's own build version in
+// a real operator (here a build-time constant), and it must be read at reconcile time: a webhook
+// that wrote it into the spec would freeze every cluster on the operator version that admitted it.
+func ImageDefaults() commonsv1alpha1.ImageSpec {
+	return commonsv1alpha1.ImageSpec{
+		Repo:            DefaultImageRepo,
+		ProductVersion:  DefaultImageProductVersion,
+		KubedoopVersion: DefaultImageKubedoopVersion,
+	}
+}

--- a/examples/trino-operator/internal/controller/trino_handler.go
+++ b/examples/trino-operator/internal/controller/trino_handler.go
@@ -80,6 +80,11 @@ func NewTrinoRoleGroupHandler(scheme *runtime.Scheme) *TrinoRoleGroupHandler {
 	// Opting into the product name lets the framework resolve spec.image itself, for the main
 	// container and for the sidecars that ship inside the product image alike.
 	base.ProductName = constants.ProductName
+	// Evaluated on every reconcile, so an operator upgrade moves existing clusters onto the
+	// co-released product image. A mutating webhook cannot do this: its defaults are persisted into
+	// the spec at admission and never recomputed, which would freeze kubedoopVersion at whatever
+	// operator version first admitted the CR.
+	base.ImageDefaults = constants.ImageDefaults()
 
 	// Declarative logging: the framework renders the Log4j2 config file into the ConfigMap
 	// from the deep-merged CRD logging spec.

--- a/examples/trino-operator/internal/webhook/v1alpha1/trinocluster_webhook.go
+++ b/examples/trino-operator/internal/webhook/v1alpha1/trinocluster_webhook.go
@@ -27,8 +27,6 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
-	commonsv1alpha1 "github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
-
 	trinov1alpha1 "github.com/zncdatadev/operator-go/examples/trino-operator/api/v1alpha1"
 	"github.com/zncdatadev/operator-go/examples/trino-operator/internal/constants"
 	"github.com/zncdatadev/operator-go/pkg/webhook"
@@ -56,22 +54,10 @@ type TrinoClusterCustomDefaulter struct{}
 func (d *TrinoClusterCustomDefaulter) Default(_ context.Context, obj *trinov1alpha1.TrinoCluster) error {
 	trinoclusterlog.Info("Defaulting for TrinoCluster", "name", obj.GetName())
 
-	// Set default image if not specified
-	if obj.Spec.Image == nil {
-		obj.Spec.Image = &commonsv1alpha1.ImageSpec{}
-	}
-	if obj.Spec.Image.Custom == "" {
-		if obj.Spec.Image.Repo == "" {
-			obj.Spec.Image.Repo = constants.DefaultImageRepo
-		}
-		if obj.Spec.Image.ProductVersion == "" {
-			obj.Spec.Image.ProductVersion = constants.DefaultImageProductVersion
-		}
-		if obj.Spec.Image.KubedoopVersion == "" {
-			obj.Spec.Image.KubedoopVersion = constants.DefaultImageKubedoopVersion
-		}
-	}
-	trinoclusterlog.Info("Set default image", "repo", obj.Spec.Image.Repo, "productVersion", obj.Spec.Image.ProductVersion, "kubedoopVersion", obj.Spec.Image.KubedoopVersion)
+	// spec.image is deliberately NOT defaulted here. Webhook defaults are persisted into the spec
+	// at admission and never recomputed, so writing kubedoopVersion here would freeze every cluster
+	// on the operator version that first admitted it. The handler's ImageDefaults fills the same
+	// fields on every reconcile instead — see internal/controller/trino_handler.go.
 
 	// Initialize coordinators if not specified
 	if obj.Spec.Coordinators == nil {
@@ -152,8 +138,10 @@ func (v *TrinoClusterCustomValidator) validateTrinoCluster(obj *trinov1alpha1.Tr
 			if err := validateImage(obj.Spec.Image.Custom); err != nil {
 				errs.AddWithValue("spec.image.custom", err.Error(), obj.Spec.Image.Custom)
 			}
-		} else if obj.Spec.Image.GetImage(constants.ProductName) == "" {
-			errs.Add("spec.image", "image must specify either custom or repo with productVersion")
+		} else if _, err := obj.Spec.Image.ResolveImage(constants.ProductName, constants.ImageDefaults()); err != nil {
+			// Resolved against the same defaults the handler uses, so a spec stating only
+			// productVersion — which the handler CAN resolve — is not rejected here.
+			errs.Add("spec.image", err.Error())
 		}
 	}
 

--- a/examples/trino-operator/internal/webhook/v1alpha1/trinocluster_webhook_test.go
+++ b/examples/trino-operator/internal/webhook/v1alpha1/trinocluster_webhook_test.go
@@ -49,21 +49,37 @@ var _ = Describe("TrinoCluster Webhook", func() {
 	})
 
 	Context("When creating TrinoCluster under Defaulting Webhook", func() {
-		It("Should apply default image when not specified", func() {
+		It("Should NOT default the image — that is the handler's job now", func() {
+			// Webhook defaults are persisted into the spec at admission and never recomputed, so
+			// writing kubedoopVersion here froze every cluster on the operator version that first
+			// admitted it: an operator upgrade could not move an existing cluster onto the
+			// co-released product image. The handler's ImageDefaults fills the same fields on every
+			// reconcile instead (internal/controller/trino_handler.go), which is also what lets a
+			// user write only `productVersion` and still get a valid kubedoop tag.
 			obj.Spec.Image = nil
 			Expect(defaulter.Default(ctx, obj)).To(Succeed())
-			Expect(obj.Spec.Image).NotTo(BeNil())
-			Expect(obj.Spec.Image.Repo).To(Equal(constants.DefaultImageRepo))
-			Expect(obj.Spec.Image.ProductVersion).To(Equal(constants.DefaultImageProductVersion))
-			Expect(obj.Spec.Image.KubedoopVersion).To(Equal(constants.DefaultImageKubedoopVersion))
+			Expect(obj.Spec.Image).To(BeNil(), "the spec must record only what the user wrote")
 		})
 
-		It("Should not override image when specified", func() {
+		It("Should leave a user-specified image untouched", func() {
 			obj.Spec.Image = &commonsv1alpha1.ImageSpec{Custom: "custom/trino:latest"}
 			Expect(defaulter.Default(ctx, obj)).To(Succeed())
 			Expect(obj.Spec.Image.Custom).To(Equal("custom/trino:latest"))
 			Expect(obj.Spec.Image.Repo).To(BeEmpty())
 			Expect(obj.Spec.Image.ProductVersion).To(BeEmpty())
+		})
+
+		It("Should let the handler resolve what the webhook no longer writes", func() {
+			// The end-to-end statement of the change: a spec carrying only productVersion — which
+			// GetImage could not turn into a reference at all — resolves against the same defaults
+			// the handler uses, including the -kubedoop suffix the registry requires.
+			obj.Spec.Image = &commonsv1alpha1.ImageSpec{ProductVersion: "999"}
+			Expect(defaulter.Default(ctx, obj)).To(Succeed())
+
+			image, err := obj.Spec.Image.ResolveImage(constants.ProductName, constants.ImageDefaults())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(image).To(Equal(constants.DefaultImageRepo + "/" + constants.ProductName +
+				":999-kubedoop" + constants.DefaultImageKubedoopVersion))
 		})
 
 		It("Should initialize coordinators with default port", func() {

--- a/pkg/apis/commons/v1alpha1/image_types.go
+++ b/pkg/apis/commons/v1alpha1/image_types.go
@@ -17,6 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
+	"strings"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -56,28 +59,162 @@ type ImageSpec struct {
 	PullPolicy corev1.PullPolicy `json:"pullPolicy,omitempty"`
 }
 
-// GetImage returns the resolved container image reference for the given product name.
-// If Custom is set it is returned directly.
-// Otherwise the image is constructed from Repo, productName, ProductVersion and KubedoopVersion.
-// Returns an empty string if productName is empty or if both Repo and ProductVersion are unset.
-func (i *ImageSpec) GetImage(productName string) string {
-	if i.Custom != "" {
-		return i.Custom
+// ResolveImage builds the container image reference from this spec, filling every field the user
+// left empty from defaults, and reports what it could not resolve.
+//
+// # Why defaults are a parameter rather than a webhook's job
+//
+// The kubedoop tag convention is `{repo}/{product}:{productVersion}-kubedoop{kubedoopVersion}`, and
+// the natural value of that last part is the OPERATOR's own build version — a reconcile-time fact
+// that moves when the operator binary is upgraded. A mutating webhook cannot supply it: webhook
+// defaults are persisted into the spec at admission and never recomputed (docs/architecture.md
+// §2.6), so a cluster admitted by operator 0.1.0 would keep asking for `-kubedoop0.1.0` images
+// forever. Passing defaults here evaluates them on every reconcile, so an operator upgrade moves
+// existing clusters onto the co-released product image.
+//
+// # Resolution order
+//
+//   - The spec's Custom wins outright — a fully qualified reference is the whole answer.
+//   - Otherwise, if the spec states ANY structured field (repo / productVersion / kubedoopVersion),
+//     the reference is built from those fields with defaults filling the gaps. `defaults.Custom` is
+//     deliberately ignored on this path: a product pinning a custom default must not silently
+//     discard a version the user asked for.
+//   - Otherwise the user has no opinion, and defaults decide alone — including `defaults.Custom`.
+//
+// PullPolicy is excluded from "states anything" on purpose: it carries a CRD default, so it is
+// filled the moment `image: {}` exists and would make every spec look non-empty.
+//
+// # Errors
+//
+// A nil/empty result with a nil error means "nobody expressed an opinion"; the caller falls back to
+// whatever image it would have used anyway. A non-nil error means the user (or the product's
+// defaults) asked for something that cannot be turned into a reference, and names the missing
+// fields — running some other image instead would silently deploy a version nobody requested.
+// An empty productName is NOT an error: it means the caller resolves images itself, and only
+// Custom can be honored.
+func (i *ImageSpec) ResolveImage(productName string, defaults ImageSpec) (string, error) {
+	spec := ImageSpec{}
+	if i != nil {
+		spec = *i
 	}
-	if productName == "" || i.Repo == "" || i.ProductVersion == "" {
+
+	if spec.Custom != "" {
+		return spec.Custom, nil
+	}
+
+	stated := spec.Repo != "" || spec.ProductVersion != "" || spec.KubedoopVersion != ""
+	if !stated {
+		if defaults.Custom != "" {
+			return defaults.Custom, nil
+		}
+	}
+
+	repo := firstNonEmpty(spec.Repo, defaults.Repo)
+	productVersion := firstNonEmpty(spec.ProductVersion, defaults.ProductVersion)
+	kubedoopVersion := firstNonEmpty(spec.KubedoopVersion, defaults.KubedoopVersion)
+
+	if productName == "" {
+		// The caller did not declare a product, so there is no repository path segment to build
+		// with. That is the caller's own arrangement (it resolves images itself), not a user error.
+		return "", nil
+	}
+	if repo == "" || productVersion == "" {
+		if !stated && defaults.Repo == "" && defaults.ProductVersion == "" {
+			// Nothing anywhere. No opinion to honor and nothing to complain about.
+			return "", nil
+		}
+		return "", fmt.Errorf(
+			"cannot resolve spec.image for product %q: %s. Set them in spec.image or in the "+
+				"handler's ImageDefaults", productName, missingImageFields(repo, productVersion))
+	}
+
+	image := repo + "/" + productName + ":" + productVersion
+	if kubedoopVersion != "" {
+		image += "-kubedoop" + kubedoopVersion
+	}
+	return image, nil
+}
+
+// ResolvedProductVersion returns the product version to publish as app.kubernetes.io/version for
+// the image ResolveImage would build from the same inputs.
+//
+// On the structured path it is the version that actually reaches the container: the user's when
+// they stated one, the defaults' otherwise. That second half is the fix — a cluster running the
+// operator's default version used to carry no version label at all, because the field the label was
+// read from was empty.
+//
+// With a Custom reference in the SPEC, the user's own productVersion is still published: `custom`
+// replaces the image *reference*, and productVersion remains their declaration of which product
+// version that reference is. It is empty when they declared none, and empty when the custom
+// reference came from `defaults` rather than the spec — a product's default version says nothing
+// about an image it did not build.
+func (i *ImageSpec) ResolvedProductVersion(defaults ImageSpec) string {
+	spec := ImageSpec{}
+	if i != nil {
+		spec = *i
+	}
+	if spec.Custom != "" {
+		return spec.ProductVersion
+	}
+	stated := spec.Repo != "" || spec.ProductVersion != "" || spec.KubedoopVersion != ""
+	if !stated && defaults.Custom != "" {
 		return ""
 	}
-	image := i.Repo + "/" + productName + ":" + i.ProductVersion
-	if i.KubedoopVersion != "" {
-		image += "-kubedoop" + i.KubedoopVersion
+	return firstNonEmpty(spec.ProductVersion, defaults.ProductVersion)
+}
+
+// missingImageFields renders the unresolved half of a reference for an error message.
+func missingImageFields(repo, productVersion string) string {
+	var missing []string
+	if repo == "" {
+		missing = append(missing, "repo is unset")
 	}
+	if productVersion == "" {
+		missing = append(missing, "productVersion is unset")
+	}
+	return strings.Join(missing, " and ")
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// GetImage returns the resolved container image reference for the given product name, with no
+// defaults layer.
+//
+// Retained for callers that resolve against a spec a webhook has already filled (the trino example
+// validates with it). It is ResolveImage with empty defaults and the error dropped, so the two can
+// never disagree; new code should prefer ResolveImage, which reports why it could not resolve
+// instead of returning "" and letting the caller run some other image.
+func (i *ImageSpec) GetImage(productName string) string {
+	image, _ := i.ResolveImage(productName, ImageSpec{})
 	return image
 }
 
 // GetPullPolicy returns the configured pull policy, defaulting to IfNotPresent.
+//
+// Nil-safe: `spec.image` is an optional pointer, so a CR that declares no image at all reaches this
+// as a nil receiver.
 func (i *ImageSpec) GetPullPolicy() corev1.PullPolicy {
-	if i.PullPolicy == "" {
+	if i == nil || i.PullPolicy == "" {
 		return corev1.PullIfNotPresent
 	}
 	return i.PullPolicy
+}
+
+// ResolvedPullPolicy is GetPullPolicy with a defaults layer, matching ResolveImage: the user's
+// choice when they made one, the product's otherwise, IfNotPresent if neither.
+func (i *ImageSpec) ResolvedPullPolicy(defaults ImageSpec) corev1.PullPolicy {
+	if i != nil && i.PullPolicy != "" {
+		return i.PullPolicy
+	}
+	if defaults.PullPolicy != "" {
+		return defaults.PullPolicy
+	}
+	return corev1.PullIfNotPresent
 }

--- a/pkg/apis/commons/v1alpha1/image_types.go
+++ b/pkg/apis/commons/v1alpha1/image_types.go
@@ -123,9 +123,13 @@ func (i *ImageSpec) ResolveImage(productName string, defaults ImageSpec) (string
 			// Nothing anywhere. No opinion to honor and nothing to complain about.
 			return "", nil
 		}
+		// Worded for a `kubectl apply` reader: a product's validating webhook forwards this
+		// verbatim, and "the handler's ImageDefaults" is SDK-internal vocabulary that means nothing
+		// to whoever is editing the CR.
 		return "", fmt.Errorf(
-			"cannot resolve spec.image for product %q: %s. Set them in spec.image or in the "+
-				"handler's ImageDefaults", productName, missingImageFields(repo, productVersion))
+			"cannot resolve spec.image for product %q: %s. Set it in spec.image, or ask the "+
+				"operator's administrator to configure a default for it",
+			productName, missingImageFields(repo, productVersion))
 	}
 
 	image := repo + "/" + productName + ":" + productVersion

--- a/pkg/apis/commons/v1alpha1/image_types_test.go
+++ b/pkg/apis/commons/v1alpha1/image_types_test.go
@@ -203,6 +203,24 @@ var _ = Describe("ResolveImage", func() {
 		Expect(image).To(BeEmpty(), "the caller falls back to whatever it would have used")
 	})
 
+	It("still resolves a default custom with no product name", func() {
+		// A fully qualified reference needs no repository path segment, from either layer. The
+		// field docs said only spec.image.custom survived an empty ProductName, which was the
+		// design before it was narrowed — an untested sentence is how that drift survives.
+		image, err := (&v1alpha1.ImageSpec{}).ResolveImage("", v1alpha1.ImageSpec{Custom: "pinned/hive:frozen"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(image).To(Equal("pinned/hive:frozen"))
+	})
+
+	It("writes its error for whoever is editing the CR, not for the SDK", func() {
+		// A product's validating webhook forwards this verbatim to a `kubectl apply`, where
+		// SDK-internal vocabulary is noise: nobody editing a CR knows what an ImageDefaults is.
+		_, err := (&v1alpha1.ImageSpec{ProductVersion: "4.1.0"}).ResolveImage("hive", v1alpha1.ImageSpec{})
+		Expect(err).To(MatchError(ContainSubstring("spec.image")))
+		Expect(err.Error()).NotTo(ContainSubstring("ImageDefaults"))
+		Expect(err.Error()).NotTo(ContainSubstring("handler"))
+	})
+
 	It("resolves only custom when no product name is given, without erroring", func() {
 		// An empty product name means the caller resolves images itself — the shape hive and
 		// zookeeper use today. Erroring here would break every one of their clusters, and it is

--- a/pkg/apis/commons/v1alpha1/image_types_test.go
+++ b/pkg/apis/commons/v1alpha1/image_types_test.go
@@ -133,3 +133,137 @@ var _ = Describe("ImageSpec", func() {
 		})
 	})
 })
+
+var _ = Describe("ResolveImage", func() {
+	defaults := v1alpha1.ImageSpec{
+		Repo:            "quay.io/zncdatadev",
+		ProductVersion:  "4.0.1",
+		KubedoopVersion: "0.0.0-dev",
+	}
+
+	It("fills what the user left empty, so a bare productVersion resolves", func() {
+		// The case that made three operators hand-roll image resolution. Kubedoop publishes only
+		// the "-kubedoop<version>" tag, and GetImage appends that suffix only when the USER wrote
+		// kubedoopVersion — so a spec carrying just productVersion produced
+		// "quay.io/zncdatadev/hive:4.0.1", which does not exist in the registry.
+		spec := &v1alpha1.ImageSpec{ProductVersion: "4.1.0"}
+		Expect(spec.ResolveImage("hive", defaults)).
+			To(Equal("quay.io/zncdatadev/hive:4.1.0-kubedoop0.0.0-dev"))
+	})
+
+	It("resolves entirely from defaults when the user states nothing", func() {
+		Expect((&v1alpha1.ImageSpec{}).ResolveImage("hive", defaults)).
+			To(Equal("quay.io/zncdatadev/hive:4.0.1-kubedoop0.0.0-dev"))
+	})
+
+	It("treats a nil spec as an empty one", func() {
+		var spec *v1alpha1.ImageSpec
+		Expect(spec.ResolveImage("hive", defaults)).
+			To(Equal("quay.io/zncdatadev/hive:4.0.1-kubedoop0.0.0-dev"))
+	})
+
+	It("ignores pullPolicy when deciding whether the user stated anything", func() {
+		// pullPolicy carries a CRD default, so it is filled the moment `image: {}` exists. Counting
+		// it would make every stored spec look like a user opinion.
+		spec := &v1alpha1.ImageSpec{PullPolicy: corev1.PullAlways}
+		Expect(spec.ResolveImage("hive", v1alpha1.ImageSpec{Custom: "pinned:1"})).To(Equal("pinned:1"))
+	})
+
+	It("lets the spec's custom win outright", func() {
+		spec := &v1alpha1.ImageSpec{Custom: "my-registry/hive:local", ProductVersion: "9.9.9"}
+		Expect(spec.ResolveImage("hive", defaults)).To(Equal("my-registry/hive:local"))
+	})
+
+	It("does not let a default custom discard a version the user asked for", func() {
+		// The whole point of this change is that a user's stated version reaches the container.
+		// A product pinning ImageDefaults.Custom must not silently undo that.
+		spec := &v1alpha1.ImageSpec{ProductVersion: "4.1.0"}
+		withCustomDefault := defaults
+		withCustomDefault.Custom = "pinned/hive:frozen"
+		Expect(spec.ResolveImage("hive", withCustomDefault)).
+			To(Equal("quay.io/zncdatadev/hive:4.1.0-kubedoop0.0.0-dev"))
+	})
+
+	It("uses a default custom when the user states nothing", func() {
+		Expect((&v1alpha1.ImageSpec{}).ResolveImage("hive", v1alpha1.ImageSpec{Custom: "pinned/hive:frozen"})).
+			To(Equal("pinned/hive:frozen"))
+	})
+
+	It("errors, naming the missing field, rather than resolving to nothing", func() {
+		// Returning "" here is what let a caller fall back to its static image and run a version
+		// nobody asked for, with no error and no event.
+		_, err := (&v1alpha1.ImageSpec{ProductVersion: "4.1.0"}).ResolveImage("hive", v1alpha1.ImageSpec{})
+		Expect(err).To(MatchError(ContainSubstring("repo is unset")))
+		Expect(err).To(MatchError(ContainSubstring("hive")))
+	})
+
+	It("says nothing when nobody expressed an opinion", func() {
+		image, err := (&v1alpha1.ImageSpec{}).ResolveImage("hive", v1alpha1.ImageSpec{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(image).To(BeEmpty(), "the caller falls back to whatever it would have used")
+	})
+
+	It("resolves only custom when no product name is given, without erroring", func() {
+		// An empty product name means the caller resolves images itself — the shape hive and
+		// zookeeper use today. Erroring here would break every one of their clusters, and it is
+		// the caller's own arrangement rather than a user mistake.
+		image, err := (&v1alpha1.ImageSpec{Repo: "r", ProductVersion: "1"}).ResolveImage("", defaults)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(image).To(BeEmpty())
+
+		Expect((&v1alpha1.ImageSpec{Custom: "pinned:1"}).ResolveImage("", defaults)).To(Equal("pinned:1"))
+	})
+
+	It("keeps GetImage in step by delegating to it", func() {
+		spec := &v1alpha1.ImageSpec{Repo: "quay.io/kubedoop", ProductVersion: "3.4.1", KubedoopVersion: "0.2.0"}
+		Expect(spec.GetImage("trino")).To(Equal("quay.io/kubedoop/trino:3.4.1-kubedoop0.2.0"))
+		Expect((&v1alpha1.ImageSpec{ProductVersion: "3.4.1"}).GetImage("trino")).To(BeEmpty(),
+			"the legacy form still reports nothing rather than the reason")
+	})
+})
+
+var _ = Describe("pull policy", func() {
+	It("is nil-safe", func() {
+		// spec.image is an optional pointer, so a CR declaring no image reaches this as nil. It
+		// used to panic, and only surfaced once ImageDefaults made a nil spec resolve to a real
+		// image instead of stopping earlier.
+		var spec *v1alpha1.ImageSpec
+		Expect(spec.GetPullPolicy()).To(Equal(corev1.PullIfNotPresent))
+		Expect(spec.ResolvedPullPolicy(v1alpha1.ImageSpec{})).To(Equal(corev1.PullIfNotPresent))
+	})
+
+	It("layers like the image does: user, then product, then IfNotPresent", func() {
+		defaults := v1alpha1.ImageSpec{PullPolicy: corev1.PullNever}
+		Expect((&v1alpha1.ImageSpec{PullPolicy: corev1.PullAlways}).ResolvedPullPolicy(defaults)).
+			To(Equal(corev1.PullAlways))
+		Expect((&v1alpha1.ImageSpec{}).ResolvedPullPolicy(defaults)).To(Equal(corev1.PullNever))
+		Expect((&v1alpha1.ImageSpec{}).ResolvedPullPolicy(v1alpha1.ImageSpec{})).
+			To(Equal(corev1.PullIfNotPresent))
+	})
+})
+
+var _ = Describe("ResolvedProductVersion", func() {
+	defaults := v1alpha1.ImageSpec{Repo: "quay.io/zncdatadev", ProductVersion: "4.0.1"}
+
+	It("reports the version the resolved image runs", func() {
+		Expect((&v1alpha1.ImageSpec{ProductVersion: "4.1.0"}).ResolvedProductVersion(defaults)).To(Equal("4.1.0"))
+		Expect((&v1alpha1.ImageSpec{}).ResolvedProductVersion(defaults)).To(Equal("4.0.1"),
+			"the default is what the pods actually run, so the label must say so")
+	})
+
+	It("keeps the user's declaration alongside a custom reference", func() {
+		// `custom` replaces the image REFERENCE; productVersion remains the user's statement of
+		// which product version that reference is. Nothing else knows, and they do.
+		spec := &v1alpha1.ImageSpec{Custom: "my-registry/hive:local", ProductVersion: "9.9.9"}
+		Expect(spec.ResolvedProductVersion(defaults)).To(Equal("9.9.9"))
+
+		Expect((&v1alpha1.ImageSpec{Custom: "my-registry/hive:local"}).ResolvedProductVersion(defaults)).
+			To(BeEmpty(), "with no declaration there is nothing to publish")
+	})
+
+	It("is empty when the custom reference came from defaults rather than the spec", func() {
+		// A product's default productVersion says nothing about an image it did not build.
+		Expect((&v1alpha1.ImageSpec{}).ResolvedProductVersion(
+			v1alpha1.ImageSpec{Custom: "pinned:1", ProductVersion: "4.0.1"})).To(BeEmpty())
+	})
+})

--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -70,13 +70,41 @@ type BaseRoleGroupHandler[CR common.ClusterInterface] struct {
 	// ImagePullPolicy is the default image pull policy.
 	ImagePullPolicy corev1.PullPolicy
 
-	// ProductName is the kubedoop product name (e.g. "trino") used to resolve the cluster CR's
-	// spec.image into a concrete image reference: "{repo}/{ProductName}:{version}-kubedoop{v}".
-	// When set, the CR-declared image wins over RoleImages and Image for every role, so products
-	// no longer have to patch the built container themselves — a post-build patch would also miss
-	// the sidecars, which are told the image before the StatefulSet is built. Empty keeps the
-	// static Image/RoleImages behavior (backward compatible).
+	// ProductName is the kubedoop product name (e.g. "trino"). It supplies two unrelated things:
+	// the app.kubernetes.io/name label value, and the repository path segment used when resolving
+	// spec.image into "{repo}/{ProductName}:{version}-kubedoop{v}".
+	//
+	// It no longer decides WHETHER spec.image is read — that is ImageDefaults' job now. The two
+	// were coupled, and because the image half could not express the kubedoop tag convention (see
+	// ImageDefaults), three migrated operators gave up all of it: they left ProductName empty,
+	// hand-rolled image resolution, and two of them emit no app.kubernetes.io/version at all.
+	//
+	// Left empty, only spec.image.custom can be honored — without a product name there is no
+	// repository path segment to build a reference from — and the handler otherwise runs its
+	// static Image/RoleImages. That is the shape a product uses when it resolves images itself.
 	ProductName string
+
+	// ImageDefaults fills in whatever spec.image leaves empty. It is read on every reconcile,
+	// which is the whole point:
+	//
+	//	handler.ProductName = "hive"
+	//	handler.ImageDefaults = commonsv1alpha1.ImageSpec{
+	//	    Repo:            "quay.io/zncdatadev",
+	//	    ProductVersion:  "4.0.1",
+	//	    KubedoopVersion: version.BuildVersion, // the operator's own build version
+	//	}
+	//
+	// KubedoopVersion is why this cannot be a webhook's job. Kubedoop product images are published
+	// only with the "-kubedoop<version>" suffix, and the natural value of that suffix is the
+	// operator's build version — a reconcile-time fact that moves when the operator binary is
+	// upgraded. Webhook defaults are persisted into the spec at admission and never recomputed
+	// (docs/architecture.md §2.6), so a cluster admitted by operator 0.1.0 would keep asking for
+	// -kubedoop0.1.0 images forever. Evaluated here, an operator upgrade moves existing clusters
+	// onto the co-released product image.
+	//
+	// Precedence is per field, user first: spec.image wins wherever it states something, these
+	// fill the rest. A spec that states nothing at all leaves these deciding alone.
+	ImageDefaults v1alpha1.ImageSpec
 
 	// RoleImages maps role names to specific images.
 	// If a role is not found here, the default Image is used.
@@ -279,7 +307,10 @@ func (h *BaseRoleGroupHandler[CR]) BuildResources(
 		if sidecarMgr == nil {
 			sidecarMgr = h.sidecarManager
 		}
-		image, pullPolicy := h.containerImage(buildCtx, buildCtx.RoleName)
+		image, pullPolicy, err := h.containerImage(buildCtx, buildCtx.RoleName)
+		if err != nil {
+			return nil, err
+		}
 		if err := sidecarMgr.SetProductImage(image, pullPolicy); err != nil {
 			return nil, fmt.Errorf("failed to set product image on sidecars: %w", err)
 		}
@@ -402,18 +433,29 @@ func (h *BaseRoleGroupHandler[CR]) LogVolumeSizeLimit() string {
 	return h.LogVolumeSize
 }
 
-// clusterImage resolves the image the cluster CR declares in spec.image. It returns "" unless the
-// product opted in by setting ProductName — spec.image is product-scoped
-// ("{repo}/{ProductName}:{version}"), so the framework cannot resolve it on its own.
-func (h *BaseRoleGroupHandler[CR]) clusterImage(buildCtx *RoleGroupBuildContext) (string, corev1.PullPolicy) {
-	if h.ProductName == "" || buildCtx == nil || buildCtx.ClusterSpec == nil || buildCtx.ClusterSpec.Image == nil {
-		return "", ""
+// clusterImage resolves the image from the cluster CR's spec.image folded over ImageDefaults.
+//
+// It returns ("", "", nil) when neither the user nor the product expressed an opinion, leaving the
+// caller to fall back. It returns an ERROR when they did and the result cannot be turned into a
+// reference: the alternative is running the handler's static image, i.e. silently deploying a
+// version nobody asked for. Same call as `config.affinity` — a contract the framework cannot honor
+// is reported, not ignored.
+func (h *BaseRoleGroupHandler[CR]) clusterImage(
+	buildCtx *RoleGroupBuildContext,
+) (string, corev1.PullPolicy, error) {
+	var spec *v1alpha1.ImageSpec
+	if buildCtx != nil && buildCtx.ClusterSpec != nil {
+		spec = buildCtx.ClusterSpec.Image
 	}
-	image := buildCtx.ClusterSpec.Image.GetImage(h.ProductName)
+
+	image, err := spec.ResolveImage(h.ProductName, h.ImageDefaults)
+	if err != nil {
+		return "", "", err
+	}
 	if image == "" {
-		return "", ""
+		return "", "", nil
 	}
-	return image, buildCtx.ClusterSpec.Image.GetPullPolicy()
+	return image, spec.ResolvedPullPolicy(h.ImageDefaults), nil
 }
 
 // containerImage returns the container image and pull policy for a role, in precedence order:
@@ -421,14 +463,20 @@ func (h *BaseRoleGroupHandler[CR]) clusterImage(buildCtx *RoleGroupBuildContext)
 // default. Resolving it here — rather than leaving each product to patch the built container —
 // keeps the image the sidecars are told about (SetProductImage, e.g. the Vector agent, which ships
 // inside the product image) identical to the one the main container actually runs.
-func (h *BaseRoleGroupHandler[CR]) containerImage(buildCtx *RoleGroupBuildContext, roleName string) (string, corev1.PullPolicy) {
-	if image, pullPolicy := h.clusterImage(buildCtx); image != "" {
-		return image, pullPolicy
+func (h *BaseRoleGroupHandler[CR]) containerImage(
+	buildCtx *RoleGroupBuildContext, roleName string,
+) (string, corev1.PullPolicy, error) {
+	image, pullPolicy, err := h.clusterImage(buildCtx)
+	if err != nil {
+		return "", "", err
+	}
+	if image != "" {
+		return image, pullPolicy, nil
 	}
 	if image, ok := h.RoleImages[roleName]; ok {
-		return image, h.ImagePullPolicy
+		return image, h.ImagePullPolicy, nil
 	}
-	return h.Image, h.ImagePullPolicy
+	return h.Image, h.ImagePullPolicy, nil
 }
 
 // containerPorts returns the container ports for a role group.
@@ -456,16 +504,26 @@ func RoleLabelKey(domain string) string { return domain + "/role" }
 // RoleGroupLabelKey returns the identity label key for the role group, under the given domain.
 func RoleGroupLabelKey(domain string) string { return domain + "/role-group" }
 
-// productVersion returns the value for app.kubernetes.io/version: spec.image.productVersion, but
-// only when the handler is CR-image driven. With ProductName unset the handler runs its static
-// Image and ignores spec.image entirely (see clusterImage), so publishing a version read from a
-// field that does not reach the container would label the pods with a version they are not
-// running.
+// productVersion returns the value for app.kubernetes.io/version: the product version the image
+// this handler actually resolves is running.
+//
+// It reads the RESOLVED version — spec.image's when the user stated one, ImageDefaults' otherwise —
+// so the label tracks the tag the pods run rather than only what the user happened to type. It is
+// empty in the two cases where that version is unknowable or unused: a Custom reference (the tag was
+// written by hand, and spec.image.productVersion never reached the container), and a handler with no
+// ProductName, which runs its static Image and resolves nothing from the CR.
+//
+// Labelling pods with a version they are not running is the one thing this label must never do,
+// which is why both exclusions are silence rather than a guess.
 func (h *BaseRoleGroupHandler[CR]) productVersion(clusterSpec *v1alpha1.GenericClusterSpec) string {
-	if h.ProductName == "" || clusterSpec == nil || clusterSpec.Image == nil {
+	if h.ProductName == "" {
 		return ""
 	}
-	return clusterSpec.Image.ProductVersion
+	var spec *v1alpha1.ImageSpec
+	if clusterSpec != nil {
+		spec = clusterSpec.Image
+	}
+	return spec.ResolvedProductVersion(h.ImageDefaults)
 }
 
 // recommendedLabels returns the Kubernetes recommended labels the framework stamps on every
@@ -704,7 +762,10 @@ func (h *BaseRoleGroupHandler[CR]) buildStatefulSet(
 	}
 
 	// Set basic properties
-	image, pullPolicy := h.containerImage(buildCtx, buildCtx.RoleName)
+	image, pullPolicy, err := h.containerImage(buildCtx, buildCtx.RoleName)
+	if err != nil {
+		return nil, err
+	}
 	stsBuilder.WithLabels(labels).
 		WithSelectorLabels(h.buildSelectorLabels(buildCtx)).
 		WithReplicas(replicas).

--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -79,9 +79,11 @@ type BaseRoleGroupHandler[CR common.ClusterInterface] struct {
 	// ImageDefaults), three migrated operators gave up all of it: they left ProductName empty,
 	// hand-rolled image resolution, and two of them emit no app.kubernetes.io/version at all.
 	//
-	// Left empty, only spec.image.custom can be honored — without a product name there is no
-	// repository path segment to build a reference from — and the handler otherwise runs its
-	// static Image/RoleImages. That is the shape a product uses when it resolves images itself.
+	// Left empty, the only references still resolvable are the fully qualified ones, which need no
+	// repository path segment: spec.image.custom, and ImageDefaults.Custom when the spec states no
+	// structured field. Everything else falls through to the handler's static Image/RoleImages
+	// rather than erroring — that is the shape a product uses when it resolves images itself, and
+	// its CRs may well carry a spec.image this handler is not equipped to read.
 	ProductName string
 
 	// ImageDefaults fills in whatever spec.image leaves empty. It is read on every reconcile,
@@ -508,13 +510,19 @@ func RoleGroupLabelKey(domain string) string { return domain + "/role-group" }
 // this handler actually resolves is running.
 //
 // It reads the RESOLVED version — spec.image's when the user stated one, ImageDefaults' otherwise —
-// so the label tracks the tag the pods run rather than only what the user happened to type. It is
-// empty in the two cases where that version is unknowable or unused: a Custom reference (the tag was
-// written by hand, and spec.image.productVersion never reached the container), and a handler with no
-// ProductName, which runs its static Image and resolves nothing from the CR.
+// so the label tracks the tag the pods run rather than only what the user happened to type. That
+// second half is the fix: a cluster running the operator's default version used to carry no version
+// label at all.
 //
-// Labelling pods with a version they are not running is the one thing this label must never do,
-// which is why both exclusions are silence rather than a guess.
+// It is empty when:
+//   - the handler declares no ProductName, so it runs its static Image and resolves nothing from
+//     the CR — a version read from a field that never reaches the container would be a guess;
+//   - the user pinned spec.image.custom and stated no productVersion alongside it;
+//   - the custom reference came from ImageDefaults rather than the spec, since a product's default
+//     version says nothing about an image it did not build.
+//
+// A spec.image.custom WITH a productVersion still publishes it: `custom` replaces the image
+// *reference*, and that field remains the user's declaration of which product version it is.
 func (h *BaseRoleGroupHandler[CR]) productVersion(clusterSpec *v1alpha1.GenericClusterSpec) string {
 	if h.ProductName == "" {
 		return ""

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -2321,15 +2321,87 @@ var _ = Describe("Container image resolution", func() {
 		Expect(resources.StatefulSet.Spec.Template.Spec.Containers[0].Image).To(Equal("fallback:1"))
 	})
 
-	It("falls back to the per-role image when the CR carries no resolvable image", func() {
+	It("fails rather than running a different version than the user asked for", func() {
+		// This used to fall back to the per-role image and start it, so a user writing
+		// `productVersion: 4.7.0` with no repo anywhere silently got whatever the handler was
+		// built with — no error, no event, no status change. Deploying an unrequested version of a
+		// stateful product is not a safe default; the same call as config.affinity.
 		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("fallback:1", testScheme)
 		handler.ProductName = "trino"
 		handler.SetRoleImage("server", "role-image:1")
 
+		_, err := handler.BuildResources(context.Background(), k8sClient, mockCR,
+			newBuildCtx(&v1alpha1.ImageSpec{ProductVersion: "4.7.0"}))
+		Expect(err).To(MatchError(ContainSubstring("repo is unset")))
+	})
+
+	It("falls back to the per-role image when nobody stated an image at all", func() {
+		// No opinion anywhere is not a misconfiguration — it is a handler running its own image.
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("fallback:1", testScheme)
+		handler.ProductName = "trino"
+		handler.SetRoleImage("server", "role-image:1")
+
+		resources, err := handler.BuildResources(context.Background(), k8sClient, mockCR, newBuildCtx(nil))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.StatefulSet.Spec.Template.Spec.Containers[0].Image).To(Equal("role-image:1"))
+	})
+
+	It("completes a partial spec.image from ImageDefaults", func() {
+		// The case that made three operators hand-roll image resolution: kubedoop publishes only
+		// the "-kubedoop<version>" tag, and a user writing just productVersion could not produce
+		// one, because the suffix was appended only when the USER supplied kubedoopVersion.
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("fallback:1", testScheme)
+		handler.ProductName = "trino"
+		handler.ImageDefaults = v1alpha1.ImageSpec{
+			Repo:            "quay.io/zncdatadev",
+			ProductVersion:  "476",
+			KubedoopVersion: "0.0.0-dev",
+		}
+
 		resources, err := handler.BuildResources(context.Background(), k8sClient, mockCR,
 			newBuildCtx(&v1alpha1.ImageSpec{ProductVersion: "4.7.0"}))
 		Expect(err).NotTo(HaveOccurred())
-		Expect(resources.StatefulSet.Spec.Template.Spec.Containers[0].Image).To(Equal("role-image:1"))
+		Expect(resources.StatefulSet.Spec.Template.Spec.Containers[0].Image).
+			To(Equal("quay.io/zncdatadev/trino:4.7.0-kubedoop0.0.0-dev"))
+	})
+
+	It("runs the defaults when the CR states no image, so an operator upgrade moves the cluster", func() {
+		// ImageDefaults is read every reconcile. A webhook could not do this: its values are
+		// persisted at admission and never recomputed, freezing kubedoopVersion at whatever
+		// operator version first admitted the CR.
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("fallback:1", testScheme)
+		handler.ProductName = "trino"
+		handler.ImageDefaults = v1alpha1.ImageSpec{
+			Repo: "quay.io/zncdatadev", ProductVersion: "476", KubedoopVersion: "0.2.0",
+		}
+
+		resources, err := handler.BuildResources(context.Background(), k8sClient, mockCR, newBuildCtx(nil))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.StatefulSet.Spec.Template.Spec.Containers[0].Image).
+			To(Equal("quay.io/zncdatadev/trino:476-kubedoop0.2.0"))
+	})
+
+	It("keeps a ProductName-less handler on its static image, and never errors", func() {
+		// The shape hive and zookeeper use today: they resolve images themselves and leave
+		// ProductName empty. Their CRs DO carry a webhook-filled spec.image, so treating an
+		// unresolvable spec as an error here would have broken every one of their clusters.
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("fallback:1", testScheme)
+
+		resources, err := handler.BuildResources(context.Background(), k8sClient, mockCR,
+			newBuildCtx(&v1alpha1.ImageSpec{Repo: "quay.io/kubedoop", ProductVersion: "4.7.0"}))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.StatefulSet.Spec.Template.Spec.Containers[0].Image).To(Equal("fallback:1"))
+	})
+
+	It("honours spec.image.custom even without a ProductName", func() {
+		// A fully qualified reference needs no product name to build, and ignoring it meant a user
+		// pinning an image on such an operator was silently overruled.
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("fallback:1", testScheme)
+
+		resources, err := handler.BuildResources(context.Background(), k8sClient, mockCR,
+			newBuildCtx(&v1alpha1.ImageSpec{Custom: "my-registry/trino:pinned"}))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.StatefulSet.Spec.Template.Spec.Containers[0].Image).To(Equal("my-registry/trino:pinned"))
 	})
 
 	It("gives the sidecars the same CR-resolved image as the main container", func() {


### PR DESCRIPTION
Closes #569. Last of the three issues from the hive-operator migration.

## The coupling

`ProductName` decided three unrelated things at once: whether `spec.image` is read, whether `app.kubernetes.io/name` is emitted, and whether `app.kubernetes.io/version` is emitted. Because the first could not express the kubedoop tag convention, a product that wanted the other two had to give up all three — and three migrated operators did exactly that, hand-rolling image resolution, with **two of them emitting no `app.kubernetes.io/version` at all**.

**Why the image path was unusable.** Kubedoop publishes product images only with the `-kubedoop<version>` suffix, and `GetImage` appended it only when the *user* wrote `kubedoopVersion`. A CR stating just `productVersion` produced `quay.io/…/hive:4.0.1` — a tag that does not exist. Separately, when `repo` or `productVersion` was empty it returned `""`, after which the handler silently ran its static image: the user's requested version discarded with **no error, no event, no status change**.

**Why defaults cannot live in a webhook.** The suffix's natural value is the operator's own build version — a reconcile-time fact. Webhook defaults are persisted into the spec at admission and never recomputed (`architecture.md` §2.6), so a cluster admitted by operator 0.1.0 keeps asking for `-kubedoop0.1.0` images forever. hdfs-operator solves it in its webhook today; that was not an invention, it copied `examples/trino-operator` — **which this PR migrates to the new shape**, so the reference stops teaching the pattern the architecture doc warns against.

## API

```go
handler.ProductName   = "trino"                 // app.kubernetes.io/name AND the repo path segment
handler.ImageDefaults = commonsv1alpha1.ImageSpec{
    Repo: "quay.io/zncdatadev", ProductVersion: "476", KubedoopVersion: version.BuildVersion,
}
```

```go
ImageSpec.ResolveImage(productName string, defaults ImageSpec) (string, error)
ImageSpec.ResolvedProductVersion(defaults ImageSpec) string
ImageSpec.ResolvedPullPolicy(defaults ImageSpec) corev1.PullPolicy
```

`GetImage` is retained and now **delegates to `ResolveImage`**, so the two cannot drift.

## Decisions worth reviewing

**An unresolvable `spec.image` fails the role group**, naming the missing field, rather than falling back. Running a version nobody asked for is not a safe default for a stateful product — the same call as `config.affinity`.

**hive/zookeeper are safe.** They leave `ProductName` empty *and* their CRs carry a webhook-filled `spec.image`, so "spec states something unresolvable ⇒ error" would have broken every one of their clusters. With `ProductName` empty nothing is resolved beyond `spec.image.custom`, and that path never errors. There is a spec pinning this.

**`spec.image.custom` is now honoured without `ProductName`** — it used to be ignored, silently overruling a user's pinned image.

**One thing I did NOT change.** `custom` + explicit `productVersion` still publishes the version label. I had it dropping the label, then found the existing spec's comment was a deliberate position ("custom replaces the *reference*; productVersion declares which version that reference is"), not an oversight — so I narrowed my change rather than overturning a considered call on weaker grounds. The real fix is that the label now follows the **resolved** version, so it appears when the version came from `ImageDefaults`.

**A nil-pointer bug the new specs caught.** `GetPullPolicy` was never nil-safe; it only started receiving nil once a nil `spec.image` could resolve to a real image. Found by a panicking spec, not by review.

## Verification

- **Six mutations, all killed**: defaults not consulted; unresolvable spec returning `""` instead of erroring; `defaults.Custom` discarding the user's version; an empty `ProductName` erroring instead of falling back; the version label read from the spec only; the nil guard removed.
- `examples/trino-operator` migrated end to end — handler sets `ImageDefaults`, the defaulting webhook's image branch is gone, and the validator resolves against the *same* defaults via a new `constants.ImageDefaults()` so it can never reject a spec the handler would accept.
- `make lint` (0 issues), `make test` (18 packages), `make verify-generate`, and the examples module's `make lint` + `make test` all pass.

## For adopters

Set `ProductName` + `ImageDefaults`, delete the hand-rolled resolver, drop the image branch of any defaulting webhook. hive and zookeeper each lose ~25 lines; hdfs additionally drops its webhook branch. Pod templates gain `app.kubernetes.io/version` (one rolling update); `.spec.selector` is untouched.