### PR TITLE
fix(reconciler): give per-CR inputs a per-call home instead of the shared handler

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -325,6 +325,27 @@ with a hash suffix by `RoleGroupResourceName`), `ServiceAccountName` (the SA the
 resolved and ensured), `SidecarManager`, `VolumeProviders` (see §16) and
 `VectorAggregatorAddress`.
 
+**It is also where a product puts its per-CR inputs.** `Image`, `ImagePullPolicy`, `ContainerPorts`
+and `ServicePorts` on the context outrank the handler's own, and the context is rebuilt per role
+group per reconcile:
+
+```go
+func (h *MyHandler) BuildResources(ctx context.Context, c client.Client, cr *MyCluster,
+    buildCtx *reconciler.RoleGroupBuildContext) (*reconciler.RoleGroupResources, error) {
+    buildCtx.ContainerPorts = h.portsFor(cr, buildCtx.RoleName) // depends on cr.Spec.Tls
+    return h.BaseRoleGroupHandler.BuildResources(ctx, c, cr, buildCtx)
+}
+```
+
+**One handler instance serves every cluster** — it is built once in `main.go` — so the older idiom
+of assigning `h.Image` or calling `h.SetRoleContainerPorts` inside `BuildResources` writes
+per-cluster values into process-wide state. Above `MaxConcurrentReconciles: 1` those writes race
+between clusters; at 1 they still leak, because a product that conditionally skips one assignment
+inherits the previous CR's value (spark-k8s-operator shipped exactly that). Handler fields remain
+correct for reconcile-**invariant** configuration; `sidecar.SidecarManager.CloneForBuild` covers the
+framework's own instance of the same hazard, a handler-registered manager whose configs
+`SetProductImage` writes into. See `docs/architecture.md` §4.4.4.
+
 **Role and role group names are constrained by the CRD, not by convention.** The keys of
 `spec.roles` and `spec.roles.<role>.roleGroups` must be lowercase RFC 1123 labels — a CEL
 `x-kubernetes-validations` rule on `GenericClusterSpec.Roles` and `RoleSpec.RoleGroups` rejects

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -344,7 +344,7 @@ between clusters; at 1 they still leak, because a product that conditionally ski
 inherits the previous CR's value (spark-k8s-operator shipped exactly that). Handler fields remain
 correct for reconcile-**invariant** configuration; `sidecar.SidecarManager.CloneForBuild` covers the
 framework's own instance of the same hazard, a handler-registered manager whose configs
-`SetProductImage` writes into. See `docs/architecture.md` §4.4.4.
+`SetProductImage` writes into. See `docs/architecture.md` §4.1.4.
 
 **Role and role group names are constrained by the CRD, not by convention.** The keys of
 `spec.roles` and `spec.roles.<role>.roleGroups` must be lowercase RFC 1123 labels — a CEL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,32 @@ changes are listed below.**
     progress markers. A product that needs e.g. cloud LoadBalancer annotations on the client Service
     has no supported way to set them; tracked in #553.
 
