### PR TITLE
feat(reconciler): let a handler declare intent before Build, instead of patching after

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -337,6 +337,30 @@ func (h *MyHandler) BuildResources(ctx context.Context, c client.Client, cr *MyC
 }
 ```
 
+`ListenerClass` and `MainContainerCustomizer` ride the same channel, and replace the other
+post-build habit: **the framework builds a complete object and the product reaches in to edit it.**
+
+```go
+buildCtx.ListenerClass = listener.ListenerClassExternalUnstable   // Service type set at Build()
+buildCtx.MainContainerCustomizer = func(c *corev1.Container) error {
+    c.Command = []string{"/bin/zkServer.sh"}                      // no Containers[0] lookup
+    return nil
+}
+```
+
+The customizer runs on the assembled primary container **before** `podOverrides` are strategic-merged,
+which is why it cannot be a post-build patch: a product editing the returned StatefulSet lands
+*after* the merge and silently beats the user. It is handed the container by identity, so nobody
+indexes `Containers[0]` — an assumption the framework never made, and which a sidecar provider
+inserting a container earlier quietly breaks. Returning an error fails the role group with a
+`*ValidationError`; **changing the image is rejected the same way**, since the image is resolved once
+and propagated to the sidecars before the StatefulSet is built (`buildCtx.Image` is that channel).
+
+`listener.ServiceTypeFor` is the shared class→type mapping restored from v0.12.6:
+`cluster-internal` → ClusterIP, `external-unstable` → **NodePort**, `external-stable` →
+LoadBalancer, anything else → ClusterIP. It lives in `pkg/listener` rather than `pkg/builder`
+because `pkg/listener` already imports `pkg/builder`.
+
 **One handler instance serves every cluster** — it is built once in `main.go` — so the older idiom
 of assigning `h.Image` or calling `h.SetRoleContainerPorts` inside `BuildResources` writes
 per-cluster values into process-wide state. Above `MaxConcurrentReconciles: 1` those writes race

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,35 @@ changes are listed below.**
     progress markers. A product that needs e.g. cloud LoadBalancer annotations on the client Service
     has no supported way to set them; tracked in #553.
 
+### features (declare intent before Build)
+
+- **`RoleGroupBuildContext.MainContainerCustomizer`** (#577) hands a product the assembled primary
+  container just before `podOverrides` are strategic-merged. The framework owns the container's
+  name, image, ports, security context, mounts and probes and nothing else, so every migrated
+  product edited the StatefulSet the framework had just returned — zookeeper-operator locating the
+  container as `Containers[0]`, an assumption the framework never made and which a sidecar provider
+  inserting a container earlier silently invalidates.
+- **The timing is the point, not the hook.** Running before the strategic merge is what keeps a
+  user's `podOverrides` outranking the product; a post-build edit inverts that precedence silently.
+  A customizer that returns an error fails the role group with a `*ValidationError`, and so does one
+  that changes the **image** — the image is resolved once and propagated to the sidecars before the
+  StatefulSet is built (the Vector agent ships inside the product image), so
+  `RoleGroupBuildContext.Image` is that channel.
+- **`RoleGroupBuildContext.ListenerClass` and `listener.ServiceTypeFor`** (#576) restore the
+  class→Service-type mapping v0.12.6 shipped as `builder.ListenerClass2ServiceType`, which v0.13
+  dropped while keeping the class constants: `cluster-internal` → ClusterIP, `external-unstable` →
+  **NodePort**, `external-stable` → LoadBalancer, anything unrecognised → ClusterIP (the narrowest
+  exposure, never an accidental public address). The client Service now gets its type at `Build()`
+  instead of being patched afterwards.
+- It lives in `pkg/listener`, not `pkg/builder` where the issue proposed it: `pkg/listener` already
+  imports `pkg/builder`, so that direction does not compile. It pairs with the Service builder's
+  existing `WithServiceType` rather than adding a second entry point.
+- **Doc correction with teeth**: `ListenerClassExternalUnstable`'s comment said "creates LoadBalancer
+  with dynamic IPs". It is a NodePort — the LoadBalancer is the *stable* class — and that wording is
+  the documented reason two migrated operators disagreed about what `external-stable` meant.
+- Both fields are additive: unset, the Service is a ClusterIP and no customizer runs, so an
+  unmigrated product renders byte-identical output.
+
 ### features (generate-once secrets)
 
 - **`reconciler.EnsureGeneratedSecret`** creates a Secret whose values are generated once and then

--- a/docs/DOC_CHANGELOG.md
+++ b/docs/DOC_CHANGELOG.md
@@ -4,6 +4,27 @@ This document tracks all changes made to the SDK documentation.
 
 ---
 
+## [2026-08-03c] (declaring intent before Build, instead of patching after)
+
+### Core Architecture (`architecture.md`)
+
+- §4.1.4 gains the second half of the build-context story: `MainContainerCustomizer` and
+  `ListenerClass` replace the post-build patch, with a table of what each one replaces and why the
+  *timing* is the point rather than the hook's existence.
+
+### Framework Documentation (`AGENTS.md`)
+
+- §4 documents both fields, the pre-`podOverrides` ordering, the rejection of an image change, and
+  where `listener.ServiceTypeFor` lives and why.
+
+### API doc correction (`pkg/listener`)
+
+- `ListenerClassExternalUnstable`'s comment said "creates LoadBalancer with dynamic IPs". It is a
+  **NodePort** — the LoadBalancer is the *stable* class. The wrong wording is the documented reason
+  two downstream operators reached opposite conclusions about `external-stable`.
+
+---
+
 ## [2026-08-03b] (an object whose content must not converge)
 
 ### Core Architecture (`architecture.md`)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -324,6 +324,15 @@ Assigning a per-cluster value to a handler field from inside `BuildResources` fa
 
 Handler fields are still the right home for invariant configuration — this is a split, not a deprecation.
 
+**The same context carries the product's declared intent, replacing the post-build patch.** `BuildResources` returns a finished object, and for anything the framework does not model the only extension point used to be mutating it afterwards. That cost twice: products re-derived what the handler already knew (zookeeper-operator located the primary container as `Containers[0]`, which a sidecar provider inserting a container earlier silently invalidates), and the edit landed *after* the framework's own ordering.
+
+| field | replaces | why declaring it first matters |
+| --- | --- | --- |
+| `MainContainerCustomizer` | patching `Containers[0]` of the returned StatefulSet | it runs before `podOverrides` are strategic-merged, so the **user's** overrides still win; a post-build edit inverts that silently |
+| `ListenerClass` | patching `Service.Spec.Type` after the fact | one shared `listener.ServiceTypeFor` mapping instead of a three-way switch re-derived per product |
+
+Both fail loudly: a customizer that returns an error, or that changes the image (resolved once and already propagated to the sidecars), fails the role group with a `*ValidationError` rather than shipping a workload missing what the product meant to set.
+
 ## 4.2 Extension Point Mechanism Module
 
 ### 4.2.1 Design Approach

--- a/pkg/builder/statefulset_builder.go
+++ b/pkg/builder/statefulset_builder.go
@@ -607,6 +607,12 @@ func (b *StatefulSetBuilder) DisableStartupProbe() *StatefulSetBuilder {
 // rewrites the template when pod overrides are applied), so sharing would let a pod-level change
 // contaminate ObjectMeta, the immutable .spec.selector, or a second Build() from the same builder.
 func (b *StatefulSetBuilder) Build() *appsv1.StatefulSet {
+	// Reset here, not next to the podOverrides reset below: customizedContainer runs inside
+	// buildPodSpec, which the struct literal calls before we ever reach that point. Same reason as
+	// there — the list describes THIS build, so a reused builder must not report the previous
+	// build's violations, nor report this one's twice.
+	b.mainContainerViolations = nil
+
 	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        b.Name,

--- a/pkg/builder/statefulset_builder.go
+++ b/pkg/builder/statefulset_builder.go
@@ -105,6 +105,11 @@ type StatefulSetBuilder struct {
 	// PodOverrideViolations() by the caller, which fails the role group.
 	podOverrideViolations []error
 
+	// mainContainerCustomizer is the product's hook into the assembled primary container; see
+	// WithMainContainerCustomizer. mainContainerViolations records what it got wrong.
+	mainContainerCustomizer func(*corev1.Container) error
+	mainContainerViolations []error
+
 	// Graceful shutdown timeout
 	TerminationGracePeriodSeconds *int64
 
@@ -358,6 +363,43 @@ func (b *StatefulSetBuilder) WithEnableServiceLinks(enable bool) *StatefulSetBui
 // most recent build — so call it afterwards. Empty means the merge preserved everything the
 // framework mounted.
 //
+// WithMainContainerCustomizer registers a function that gets the assembled primary container just
+// before pod overrides are applied.
+//
+// It exists because the framework owns the primary container's name, image, ports, security
+// context, volume mounts and probes, but nothing else — so every product reached into the
+// StatefulSet the framework had just returned and edited it in place, re-deriving the container it
+// was handed. zookeeper-operator located it as `Containers[0]`, an assumption the framework has
+// never promised: the moment a sidecar provider inserts a container earlier, that silently
+// configures the wrong one.
+//
+// TIMING IS THE POINT, and it is why this cannot be a post-Build patch. The customizer runs AFTER
+// the framework has assembled the container and BEFORE podOverrides are strategic-merged, so a
+// user's podOverrides still outrank whatever the product set here — a post-Build edit would invert
+// that precedence silently.
+//
+// The image is off limits: it is resolved once and propagated to the sidecars before the
+// StatefulSet is built (the Vector agent ships inside the product image), so changing it here would
+// leave them on a different one. Build() records that as a violation rather than accepting it; set
+// RoleGroupBuildContext.Image instead.
+func (b *StatefulSetBuilder) WithMainContainerCustomizer(fn func(*corev1.Container) error) *StatefulSetBuilder {
+	b.mainContainerCustomizer = fn
+	return b
+}
+
+// MainContainerViolations returns the errors the main container customizer produced, if any.
+//
+// Build() cannot return an error, so — exactly as with PodOverrideViolations — the failure is
+// recorded and the caller surfaces it. BaseRoleGroupHandler turns these into a *ValidationError
+// that fails the role group, because a customizer that failed silently would ship a workload
+// missing the command, args or probes the product meant to set.
+func (b *StatefulSetBuilder) MainContainerViolations() []error {
+	if len(b.mainContainerViolations) == 0 {
+		return nil
+	}
+	return append([]error(nil), b.mainContainerViolations...)
+}
+
 // The slice is copied out, like every other value Build() hands back: the builder must not share
 // mutable state with its callers.
 func (b *StatefulSetBuilder) PodOverrideViolations() []error {
@@ -631,7 +673,7 @@ func (b *StatefulSetBuilder) buildPodSpec() corev1.PodSpec {
 		Volumes:                       cloneSlice(b.Volumes),
 		InitContainers:                cloneSlice(b.InitContainers),
 		Containers: []corev1.Container{
-			b.buildContainer(),
+			b.customizedContainer(),
 		},
 	}
 
@@ -642,6 +684,31 @@ func (b *StatefulSetBuilder) buildPodSpec() corev1.PodSpec {
 	}
 
 	return spec
+}
+
+// customizedContainer assembles the primary container and hands it to the registered customizer.
+// Any error, and any attempt to change the image, is recorded for the caller to surface.
+func (b *StatefulSetBuilder) customizedContainer() corev1.Container {
+	container := b.buildContainer()
+	if b.mainContainerCustomizer == nil {
+		return container
+	}
+
+	image := container.Image
+	if err := b.mainContainerCustomizer(&container); err != nil {
+		b.mainContainerViolations = append(b.mainContainerViolations,
+			fmt.Errorf("main container customizer for %q: %w", container.Name, err))
+		return container
+	}
+	if container.Image != image {
+		b.mainContainerViolations = append(b.mainContainerViolations, fmt.Errorf(
+			"main container customizer changed the image of %q from %q to %q: the image is resolved "+
+				"once and propagated to the sidecars before the StatefulSet is built, so changing it "+
+				"here would leave them on the old one — set RoleGroupBuildContext.Image instead",
+			container.Name, image, container.Image))
+		container.Image = image
+	}
+	return container
 }
 
 // buildContainer builds the main container.

--- a/pkg/builder/statefulset_builder_test.go
+++ b/pkg/builder/statefulset_builder_test.go
@@ -18,6 +18,7 @@ package builder_test
 
 import (
 	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"

--- a/pkg/builder/statefulset_builder_test.go
+++ b/pkg/builder/statefulset_builder_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package builder_test
 
 import (
+	"fmt"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
@@ -1795,5 +1796,29 @@ var _ = Describe("storageClass distinguishes unset from empty", func() {
 	It("writes the named class", func() {
 		Expect(build(ptr.To("fast-ssd")).Spec.VolumeClaimTemplates[0].Spec.StorageClassName).
 			To(HaveValue(Equal("fast-ssd")))
+	})
+})
+
+var _ = Describe("Main container customizer violations", func() {
+	It("reports only the current build's violations when a builder is reused", func() {
+		// The list describes THIS build. Accumulating would report a stale violation for a builder
+		// whose customizer has since been fixed, and report a surviving one twice — the same reason
+		// podOverrideViolations is reset, and the reset has to happen earlier here because
+		// customizedContainer runs inside buildPodSpec.
+		b := builder.NewStatefulSetBuilder("sts", "default").
+			WithImage("img:1", corev1.PullIfNotPresent).
+			WithMainContainerCustomizer(func(*corev1.Container) error {
+				return fmt.Errorf("boom")
+			})
+
+		b.Build()
+		Expect(b.MainContainerViolations()).To(HaveLen(1))
+
+		b.Build()
+		Expect(b.MainContainerViolations()).To(HaveLen(1), "the second build must not double-count")
+
+		b.WithMainContainerCustomizer(func(*corev1.Container) error { return nil })
+		b.Build()
+		Expect(b.MainContainerViolations()).To(BeEmpty(), "a fixed customizer must clear the list")
 	})
 })

--- a/pkg/listener/service_type.go
+++ b/pkg/listener/service_type.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package listener
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// ServiceTypeFor maps a listener class to the Service type that realises it.
+//
+//	cluster-internal   -> ClusterIP      (reachable inside the cluster only)
+//	external-unstable  -> NodePort       (outside, at an address tied to the node the pod is on)
+//	external-stable    -> LoadBalancer   (outside, at an address that survives rescheduling)
+//
+// An unrecognised or empty class maps to ClusterIP: the exposure a user did not ask for should be
+// the narrowest one, not an accidental public address.
+//
+// This restores the mapping v0.12.6 shipped as builder.ListenerClass2ServiceType, which v0.13
+// dropped while keeping the class constants. The concept survived and the code that applied it did
+// not, so every product exposing a UI re-derived the same three-way switch AFTER the framework had
+// built the Service — and the two operators that had already migrated disagreed about
+// external-stable. A shared mapping is exactly what prevents that.
+//
+// It lives here rather than in pkg/builder, where the issue proposed it: pkg/listener already
+// imports pkg/builder, so the reverse direction does not compile. Pair it with the Service
+// builder's existing WithServiceType rather than adding a second entry point:
+//
+//	builder.NewServiceBuilder(name, ns).
+//	    WithServiceType(builder.ServiceType(listener.ServiceTypeFor(class)))
+//
+// The conversion is there because pkg/builder declares its own ServiceType enum parallel to
+// corev1's. This returns the Kubernetes type, which is the one a product ends up comparing against
+// on a live Service.
+func ServiceTypeFor(class ListenerClass) corev1.ServiceType {
+	switch class {
+	case ListenerClassExternalUnstable:
+		return corev1.ServiceTypeNodePort
+	case ListenerClassExternalStable:
+		return corev1.ServiceTypeLoadBalancer
+	case ListenerClassClusterInternal:
+		return corev1.ServiceTypeClusterIP
+	default:
+		return corev1.ServiceTypeClusterIP
+	}
+}

--- a/pkg/listener/service_type_test.go
+++ b/pkg/listener/service_type_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package listener_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/zncdatadev/operator-go/pkg/listener"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var _ = Describe("ServiceTypeFor", func() {
+	It("maps each class to the Service type that realises it", func() {
+		// Restored from v0.12.6's builder.ListenerClass2ServiceType. "unstable" is NodePort — the
+		// address is tied to whichever node the pod lands on and changes when it is rescheduled;
+		// the LoadBalancer is the STABLE class. The constant's doc comment said the opposite until
+		// this change, which is why two downstream operators drew opposite conclusions.
+		Expect(listener.ServiceTypeFor(listener.ListenerClassClusterInternal)).
+			To(Equal(corev1.ServiceTypeClusterIP))
+		Expect(listener.ServiceTypeFor(listener.ListenerClassExternalUnstable)).
+			To(Equal(corev1.ServiceTypeNodePort))
+		Expect(listener.ServiceTypeFor(listener.ListenerClassExternalStable)).
+			To(Equal(corev1.ServiceTypeLoadBalancer))
+	})
+
+	It("falls back to the narrowest exposure for a class it does not know", func() {
+		// An unrecognised value must not become an accidental public address.
+		Expect(listener.ServiceTypeFor("")).To(Equal(corev1.ServiceTypeClusterIP))
+		Expect(listener.ServiceTypeFor(listener.ListenerClass("something-new"))).
+			To(Equal(corev1.ServiceTypeClusterIP))
+	})
+})

--- a/pkg/listener/volume_builder.go
+++ b/pkg/listener/volume_builder.go
@@ -25,11 +25,20 @@ import (
 type ListenerClass string
 
 const (
-	// ListenerClassClusterInternal creates ClusterIP Service.
+	// ListenerClassClusterInternal exposes the workload inside the cluster only: a ClusterIP
+	// Service.
 	ListenerClassClusterInternal ListenerClass = "cluster-internal"
-	// ListenerClassExternalStable creates LoadBalancer with stable IPs.
+	// ListenerClassExternalStable exposes the workload at an address that does not change as pods
+	// move: a LoadBalancer Service.
 	ListenerClassExternalStable ListenerClass = "external-stable"
-	// ListenerClassExternalUnstable creates LoadBalancer with dynamic IPs.
+	// ListenerClassExternalUnstable exposes the workload outside the cluster at an address tied to
+	// whichever node the pod lands on: a NodePort Service. "Unstable" is precisely that — the
+	// address changes when the pod is rescheduled.
+	//
+	// This comment previously said "LoadBalancer with dynamic IPs", which is what the name is NOT:
+	// a LoadBalancer is the STABLE class. builder.ListenerClassServiceType is the executable form
+	// of the mapping, and two downstream operators had already drawn opposite conclusions from the
+	// old wording.
 	ListenerClassExternalUnstable ListenerClass = "external-unstable"
 )
 

--- a/pkg/listener/volume_builder.go
+++ b/pkg/listener/volume_builder.go
@@ -36,7 +36,7 @@ const (
 	// address changes when the pod is rescheduled.
 	//
 	// This comment previously said "LoadBalancer with dynamic IPs", which is what the name is NOT:
-	// a LoadBalancer is the STABLE class. builder.ListenerClassServiceType is the executable form
+	// a LoadBalancer is the STABLE class. ServiceTypeFor is the executable form
 	// of the mapping, and two downstream operators had already drawn opposite conclusions from the
 	// old wording.
 	ListenerClassExternalUnstable ListenerClass = "external-unstable"

--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -29,6 +29,7 @@ import (
 	"github.com/zncdatadev/operator-go/pkg/common"
 	"github.com/zncdatadev/operator-go/pkg/config"
 	"github.com/zncdatadev/operator-go/pkg/constant"
+	"github.com/zncdatadev/operator-go/pkg/listener"
 	"github.com/zncdatadev/operator-go/pkg/productlogging"
 	"github.com/zncdatadev/operator-go/pkg/security"
 	"github.com/zncdatadev/operator-go/pkg/sidecar"
@@ -779,11 +780,67 @@ func (h *BaseRoleGroupHandler[CR]) buildHeadlessService(buildCtx *RoleGroupBuild
 
 // buildService creates the client-facing service.
 func (h *BaseRoleGroupHandler[CR]) buildService(buildCtx *RoleGroupBuildContext, labels map[string]string, ports []corev1.ServicePort) *corev1.Service {
-	return builder.NewServiceBuilder(buildCtx.ResourceName, buildCtx.ClusterNamespace).
+	svcBuilder := builder.NewServiceBuilder(buildCtx.ResourceName, buildCtx.ClusterNamespace).
 		WithLabels(labels).
 		WithSelector(h.buildSelectorLabels(buildCtx)).
-		WithPorts(ports).
-		Build()
+		WithPorts(ports)
+	// Set the type from the declared listener class before Build(), rather than leaving the
+	// product to patch Service.Spec.Type on the object it gets back.
+	if buildCtx.ListenerClass != "" {
+		svcBuilder = svcBuilder.WithServiceType(builder.ServiceType(listener.ServiceTypeFor(buildCtx.ListenerClass)))
+	}
+	return svcBuilder.Build()
+}
+
+// wireVolumes attaches the role group ConfigMap and the product's CSI volumes to the builder.
+//
+// Extracted from buildStatefulSet, which was over the cyclomatic budget: this is the one part of it
+// that is a self-contained unit (pod volumes plus the matching mounts on the primary container),
+// and it runs before the container rename and sidecar injection so both see the final shape.
+func (h *BaseRoleGroupHandler[CR]) wireVolumes(
+	stsBuilder *builder.StatefulSetBuilder, buildCtx *RoleGroupBuildContext,
+) {
+	// Mount the role group ConfigMap as the "config" volume at configMountPath().
+	//
+	// This is intentionally NOT gated on MergedConfig.ConfigFiles. ConfigFiles is populated
+	// only from role/role-group configOverrides, but the role group ConfigMap
+	// (buildCtx.ResourceName) is ALWAYS produced by buildConfigMap — a product can populate its
+	// real config (e.g. zoo.cfg, security.properties, logback.xml) directly into ConfigMap.Data
+	// with no overrides at all. Gating the mount on ConfigFiles would starve those products of
+	// their config in the common no-overrides case, forcing them to hand-create a config volume
+	// and strip the framework's. The mount references buildCtx.ResourceName, which the same
+	// handler's buildConfigMap always creates, so the referenced ConfigMap always exists.
+	stsBuilder.AddVolume(corev1.Volume{
+		Name: "config",
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{
+					Name: buildCtx.ResourceName,
+				},
+			},
+		},
+	})
+	stsBuilder.AddVolumeMount(corev1.VolumeMount{
+		Name:      "config",
+		MountPath: h.configMountPath(),
+		ReadOnly:  true,
+	})
+
+	// Inject product-registered CSI volumes (secret/TLS certificates, listener address
+	// volumes). These flow through the same builder path as the config volume (volumes on the
+	// pod, mounts on the primary container), before the container rename and sidecar injection.
+	// buildCtx.VolumeProviders is per-build-context, so nothing accumulates across reconciles.
+	for _, vp := range buildCtx.VolumeProviders {
+		if vp == nil {
+			continue
+		}
+		for _, v := range vp.Volumes() {
+			stsBuilder.AddVolume(v)
+		}
+		for _, m := range vp.VolumeMounts() {
+			stsBuilder.AddVolumeMount(m)
+		}
+	}
 }
 
 // buildStatefulSet creates the StatefulSet for the role group.
@@ -901,47 +958,7 @@ func (h *BaseRoleGroupHandler[CR]) buildStatefulSet(
 		stsBuilder.WithPodOverrides(buildCtx.MergedConfig.PodOverrides)
 	}
 
-	// Mount the role group ConfigMap as the "config" volume at configMountPath().
-	//
-	// This is intentionally NOT gated on MergedConfig.ConfigFiles. ConfigFiles is populated
-	// only from role/role-group configOverrides, but the role group ConfigMap
-	// (buildCtx.ResourceName) is ALWAYS produced by buildConfigMap — a product can populate its
-	// real config (e.g. zoo.cfg, security.properties, logback.xml) directly into ConfigMap.Data
-	// with no overrides at all. Gating the mount on ConfigFiles would starve those products of
-	// their config in the common no-overrides case, forcing them to hand-create a config volume
-	// and strip the framework's. The mount references buildCtx.ResourceName, which the same
-	// handler's buildConfigMap always creates, so the referenced ConfigMap always exists.
-	stsBuilder.AddVolume(corev1.Volume{
-		Name: "config",
-		VolumeSource: corev1.VolumeSource{
-			ConfigMap: &corev1.ConfigMapVolumeSource{
-				LocalObjectReference: corev1.LocalObjectReference{
-					Name: buildCtx.ResourceName,
-				},
-			},
-		},
-	})
-	stsBuilder.AddVolumeMount(corev1.VolumeMount{
-		Name:      "config",
-		MountPath: h.configMountPath(),
-		ReadOnly:  true,
-	})
-
-	// Inject product-registered CSI volumes (secret/TLS certificates, listener address
-	// volumes). These flow through the same builder path as the config volume (volumes on the
-	// pod, mounts on the primary container), before the container rename and sidecar injection.
-	// buildCtx.VolumeProviders is per-build-context, so nothing accumulates across reconciles.
-	for _, vp := range buildCtx.VolumeProviders {
-		if vp == nil {
-			continue
-		}
-		for _, v := range vp.Volumes() {
-			stsBuilder.AddVolume(v)
-		}
-		for _, m := range vp.VolumeMounts() {
-			stsBuilder.AddVolumeMount(m)
-		}
-	}
+	h.wireVolumes(stsBuilder, buildCtx)
 
 	// Name the primary container when the product needs a significant name (e.g. to match its
 	// per-container logging key). This must reach the builder BEFORE Build(): podOverrides are
@@ -954,6 +971,12 @@ func (h *BaseRoleGroupHandler[CR]) buildStatefulSet(
 		stsBuilder.WithMainContainerName(mainName)
 	}
 
+	// Registered BEFORE Build(): the customizer runs on the assembled container and podOverrides
+	// are strategic-merged afterwards, so the user's overrides keep the last word.
+	if buildCtx.MainContainerCustomizer != nil {
+		stsBuilder.WithMainContainerCustomizer(buildCtx.MainContainerCustomizer)
+	}
+
 	// Build the StatefulSet
 	sts := stsBuilder.Build()
 
@@ -964,6 +987,14 @@ func (h *BaseRoleGroupHandler[CR]) buildStatefulSet(
 	// Refusing to build is the only way that stops being silent.
 	if violations := stsBuilder.PodOverrideViolations(); len(violations) > 0 {
 		return nil, NewValidationError("podOverrides", buildCtx.RoleName, buildCtx.RoleGroupName,
+			stderrors.Join(violations...))
+	}
+
+	// A customizer that failed would otherwise ship a workload missing the command, args or probes
+	// the product meant to set — the same reason podOverrides violations fail the build rather than
+	// being logged.
+	if violations := stsBuilder.MainContainerViolations(); len(violations) > 0 {
+		return nil, NewValidationError("mainContainerCustomizer", buildCtx.RoleName, buildCtx.RoleGroupName,
 			stderrors.Join(violations...))
 	}
 

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -2972,3 +2972,129 @@ func (p *recordingSidecarProvider) Inject(podSpec *corev1.PodSpec, cfg *sidecar.
 	return nil
 }
 func (p *recordingSidecarProvider) Validate(context.Context, client.Client, string) error { return nil }
+
+var _ = Describe("Declaring intent before Build", func() {
+	// Both of these replace the same shape: the framework builds a complete object and the product
+	// reaches in and edits it. Declaring the intent first keeps ordering framework-owned.
+	var mockCR *testutil.MockCluster
+
+	BeforeEach(func() { mockCR = testutil.NewMockCluster("test-cluster", "default") })
+
+	declareCtx := func(mutate func(*reconciler.RoleGroupBuildContext)) *reconciler.RoleGroupBuildContext {
+		buildCtx := &reconciler.RoleGroupBuildContext{
+			ClusterName:      "test-cluster",
+			ClusterNamespace: "default",
+			RoleName:         "server",
+			RoleSpec:         &v1alpha1.RoleSpec{},
+			RoleGroupName:    "default",
+			RoleGroupSpec:    v1alpha1.RoleGroupSpec{Replicas: ptr.To(int32(1))},
+			MergedConfig:     &config.MergedConfig{},
+			ResourceName:     "test-cluster-server-default",
+			ServicePorts:     []corev1.ServicePort{{Name: "http", Port: 8080}},
+		}
+		if mutate != nil {
+			mutate(buildCtx)
+		}
+		return buildCtx
+	}
+
+	It("sets the client Service type from the declared listener class", func() {
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("img:1", testScheme)
+
+		resources, err := handler.BuildResources(context.Background(), k8sClient, mockCR,
+			declareCtx(func(b *reconciler.RoleGroupBuildContext) {
+				b.ListenerClass = listener.ListenerClassExternalUnstable
+			}))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.Service.Spec.Type).To(Equal(corev1.ServiceTypeNodePort))
+	})
+
+	It("leaves the Service a ClusterIP when no class is declared", func() {
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("img:1", testScheme)
+
+		resources, err := handler.BuildResources(context.Background(), k8sClient, mockCR, declareCtx(nil))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.Service.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
+	})
+
+	It("hands the customizer the primary container, whichever index it ends up at", func() {
+		// zookeeper-operator located it as Containers[0], an assumption the framework never made:
+		// a sidecar provider inserting a container earlier silently configures the wrong one.
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("img:1", testScheme)
+		handler.MainContainerName = "zookeeper"
+
+		var sawName string
+		resources, err := handler.BuildResources(context.Background(), k8sClient, mockCR,
+			declareCtx(func(b *reconciler.RoleGroupBuildContext) {
+				b.MainContainerCustomizer = func(c *corev1.Container) error {
+					sawName = c.Name
+					c.Command = []string{"/bin/zkServer.sh"}
+					c.Args = []string{"start-foreground"}
+					c.Env = append(c.Env, corev1.EnvVar{Name: "ZK_ID", Value: "1"})
+					return nil
+				}
+			}))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sawName).To(Equal("zookeeper"), "the customizer is handed the container by identity, not by index")
+
+		main := resources.StatefulSet.Spec.Template.Spec.Containers[0]
+		Expect(main.Command).To(Equal([]string{"/bin/zkServer.sh"}))
+		Expect(main.Args).To(Equal([]string{"start-foreground"}))
+		Expect(main.Env).To(ContainElement(corev1.EnvVar{Name: "ZK_ID", Value: "1"}))
+	})
+
+	It("lets podOverrides outrank the customizer", func() {
+		// The reason this is a pre-Build hook rather than a post-build patch. A product editing the
+		// returned StatefulSet would land AFTER the strategic merge and silently beat the user.
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("img:1", testScheme)
+		handler.MainContainerName = "main"
+
+		resources, err := handler.BuildResources(context.Background(), k8sClient, mockCR,
+			declareCtx(func(b *reconciler.RoleGroupBuildContext) {
+				b.MergedConfig.PodOverrides = &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{Containers: []corev1.Container{{
+						Name: "main",
+						Env:  []corev1.EnvVar{{Name: "LEVEL", Value: "from-user"}},
+					}}},
+				}
+				b.MainContainerCustomizer = func(c *corev1.Container) error {
+					c.Env = append(c.Env, corev1.EnvVar{Name: "LEVEL", Value: "from-product"})
+					return nil
+				}
+			}))
+		Expect(err).NotTo(HaveOccurred())
+
+		main := resources.StatefulSet.Spec.Template.Spec.Containers[0]
+		Expect(main.Env).To(ContainElement(corev1.EnvVar{Name: "LEVEL", Value: "from-user"}))
+		Expect(main.Env).NotTo(ContainElement(corev1.EnvVar{Name: "LEVEL", Value: "from-product"}))
+	})
+
+	It("fails the role group when the customizer errors", func() {
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("img:1", testScheme)
+
+		_, err := handler.BuildResources(context.Background(), k8sClient, mockCR,
+			declareCtx(func(b *reconciler.RoleGroupBuildContext) {
+				b.MainContainerCustomizer = func(*corev1.Container) error {
+					return fmt.Errorf("no JVM heap could be computed")
+				}
+			}))
+		Expect(err).To(MatchError(ContainSubstring("no JVM heap could be computed")))
+		Expect(reconciler.IsValidationError(err)).To(BeTrue())
+	})
+
+	It("refuses an image change from the customizer, and keeps the resolved one", func() {
+		// The image is propagated to the sidecars before the StatefulSet is built (the Vector agent
+		// ships inside the product image), so changing it here would leave them on the old one.
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("img:1", testScheme)
+
+		_, err := handler.BuildResources(context.Background(), k8sClient, mockCR,
+			declareCtx(func(b *reconciler.RoleGroupBuildContext) {
+				b.MainContainerCustomizer = func(c *corev1.Container) error {
+					c.Image = "sneaky:2"
+					return nil
+				}
+			}))
+		Expect(err).To(MatchError(ContainSubstring("RoleGroupBuildContext.Image")))
+		Expect(err).To(MatchError(ContainSubstring("sneaky:2")))
+	})
+})

--- a/pkg/reconciler/role_group_handler.go
+++ b/pkg/reconciler/role_group_handler.go
@@ -24,6 +24,7 @@ import (
 	"github.com/zncdatadev/operator-go/pkg/common"
 	"github.com/zncdatadev/operator-go/pkg/config"
 	"github.com/zncdatadev/operator-go/pkg/constant"
+	"github.com/zncdatadev/operator-go/pkg/listener"
 	"github.com/zncdatadev/operator-go/pkg/productlogging"
 	"github.com/zncdatadev/operator-go/pkg/sidecar"
 	"github.com/zncdatadev/operator-go/pkg/vector"
@@ -225,6 +226,29 @@ type RoleGroupBuildContext struct {
 	ImagePullPolicy corev1.PullPolicy
 	ContainerPorts  []corev1.ContainerPort
 	ServicePorts    []corev1.ServicePort
+
+	// ListenerClass sets the client Service's type through listener.ServiceTypeFor, so the
+	// Service is right when it is BUILT. Products used to patch Service.Spec.Type after
+	// BuildResources returned, each re-deriving the same three-way switch — two of them with raw
+	// string literals rather than the framework constants, and disagreeing about what
+	// external-stable meant. Empty leaves the builder's default (ClusterIP).
+	ListenerClass listener.ListenerClass
+
+	// MainContainerCustomizer gets the assembled primary container just before podOverrides are
+	// applied, which is the whole point: a user's podOverrides still outrank whatever the product
+	// sets here, and a post-build edit would invert that precedence silently.
+	//
+	// The framework owns the primary container's name, image, ports, security context, volume
+	// mounts and probes; everything else — command, args, env, probes the product wants to
+	// replace, lifecycle hooks — has no other channel, so products reached into the returned
+	// StatefulSet and edited it, re-deriving the container they had just been handed.
+	// zookeeper-operator located it as Containers[0], which the framework has never promised: the
+	// moment a sidecar provider inserts a container earlier, that configures the wrong one.
+	//
+	// Returning an error fails the role group with a *ValidationError. Changing the image is
+	// rejected the same way — it is resolved once and propagated to the sidecars before the
+	// StatefulSet is built, so set Image above instead.
+	MainContainerCustomizer func(*corev1.Container) error
 
 	// VectorAggregatorAddress is the resolved Vector aggregator discovery address, populated by
 	// GenericReconciler when the Vector agent is enabled and the CR implements


### PR DESCRIPTION
Closes #577, closes #576. Both are the same root cause, hence one PR.

## The shape both issues describe

`BuildResources` returns a **finished** object, and for anything the framework does not model the only extension point was mutating it afterwards. That costs twice: products re-derive what the handler already knows, and the edit lands *after* the framework's own ordering.

| field | replaces | why declaring it first matters |
| --- | --- | --- |
| `MainContainerCustomizer` | patching `Containers[0]` of the returned StatefulSet | runs **before** `podOverrides` are strategic-merged, so the **user's** overrides still win |
| `ListenerClass` | patching `Service.Spec.Type` after the fact | one shared mapping instead of a three-way switch re-derived per product |

Both ride the per-CR channel established in #582, so there is one place a product declares per-cluster inputs rather than a second mechanism.

## #577 — the primary container

The framework owns the container's name, image, ports, security context, mounts and probes and **nothing else**, so every migrated product reached into the returned StatefulSet. zookeeper-operator located it as `Containers[0]` — an assumption the framework has never made, and which a sidecar provider inserting a container earlier silently invalidates.

**The timing is the point, not the hook.** Running before the merge is what keeps a user's `podOverrides` outranking the product; a post-build edit inverts that precedence silently. There is a spec for it, and **the mutation that moves the customizer after `Build()` fails it**.

A customizer that errors fails the role group with a `*ValidationError` — and so does one that changes the **image**: the image is resolved once and propagated to the sidecars before the StatefulSet is built (the Vector agent ships inside the product image), so changing it there would leave them on the old one. `RoleGroupBuildContext.Image` is that channel.

## #576 — the listener class

I recovered the mapping from git history rather than reinventing it — v0.12.6's `builder.ListenerClass2ServiceType`:

```
cluster-internal   -> ClusterIP
external-unstable  -> NodePort
external-stable    -> LoadBalancer
unrecognised       -> ClusterIP   (the narrowest exposure, never an accidental public address)
```

**Two deviations from the issue's proposal, both forced:**

1. It lives in **`pkg/listener`**, not `pkg/builder`: `pkg/listener` already imports `pkg/builder`, so `func builder.ListenerClassServiceType(class listener.ListenerClass)` does not compile. It pairs with the Service builder's existing `WithServiceType` rather than adding a second entry point.
2. `ListenerClass` goes on the **build context**, not as a `ListenerClassFunc` handler field — same effect, and it reuses the channel #582 just established instead of adding a parallel one.

**A doc correction with teeth**: `ListenerClassExternalUnstable`'s comment said *"creates LoadBalancer with dynamic IPs"*. It is a **NodePort** — the LoadBalancer is the *stable* class. That wording is the documented reason the two migrated operators disagreed about what `external-stable` meant, so it is fixed here.

## Verification

- Six handler specs + two for the mapping.
- **Four mutations killed**: the customizer running after the merge (post-build semantics), an image change accepted, `external-unstable` mapped the way the wrong comment implied, and a customizer error swallowed.
- `make lint` (0 issues), `make test` (18 packages), **the whole suite under `-race`**, `make verify-generate`, and the examples module's `make lint` + `make test` all pass.

## One thing worth reviewing

Adding two branches pushed `buildStatefulSet` past the cyclomatic budget (32 > 30). Rather than raising the threshold, the config-volume and CSI-volume-provider wiring is extracted into `wireVolumes` — the one genuinely self-contained unit in that function. No behaviour change; it still runs before the container rename and sidecar injection.

## Compatibility

Additive. Unset, the Service is a ClusterIP and no customizer runs, so an unmigrated product renders byte-identical output.