+### fix (shared handler state)
+
+- **`RoleGroupBuildContext` gains `Image`, `ImagePullPolicy`, `ContainerPorts` and `ServicePorts`**
+  (#525) — the per-CR inputs a product derives from the cluster it is building for. They outrank the
+  handler's own values, and the context is rebuilt per role group per reconcile.
+- **Why it matters.** One handler instance is constructed in `main.go` and serves every CR and every
+  reconcile, so the established idiom — assigning `h.Image` or calling `h.SetRoleContainerPorts`
+  from inside `BuildResources` — writes per-cluster values into process-wide state. Above
+  `MaxConcurrentReconciles: 1` those writes **race** between clusters; at the default of 1 they
+  still **leak**, because a product that conditionally skips one assignment inherits the previous
+  CR's value. spark-k8s-operator shipped exactly that (a CR omitting `pullPolicy` took the last
+  CR's), with a serial reconcile loop and no race involved.
+- **The framework held one too.** `SidecarManager.SetProductImage` writes the resolved image into
+  the manager's configs, so a manager registered through `BaseRoleGroupHandler.WithSidecarManager` —
+  process-wide — carried one cluster's image into the next. New
+  `sidecar.SidecarManager.CloneForBuild()` copies the configs for the build; providers and phases
+  are shared, being read-only during it. The reconciler-created manager is already per-role-group
+  and is used as-is.
+- Additive and backward compatible: unset context fields fall back to the handler exactly as before,
+  so a product that has not migrated renders byte-identical output. Handler fields stay correct for
+  reconcile-**invariant** configuration — this is a split, not a deprecation — and their doc
+  comments plus the `SetRole*` setters now say which is which.
+- Pinned by five specs, one of which builds eight clusters concurrently through a single handler.
+  `make test` runs with `-race` in CI, so the old idiom is reported there as a data race rather than
+  as a wrong value — verified by temporarily reintroducing it.
+
 ### BREAKING (image resolution)
 
 - **`BaseRoleGroupHandler.ProductName` no longer decides whether `spec.image` is read** (#569). It

--- a/docs/DOC_CHANGELOG.md
+++ b/docs/DOC_CHANGELOG.md
@@ -4,6 +4,26 @@ This document tracks all changes made to the SDK documentation.
 
 ---
 
+## [2026-08-03a] (handler lifetime, and where per-CR inputs go)
+
+### Core Architecture (`architecture.md`)
+
+- New **§4.4.4 Handler Lifetime and Per-CR Inputs**: one handler instance serves every cluster, a
+  table of what belongs on the handler versus the build context, and the two failure modes of
+  getting it wrong — the race above `MaxConcurrentReconciles: 1`, and the quieter stale-value leak
+  at concurrency 1 that spark-k8s-operator actually shipped.
+- Records that `BuildResources` is read-only on the handler, and that the framework's own instance
+  of the hazard (a handler-registered `SidecarManager`, whose configs `SetProductImage` writes into)
+  is now cloned per build.
+- Answers the first of the three gaps #579 names.
+
+### Framework Documentation (`AGENTS.md`)
+
+- §4 documents the per-CR input fields on `RoleGroupBuildContext`, with the example call and the
+  reason the older handler-mutating idiom is unsafe.
+
+---
+
 ## [2026-08-02d] (image resolution moves to reconcile time)
 
 ### Core Architecture (`architecture.md`)

--- a/docs/DOC_CHANGELOG.md
+++ b/docs/DOC_CHANGELOG.md
@@ -8,7 +8,7 @@ This document tracks all changes made to the SDK documentation.
 
 ### Core Architecture (`architecture.md`)
 
-- New **§4.4.4 Handler Lifetime and Per-CR Inputs**: one handler instance serves every cluster, a
+- New **§4.1.4 Handler Lifetime and Per-CR Inputs**: one handler instance serves every cluster, a
   table of what belongs on the handler versus the build context, and the two failure modes of
   getting it wrong — the race above `MaxConcurrentReconciles: 1`, and the quieter stale-value leak
   at concurrency 1 that spark-k8s-operator actually shipped.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -484,6 +484,24 @@ Deletion is a **state machine driven across several reconciles**, not a single p
 - **Manual Resource Deletion**: Rely on idempotent deletion (`IsNotFound` short-circuit) to avoid errors, syncing Status in the next reconciliation.
 - **Status Tampering**: Query cluster resources before deletion, and verify the ownerReference, so only resources this cluster actually owns are deleted.
 
+### 4.4.4 Handler Lifetime and Per-CR Inputs
+
+**One `RoleGroupHandler` instance serves every cluster.** It is constructed once in `main.go` and the controller reuses it for every CR and every reconcile, so every field on it is process-wide state. That is not obvious from the embedding idiom the SDK encourages, and it has produced real defects downstream.
+
+| where a value lives | lifetime | what belongs there |
+| --- | --- | --- |
+| handler fields (`Image`, `RoleContainerPorts`, …) | process | reconcile-**invariant** settings — a static image, `ProductName`, `ImageDefaults`, ports that do not depend on the CR |
+| `RoleGroupBuildContext` (`Image`, `ImagePullPolicy`, `ContainerPorts`, `ServicePorts`) | one role group of one reconcile | anything derived from **this** CR |
+
+Assigning a per-cluster value to a handler field from inside `BuildResources` fails in two ways, and the quieter one bites first:
+
+- above `MaxConcurrentReconciles: 1` the writes **race**, and one cluster's image or TLS-dependent ports are built into another cluster's workload;
+- at the default concurrency of 1 it **leaks**: a product that conditionally skips one assignment silently inherits the previous CR's value. spark-k8s-operator shipped exactly that — a CR omitting `pullPolicy` took the last CR's — with a serial reconcile loop and no race involved.
+
+`BuildResources` on the base handler is **read-only on the handler**; the per-call fields are read from the build context, which is rebuilt per role group. The one place the framework itself held per-CR state was a handler-registered `SidecarManager`: `SetProductImage` writes the resolved image into its configs, so it is now cloned for the build. `VolumeProviders` already followed this shape and is the precedent the new fields copy.
+
+Handler fields are still the right home for invariant configuration — this is a split, not a deprecation.
+
 ## 4.5 Configuration Generator Module
 
 ### 4.5.1 Design Background

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -306,6 +306,24 @@ Original interfaces relied on type assertions, presenting runtime error risks an
 
 Compile-time type checking removes runtime type assertions from the reconciler and from product extensions alike; new products only need to bind generic types, reducing boilerplate.
 
+### 4.1.4 Handler Lifetime and Per-CR Inputs
+
+**One `RoleGroupHandler` instance serves every cluster.** It is constructed once in `main.go` and the controller reuses it for every CR and every reconcile, so every field on it is process-wide state. That is not obvious from the embedding idiom the SDK encourages, and it has produced real defects downstream.
+
+| where a value lives | lifetime | what belongs there |
+| --- | --- | --- |
+| handler fields (`Image`, `RoleContainerPorts`, …) | process | reconcile-**invariant** settings — a static image, `ProductName`, `ImageDefaults`, ports that do not depend on the CR |
+| `RoleGroupBuildContext` (`Image`, `ImagePullPolicy`, `ContainerPorts`, `ServicePorts`) | one role group of one reconcile | anything derived from **this** CR |
+
+Assigning a per-cluster value to a handler field from inside `BuildResources` fails in two ways, and the quieter one bites first:
+
+- above `MaxConcurrentReconciles: 1` the writes **race**, and one cluster's image or TLS-dependent ports are built into another cluster's workload;
+- at the default concurrency of 1 it **leaks**: a product that conditionally skips one assignment silently inherits the previous CR's value. spark-k8s-operator shipped exactly that — a CR omitting `pullPolicy` took the last CR's — with a serial reconcile loop and no race involved.
+
+`BuildResources` on the base handler is **read-only on the handler**; the per-call fields are read from the build context, which is rebuilt per role group. The one place the framework itself held per-CR state was a handler-registered `SidecarManager`: `SetProductImage` writes the resolved image into its configs, so it is now cloned for the build. `VolumeProviders` already followed this shape and is the precedent the new fields copy.
+
+Handler fields are still the right home for invariant configuration — this is a split, not a deprecation.
+
 ## 4.2 Extension Point Mechanism Module
 
 ### 4.2.1 Design Approach
@@ -483,24 +501,6 @@ Deletion is a **state machine driven across several reconciles**, not a single p
 - **CR First Creation**: Status is empty, no orphaned resources, the reconciled role groups are recorded in Status.
 - **Manual Resource Deletion**: Rely on idempotent deletion (`IsNotFound` short-circuit) to avoid errors, syncing Status in the next reconciliation.
 - **Status Tampering**: Query cluster resources before deletion, and verify the ownerReference, so only resources this cluster actually owns are deleted.
-
-### 4.4.4 Handler Lifetime and Per-CR Inputs
-
-**One `RoleGroupHandler` instance serves every cluster.** It is constructed once in `main.go` and the controller reuses it for every CR and every reconcile, so every field on it is process-wide state. That is not obvious from the embedding idiom the SDK encourages, and it has produced real defects downstream.
-
-| where a value lives | lifetime | what belongs there |
-| --- | --- | --- |
-| handler fields (`Image`, `RoleContainerPorts`, …) | process | reconcile-**invariant** settings — a static image, `ProductName`, `ImageDefaults`, ports that do not depend on the CR |
-| `RoleGroupBuildContext` (`Image`, `ImagePullPolicy`, `ContainerPorts`, `ServicePorts`) | one role group of one reconcile | anything derived from **this** CR |
-
-Assigning a per-cluster value to a handler field from inside `BuildResources` fails in two ways, and the quieter one bites first:
-
-- above `MaxConcurrentReconciles: 1` the writes **race**, and one cluster's image or TLS-dependent ports are built into another cluster's workload;
-- at the default concurrency of 1 it **leaks**: a product that conditionally skips one assignment silently inherits the previous CR's value. spark-k8s-operator shipped exactly that — a CR omitting `pullPolicy` took the last CR's — with a serial reconcile loop and no race involved.
-
-`BuildResources` on the base handler is **read-only on the handler**; the per-call fields are read from the build context, which is rebuilt per role group. The one place the framework itself held per-CR state was a handler-registered `SidecarManager`: `SetProductImage` writes the resolved image into its configs, so it is now cloned for the build. `VolumeProviders` already followed this shape and is the precedent the new fields copy.
-
-Handler fields are still the right home for invariant configuration — this is a split, not a deprecation.
 
 ## 4.5 Configuration Generator Module
 

--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -63,11 +63,22 @@ const managedByValue = "operator-go"
 //	    // Add HDFS-specific customizations
 //	    return resources, nil
 //	}
+//
+// ONE INSTANCE SERVES EVERY CLUSTER. A handler is constructed once in main.go and the controller
+// reuses it for every CR and every reconcile, so every field below is process-wide state. Set them
+// at construction, from values that do not depend on which cluster is being reconciled.
+//
+// Anything that DOES depend on the cluster — an image derived from its spec, ports that move when
+// its TLS toggle flips — goes on RoleGroupBuildContext instead, which is rebuilt per role group per
+// reconcile. Assigning such a value here from inside BuildResources races above
+// MaxConcurrentReconciles 1, and even at 1 it leaks: skip the assignment on one CR and it silently
+// inherits the previous CR's value.
 type BaseRoleGroupHandler[CR common.ClusterInterface] struct {
-	// Image is the default container image for all roles.
+	// Image is the default container image for all roles, and must be reconcile-invariant — see
+	// the note above the type, and RoleGroupBuildContext.Image for the per-cluster channel.
 	Image string
 
-	// ImagePullPolicy is the default image pull policy.
+	// ImagePullPolicy is the default image pull policy. Reconcile-invariant, as above.
 	ImagePullPolicy corev1.PullPolicy
 
 	// ProductName is the kubedoop product name (e.g. "trino"). It supplies two unrelated things:
@@ -109,13 +120,14 @@ type BaseRoleGroupHandler[CR common.ClusterInterface] struct {
 	ImageDefaults v1alpha1.ImageSpec
 
 	// RoleImages maps role names to specific images.
-	// If a role is not found here, the default Image is used.
+	// If a role is not found here, the default Image is used. Reconcile-invariant.
 	RoleImages map[string]string
 
-	// RoleContainerPorts maps role names to container ports.
+	// RoleContainerPorts maps role names to container ports. Reconcile-invariant: ports that
+	// depend on the CR belong on RoleGroupBuildContext.ContainerPorts.
 	RoleContainerPorts map[string][]corev1.ContainerPort
 
-	// RoleServicePorts maps role names to service ports.
+	// RoleServicePorts maps role names to service ports. Reconcile-invariant, as above.
 	RoleServicePorts map[string][]corev1.ServicePort
 
 	// ConfigGenerator is used to generate configuration files.
@@ -307,7 +319,13 @@ func (h *BaseRoleGroupHandler[CR]) BuildResources(
 	// empty image field.
 	if sidecarMgr := buildCtx.SidecarManager; sidecarMgr != nil || h.sidecarManager != nil {
 		if sidecarMgr == nil {
-			sidecarMgr = h.sidecarManager
+			// The handler's manager is process-wide, and SetProductImage below writes THIS
+			// cluster's image into it. Build against a copy, or the next cluster inherits it —
+			// the framework's own instance of the shared-state defect this context's Image field
+			// exists to fix. The reconciler-created manager (the common path) is already
+			// per-role-group, so it is used as-is.
+			sidecarMgr = h.sidecarManager.CloneForBuild()
+			buildCtx.SidecarManager = sidecarMgr
 		}
 		image, pullPolicy, err := h.containerImage(buildCtx, buildCtx.RoleName)
 		if err != nil {
@@ -333,7 +351,7 @@ func (h *BaseRoleGroupHandler[CR]) BuildResources(
 	resources.HeadlessService = headlessSvc
 
 	// Build Service (if ports are defined)
-	svcPorts := h.servicePorts(buildCtx.RoleName, buildCtx.RoleGroupName)
+	svcPorts := h.servicePorts(buildCtx, buildCtx.RoleName)
 	if len(svcPorts) > 0 {
 		resources.Service = h.buildService(buildCtx, labels, svcPorts)
 	}
@@ -475,22 +493,44 @@ func (h *BaseRoleGroupHandler[CR]) containerImage(
 	if image != "" {
 		return image, pullPolicy, nil
 	}
-	if image, ok := h.RoleImages[roleName]; ok {
-		return image, h.ImagePullPolicy, nil
+	// The per-call channel outranks the handler's own configuration: it is the one input that is
+	// allowed to depend on WHICH cluster is being built (see RoleGroupBuildContext.Image).
+	if buildCtx != nil && buildCtx.Image != "" {
+		return buildCtx.Image, h.pullPolicy(buildCtx), nil
 	}
-	return h.Image, h.ImagePullPolicy, nil
+	if image, ok := h.RoleImages[roleName]; ok {
+		return image, h.pullPolicy(buildCtx), nil
+	}
+	return h.Image, h.pullPolicy(buildCtx), nil
 }
 
-// containerPorts returns the container ports for a role group.
-func (h *BaseRoleGroupHandler[CR]) containerPorts(roleName, _ string) []corev1.ContainerPort {
+// pullPolicy resolves the pull policy for a handler-supplied image: the per-call value when the
+// product set one, the handler's otherwise.
+func (h *BaseRoleGroupHandler[CR]) pullPolicy(buildCtx *RoleGroupBuildContext) corev1.PullPolicy {
+	if buildCtx != nil && buildCtx.ImagePullPolicy != "" {
+		return buildCtx.ImagePullPolicy
+	}
+	return h.ImagePullPolicy
+}
+
+// containerPorts returns the container ports for a role group: the per-call value when the product
+// set one (ports that depend on the CR — a TLS toggle moving 8080 to 8443 — belong there), the
+// handler's per-role map otherwise.
+func (h *BaseRoleGroupHandler[CR]) containerPorts(buildCtx *RoleGroupBuildContext, roleName string) []corev1.ContainerPort {
+	if buildCtx != nil && len(buildCtx.ContainerPorts) > 0 {
+		return buildCtx.ContainerPorts
+	}
 	if ports, ok := h.RoleContainerPorts[roleName]; ok {
 		return ports
 	}
 	return nil
 }
 
-// servicePorts returns the service ports for a role group.
-func (h *BaseRoleGroupHandler[CR]) servicePorts(roleName, _ string) []corev1.ServicePort {
+// servicePorts returns the service ports for a role group, with the same precedence.
+func (h *BaseRoleGroupHandler[CR]) servicePorts(buildCtx *RoleGroupBuildContext, roleName string) []corev1.ServicePort {
+	if buildCtx != nil && len(buildCtx.ServicePorts) > 0 {
+		return buildCtx.ServicePorts
+	}
 	if ports, ok := h.RoleServicePorts[roleName]; ok {
 		return ports
 	}
@@ -733,7 +773,7 @@ func (h *BaseRoleGroupHandler[CR]) buildHeadlessService(buildCtx *RoleGroupBuild
 		WithLabels(labels).
 		WithSelector(h.buildSelectorLabels(buildCtx)).
 		WithPublishNotReadyAddresses(h.PublishNotReadyAddresses).
-		WithPorts(h.servicePorts(buildCtx.RoleName, buildCtx.RoleGroupName)).
+		WithPorts(h.servicePorts(buildCtx, buildCtx.RoleName)).
 		Build()
 }
 
@@ -779,7 +819,7 @@ func (h *BaseRoleGroupHandler[CR]) buildStatefulSet(
 		WithReplicas(replicas).
 		WithImage(image, pullPolicy).
 		WithConfig(buildCtx.MergedConfig).
-		WithPorts(h.containerPorts(buildCtx.RoleName, buildCtx.RoleGroupName))
+		WithPorts(h.containerPorts(buildCtx, buildCtx.RoleName))
 
 	// Bind the reconciler-managed ServiceAccount to the pod template when configured, so the
 	// created SA is actually used. Empty leaves ServiceAccountName unset (pods use the namespace
@@ -1045,6 +1085,10 @@ func (h *BaseRoleGroupHandler[CR]) buildRoleLabels(buildCtx *RoleBuildContext) m
 }
 
 // SetRoleImage sets the image for a specific role.
+//
+// Call this at CONSTRUCTION. It writes into the shared handler instance, so calling it
+// from inside BuildResources publishes one cluster's value process-wide — use
+// RoleGroupBuildContext.Image for a value derived from the CR.
 func (h *BaseRoleGroupHandler[CR]) SetRoleImage(roleName, image string) {
 	if h.RoleImages == nil {
 		h.RoleImages = make(map[string]string)
@@ -1053,6 +1097,10 @@ func (h *BaseRoleGroupHandler[CR]) SetRoleImage(roleName, image string) {
 }
 
 // SetRoleContainerPorts sets the container ports for a specific role.
+//
+// Call this at CONSTRUCTION. It writes into the shared handler instance, so calling it
+// from inside BuildResources publishes one cluster's value process-wide — use
+// RoleGroupBuildContext.ContainerPorts for a value derived from the CR.
 func (h *BaseRoleGroupHandler[CR]) SetRoleContainerPorts(roleName string, ports []corev1.ContainerPort) {
 	if h.RoleContainerPorts == nil {
 		h.RoleContainerPorts = make(map[string][]corev1.ContainerPort)
@@ -1061,6 +1109,10 @@ func (h *BaseRoleGroupHandler[CR]) SetRoleContainerPorts(roleName string, ports 
 }
 
 // SetRoleServicePorts sets the service ports for a specific role.
+//
+// Call this at CONSTRUCTION. It writes into the shared handler instance, so calling it
+// from inside BuildResources publishes one cluster's value process-wide — use
+// RoleGroupBuildContext.ServicePorts for a value derived from the CR.
 func (h *BaseRoleGroupHandler[CR]) SetRoleServicePorts(roleName string, ports []corev1.ServicePort) {
 	if h.RoleServicePorts == nil {
 		h.RoleServicePorts = make(map[string][]corev1.ServicePort)

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -19,7 +19,9 @@ package reconciler_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
+	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -2818,3 +2820,155 @@ var _ = Describe("fsGroup ownership recursion", func() {
 		Expect(*podSC.RunAsNonRoot).To(BeTrue())
 	})
 })
+
+var _ = Describe("Per-CR inputs on the build context", func() {
+	// The handler is constructed once in main.go and shared across every CR and every reconcile.
+	// These specs pin the channel that lets a product supply per-cluster values without writing
+	// them into that shared instance.
+	var mockCR *testutil.MockCluster
+
+	BeforeEach(func() { mockCR = testutil.NewMockCluster("test-cluster", "default") })
+
+	buildCtxWith := func(mutate func(*reconciler.RoleGroupBuildContext)) *reconciler.RoleGroupBuildContext {
+		buildCtx := &reconciler.RoleGroupBuildContext{
+			ClusterName:      "test-cluster",
+			ClusterNamespace: "default",
+			RoleName:         "server",
+			RoleSpec:         &v1alpha1.RoleSpec{},
+			RoleGroupName:    "default",
+			RoleGroupSpec:    v1alpha1.RoleGroupSpec{Replicas: ptr.To(int32(1))},
+			MergedConfig:     &config.MergedConfig{},
+			ResourceName:     "test-cluster-server-default",
+		}
+		if mutate != nil {
+			mutate(buildCtx)
+		}
+		return buildCtx
+	}
+
+	It("prefers the per-call image and ports over the handler's own", func() {
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("handler-image:1", testScheme)
+		handler.SetRoleImage("server", "role-image:1")
+		handler.SetRoleContainerPorts("server", []corev1.ContainerPort{{Name: "http", ContainerPort: 8080}})
+		handler.SetRoleServicePorts("server", []corev1.ServicePort{{Name: "http", Port: 8080}})
+
+		resources, err := handler.BuildResources(context.Background(), k8sClient, mockCR,
+			buildCtxWith(func(b *reconciler.RoleGroupBuildContext) {
+				b.Image = "per-call:2"
+				b.ImagePullPolicy = corev1.PullAlways
+				b.ContainerPorts = []corev1.ContainerPort{{Name: "https", ContainerPort: 8443}}
+				b.ServicePorts = []corev1.ServicePort{{Name: "https", Port: 8443}}
+			}))
+		Expect(err).NotTo(HaveOccurred())
+
+		container := resources.StatefulSet.Spec.Template.Spec.Containers[0]
+		Expect(container.Image).To(Equal("per-call:2"))
+		Expect(container.ImagePullPolicy).To(Equal(corev1.PullAlways))
+		Expect(container.Ports).To(HaveLen(1))
+		Expect(container.Ports[0].ContainerPort).To(Equal(int32(8443)))
+		Expect(resources.Service.Spec.Ports[0].Port).To(Equal(int32(8443)))
+	})
+
+	It("falls back to the handler when the build states nothing", func() {
+		// Reconcile-INVARIANT settings still belong on the handler; this channel is only for the
+		// values that depend on which cluster is being built.
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("handler-image:1", testScheme)
+		handler.SetRoleContainerPorts("server", []corev1.ContainerPort{{Name: "http", ContainerPort: 8080}})
+
+		resources, err := handler.BuildResources(context.Background(), k8sClient, mockCR, buildCtxWith(nil))
+		Expect(err).NotTo(HaveOccurred())
+
+		container := resources.StatefulSet.Spec.Template.Spec.Containers[0]
+		Expect(container.Image).To(Equal("handler-image:1"))
+		Expect(container.Ports[0].ContainerPort).To(Equal(int32(8080)))
+	})
+
+	It("does not carry one cluster's values into the next through the shared handler", func() {
+		// The quiet half of the hazard, and the one that bites at the default concurrency of 1:
+		// spark-k8s-operator shipped a CR inheriting the previous CR's pullPolicy, with a serial
+		// reconcile loop and no race involved.
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("handler-image:1", testScheme)
+
+		first, err := handler.BuildResources(context.Background(), k8sClient, mockCR,
+			buildCtxWith(func(b *reconciler.RoleGroupBuildContext) {
+				b.Image = "cluster-a:1"
+				b.ImagePullPolicy = corev1.PullAlways
+				b.ContainerPorts = []corev1.ContainerPort{{Name: "https", ContainerPort: 8443}}
+			}))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(first.StatefulSet.Spec.Template.Spec.Containers[0].Image).To(Equal("cluster-a:1"))
+
+		// The second cluster states nothing — under the old idiom it would inherit cluster A's.
+		second, err := handler.BuildResources(context.Background(), k8sClient,
+			testutil.NewMockCluster("other-cluster", "default"), buildCtxWith(nil))
+		Expect(err).NotTo(HaveOccurred())
+
+		container := second.StatefulSet.Spec.Template.Spec.Containers[0]
+		Expect(container.Image).To(Equal("handler-image:1"), "cluster A's image must not leak")
+		Expect(container.ImagePullPolicy).NotTo(Equal(corev1.PullAlways))
+		Expect(container.Ports).To(BeEmpty(), "cluster A's ports must not leak")
+	})
+
+	It("builds concurrently on one handler without crossing values", func() {
+		// The loud half: this is what raising MaxConcurrentReconciles above 1 does. `make test`
+		// runs with -race in CI, so a handler-side write would be reported as a data race here
+		// rather than as a wrong value.
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("handler-image:1", testScheme)
+
+		const workers = 8
+		images := make([]string, workers)
+		var wg sync.WaitGroup
+		for i := range workers {
+			wg.Add(1)
+			go func() {
+				defer GinkgoRecover()
+				defer wg.Done()
+				want := fmt.Sprintf("cluster-%d:1", i)
+				resources, err := handler.BuildResources(context.Background(), k8sClient,
+					testutil.NewMockCluster(fmt.Sprintf("cluster-%d", i), "default"),
+					buildCtxWith(func(b *reconciler.RoleGroupBuildContext) {
+						b.ClusterName = fmt.Sprintf("cluster-%d", i)
+						b.ResourceName = fmt.Sprintf("cluster-%d-server-default", i)
+						b.Image = want
+					}))
+				Expect(err).NotTo(HaveOccurred())
+				images[i] = resources.StatefulSet.Spec.Template.Spec.Containers[0].Image
+			}()
+		}
+		wg.Wait()
+
+		for i := range workers {
+			Expect(images[i]).To(Equal(fmt.Sprintf("cluster-%d:1", i)))
+		}
+	})
+
+	It("does not write one cluster's image into a handler-wide sidecar manager", func() {
+		// The framework's own instance of the same defect: SetProductImage writes into the
+		// manager's configs, and a manager registered on the handler outlives the build.
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("handler-image:1", testScheme)
+		mgr := sidecar.NewSidecarManager()
+		mgr.Register(&recordingSidecarProvider{name: "probe"}, &sidecar.SidecarConfig{Enabled: true})
+		handler.WithSidecarManager(mgr)
+
+		_, err := handler.BuildResources(context.Background(), k8sClient, mockCR,
+			buildCtxWith(func(b *reconciler.RoleGroupBuildContext) { b.Image = "cluster-a:1" }))
+		Expect(err).NotTo(HaveOccurred())
+
+		cfg, ok := mgr.GetConfig("probe")
+		Expect(ok).To(BeTrue())
+		Expect(cfg.Image).To(BeEmpty(),
+			"the handler's manager is process-wide; this cluster's image must not be written into it")
+	})
+})
+
+// recordingSidecarProvider is a minimal provider: it only has to be registered so SetProductImage
+// has a config to write into.
+type recordingSidecarProvider struct{ name string }
+
+func (p *recordingSidecarProvider) Name() string { return p.name }
+func (p *recordingSidecarProvider) Inject(podSpec *corev1.PodSpec, cfg *sidecar.SidecarConfig) error {
+	podSpec.InitContainers = append(podSpec.InitContainers,
+		corev1.Container{Name: p.name, Image: cfg.Image})
+	return nil
+}
+func (p *recordingSidecarProvider) Validate(context.Context, client.Client, string) error { return nil }

--- a/pkg/reconciler/role_group_handler.go
+++ b/pkg/reconciler/role_group_handler.go
@@ -192,6 +192,40 @@ type RoleGroupBuildContext struct {
 	// calling BaseRoleGroupHandler.BuildResources. Empty means no extra volumes (backward compatible).
 	VolumeProviders []VolumeProvider
 
+	// Image, ImagePullPolicy, ContainerPorts and ServicePorts are the per-CR inputs a product
+	// derives from the cluster it is building for. Set them here, NOT on the handler.
+	//
+	//	func (h *MyHandler) BuildResources(ctx context.Context, c client.Client, cr *MyCluster,
+	//	    buildCtx *reconciler.RoleGroupBuildContext) (*reconciler.RoleGroupResources, error) {
+	//	    buildCtx.ContainerPorts = h.portsFor(cr, buildCtx.RoleName) // depends on cr.Spec.Tls
+	//	    return h.BaseRoleGroupHandler.BuildResources(ctx, c, cr, buildCtx)
+	//	}
+	//
+	// The handler instance is constructed once in main.go and shared by the controller across
+	// every CR and every reconcile, so the older idiom — assigning h.Image or calling
+	// h.SetRoleContainerPorts from inside BuildResources — writes per-cluster values into
+	// process-wide state. That has two failure modes, and the quieter one bites first:
+	//
+	//   - with MaxConcurrentReconciles above 1 the writes RACE, and one cluster's image or
+	//     TLS-dependent ports are built into another cluster's workload;
+	//   - even at the default concurrency of 1, a product that conditionally SKIPS one of those
+	//     assignments silently inherits the previous CR's value. spark-k8s-operator shipped
+	//     exactly that (a CR omitting pullPolicy took the last CR's), with a serial reconcile
+	//     loop and no race involved.
+	//
+	// This context is rebuilt for every role group of every reconcile, so nothing set here can
+	// reach another cluster. Unset fields fall back to the handler's own configuration, which is
+	// where reconcile-INVARIANT settings belong (a static image, ProductName, ImageDefaults, the
+	// ports of a product whose ports do not depend on the CR).
+	//
+	// Precedence, highest first: this context > the handler's per-role maps > the handler's
+	// defaults. For the image specifically, the CR's own spec.image still outranks all three —
+	// see BaseRoleGroupHandler.ImageDefaults.
+	Image           string
+	ImagePullPolicy corev1.PullPolicy
+	ContainerPorts  []corev1.ContainerPort
+	ServicePorts    []corev1.ServicePort
+
 	// VectorAggregatorAddress is the resolved Vector aggregator discovery address, populated by
 	// GenericReconciler when the Vector agent is enabled and the CR implements
 	// VectorAggregatorProvider (the reconciler reads its ConfigMap name and resolves the address

--- a/pkg/sidecar/manager.go
+++ b/pkg/sidecar/manager.go
@@ -245,6 +245,40 @@ func (m *SidecarManager) Count() int {
 	return len(m.providers)
 }
 
+// CloneForBuild returns a copy safe to mutate for one build.
+//
+// SetProductImage writes the resolved image into every enabled config, so a manager that outlives a
+// single build — one a product registered on its handler with
+// BaseRoleGroupHandler.WithSidecarManager, which is process-wide and shared across every CR — would
+// otherwise carry one cluster's image into the next cluster's pods, and race outright above
+// MaxConcurrentReconciles 1. That is the same defect as the handler's per-CR fields
+// (RoleGroupBuildContext.Image), on the framework's own side of the line.
+//
+// The configs map and its entries are copied because they are what gets written. Providers and
+// phases are shared: they are read-only during a build, and a provider is a product-supplied
+// implementation that must not be duplicated. Client and namespace are plain values.
+func (m *SidecarManager) CloneForBuild() *SidecarManager {
+	if m == nil {
+		return nil
+	}
+	clone := &SidecarManager{
+		providers: m.providers,
+		phases:    m.phases,
+		client:    m.client,
+		namespace: m.namespace,
+		configs:   make(map[string]*SidecarConfig, len(m.configs)),
+	}
+	for name, config := range m.configs {
+		if config == nil {
+			clone.configs[name] = nil
+			continue
+		}
+		copied := *config
+		clone.configs[name] = &copied
+	}
+	return clone
+}
+
 // SetProductImage sets the product image on all enabled sidecar configs that
 // don't already have an image or pull policy set. This is used to propagate
 // the product container image to built-in sidecars (e.g. JMX Exporter) that


### PR DESCRIPTION
Closes #525. First of the remaining downstream-feedback issues, and the only one that is a **correctness** problem rather than developer experience.

## The hazard

One `RoleGroupHandler` instance is constructed in `main.go` and the controller reuses it for **every CR and every reconcile**, so every field on it is process-wide state. The embedding idiom the SDK encourages hides that, and products accordingly assign per-cluster values from inside `BuildResources`:

```go
h.Image = image                       // derived from THIS CR
h.SetRoleContainerPorts(role, ports)  // derived from THIS CR's TLS config
```

Two failure modes, and **the quieter one bites first**:

- above `MaxConcurrentReconciles: 1` the writes **race**, and one cluster's image or TLS-dependent ports are built into another cluster's workload;
- at the default concurrency of **1** it still **leaks**: a product that conditionally skips one assignment silently inherits the previous CR's value. spark-k8s-operator shipped exactly that — a CR omitting `pullPolicy` took the last CR's — with a serial reconcile loop and no race involved.

## The change

`RoleGroupBuildContext` gains `Image`, `ImagePullPolicy`, `ContainerPorts`, `ServicePorts`. They outrank the handler's values, and the context is rebuilt per role group per reconcile:

```go
func (h *MyHandler) BuildResources(ctx context.Context, c client.Client, cr *MyCluster,
    buildCtx *reconciler.RoleGroupBuildContext) (*reconciler.RoleGroupResources, error) {
    buildCtx.ContainerPorts = h.portsFor(cr, buildCtx.RoleName)
    return h.BaseRoleGroupHandler.BuildResources(ctx, c, cr, buildCtx)
}
```

`VolumeProviders` already had this shape and is the precedent these copy, down to the "write into `buildCtx`, then delegate" call pattern — so this is the existing idiom extended, not a new one.

## The framework held one too

Found while fixing the product-side version: `SidecarManager.SetProductImage` writes the resolved image into the manager's **configs**, so a manager registered through `WithSidecarManager` — process-wide — carried one cluster's image into the next, and raced outright.

New `SidecarManager.CloneForBuild()`: the configs map and its entries are copied, because they are what gets written; providers and phases are shared, being read-only during a build and product-supplied. The reconciler-created manager is already per-role-group and is used as-is. The clone is written back onto the build context so injection and image propagation cannot target different managers — which the comment at that site already required.

## Compatibility

Additive. An unset context field falls back to the handler exactly as before, so an unmigrated product renders **byte-identical** output. Handler fields stay correct for reconcile-**invariant** configuration — this is a split, not a deprecation — and the field docs plus the `SetRole*` setters now say which is which.

## Verification

- Five specs: precedence, fallback, no cross-CR leak, **eight clusters built concurrently through one handler**, and the sidecar-manager clone.
- **The concurrency spec detects the defect, not just the fix.** `make test` runs `-race` in CI; temporarily reintroducing `handler.Image = want` inside that spec's goroutines produces data races. Verified.
- Three mutations killed: per-call image precedence removed, per-call ports precedence removed, `CloneForBuild` removed.
- `make lint` (0 issues), `make test` (18 packages), **the whole suite under `-race` clean**, `make verify-generate`, and the examples module's `make test` all pass.

## Docs

`docs/architecture.md` gains **§4.4.4 Handler Lifetime and Per-CR Inputs** — a table of what belongs where, both failure modes, and the statement that `BuildResources` is read-only on the handler. That also answers the first of the three gaps #579 names.

## Note

`examples/trino-operator` does **not** exercise the new fields, and I left it that way: since #581 it sets everything at construction, and trino has no CR-dependent image or ports. Inventing one to demo the channel would be contrived. The specs cover it instead.