### PR TITLE
feat(builder): customizable metrics service name and annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ changes are listed below.**
 
 ### features (metrics service customization)
 
-- **The per-role-group metrics Service slot is now name- and annotation-customizable.**
+- **The per-role-group metrics Service slot is now name- and annotation-customizable** (#586).
   `builder.MetricsServiceBuilder` gains `WithName` — overriding the default `{resourceName}-metrics`
   name — and `WithAnnotations`, merged into the generated Prometheus annotation set with caller
   entries winning on key collisions. Products migrating from pre-framework operators that published

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,25 @@ builders, config/logging rendering and the CSI wiring, followed by three API red
 the contracts a product operator implements. **Downstream operators must migrate — the breaking
 changes are listed below.**
 
+### features (metrics service customization)
+
+- **The per-role-group metrics Service slot is now name- and annotation-customizable.**
+  `builder.MetricsServiceBuilder` gains `WithName` — overriding the default `{resourceName}-metrics`
+  name — and `WithAnnotations`, merged into the generated Prometheus annotation set with caller
+  entries winning on key collisions. Products migrating from pre-framework operators that published
+  the metrics Service under the role group resource name can keep that DNS name byte-stable across
+  a Gen 3 migration instead of shipping the Service through the `ExtraResources` escape hatch.
+- **The slot is identified by labels, not by derived name.** The apply path stamps the slot label
+  plus the framework's role group identity (the instance label and the role group marker) on
+  whatever Service the handler ships as `RoleGroupResources.MetricsService`, and the reclaim runs a
+  label-selected List — with the historical derived-name lookup retained as a fallback for slots
+  applied before the stamping existed. A custom-named metrics Service is therefore reclaimed
+  exactly like the default one when the handler stops shipping it; the name-derived lookup alone
+  would never have found it, leaking a scrape target pointing at nothing. The filter stays
+  precise: a product object under the derived name — or the client Service of a role group
+  literally called `<group>-metrics` — carries neither the marker nor the slot label and is never
+  touched.
+
 ### BREAKING CHANGES
 
 - `common.ClusterInterface` shrank from twelve methods to `client.Object` plus `GetSpec` and

--- a/pkg/builder/AGENTS.md
+++ b/pkg/builder/AGENTS.md
@@ -36,6 +36,13 @@ extension).
 - **`WithLabels` / `WithAnnotations` merge, they do not replace.** This holds for every builder
   that has them (StatefulSet, Service, ConfigMap, PDB, RBAC, ServiceAccount); calling them twice
   unions the entries.
+- **`MetricsServiceBuilder` name and annotations are customizable.** The Service is named
+  `{resourceName}-metrics` unless `WithName` overrides it — the migration path for products whose
+  pre-framework operator published the metrics Service under the role group resource name.
+  `WithAnnotations` merges extra entries into the generated Prometheus annotation set; caller
+  entries win on key collisions, so any default can be restated or replaced. The reconciler's
+  metrics slot identifies this Service by the labels it stamps at apply time (the slot label plus
+  the role group marker), so apply and reclaim behave identically under a custom name.
 - **`PDBBuilder.Build()` panics without a selector.** An empty `LabelSelector` is accepted by the
   API server and selects *every* pod in the namespace, so a PDB built without `WithSelector` would
   silently block node drains for workloads the operator does not own. It is the only object in

--- a/pkg/builder/metrics_service_builder.go
+++ b/pkg/builder/metrics_service_builder.go
@@ -27,27 +27,30 @@ import (
 
 // MetricsServiceBuilder constructs a headless Service with Prometheus scrape annotations.
 // Conventions applied automatically:
-//   - Service name: "{resourceName}-metrics"
+//   - Service name: "{resourceName}-metrics" (override with WithName)
 //   - ClusterIP: None (headless)
-//   - Prometheus annotations: scrape=true, port, scheme=http
+//   - Prometheus annotations: scrape=true, port, scheme=http (extend with WithAnnotations)
 //   - Service labels: input labels + "prometheus.io/scrape=true"
 //   - Selector: input labels (without prometheus annotation)
 //
-// Override defaults with WithScheme() and WithPath().
+// Override defaults with WithScheme(), WithPath(), WithName() and WithAnnotations().
 type MetricsServiceBuilder struct {
 	resourceName   string
 	namespace      string
+	name           string
 	port           int32
 	portName       string
 	targetPortName string
 	labels         map[string]string
 	selector       map[string]string
+	annotations    map[string]string
 	scheme         string
 	path           string
 }
 
 // NewMetricsServiceBuilder creates a builder for a metrics headless service.
-// resourceName is the role group resource name; "-metrics" suffix is appended automatically.
+// resourceName is the role group resource name; the Service is named "{resourceName}-metrics"
+// unless WithName overrides it.
 // port is the metrics port number.
 // labels are used for both service labels and selector.
 // The labels are copied, like every other builder's: a caller that keeps mutating the map it
@@ -73,6 +76,29 @@ func (b *MetricsServiceBuilder) WithScheme(scheme string) *MetricsServiceBuilder
 // WithPath sets the Prometheus metrics path (default: "" which means /metrics).
 func (b *MetricsServiceBuilder) WithPath(path string) *MetricsServiceBuilder {
 	b.path = path
+	return b
+}
+
+// WithName overrides the default "{resourceName}-metrics" Service name. Products migrating from
+// pre-framework operators whose metrics Service shared the role group resource name use this to
+// keep the published DNS name stable across the migration. The framework's apply and reclaim
+// paths identify the metrics slot by its labels, not by this name, so a custom name stays fully
+// managed (including deletion when the handler stops shipping a MetricsService).
+func (b *MetricsServiceBuilder) WithName(name string) *MetricsServiceBuilder {
+	b.name = name
+	return b
+}
+
+// WithAnnotations merges extra annotations into the generated Prometheus set. Entries passed
+// here win on key collisions, so a product can also restate or replace any of the defaults.
+// The map is copied entry-wise; later calls merge into earlier ones.
+func (b *MetricsServiceBuilder) WithAnnotations(annotations map[string]string) *MetricsServiceBuilder {
+	if b.annotations == nil {
+		b.annotations = map[string]string{}
+	}
+	for k, v := range annotations {
+		b.annotations[k] = v
+	}
 	return b
 }
 
@@ -114,6 +140,10 @@ func (b *MetricsServiceBuilder) Build() *corev1.Service {
 	if b.path != "" {
 		annotations["prometheus.io/path"] = b.path
 	}
+	// Product annotations win over the generated defaults on key collisions.
+	for k, v := range b.annotations {
+		annotations[k] = v
+	}
 
 	selectorSource := b.selector
 	if selectorSource == nil {
@@ -129,9 +159,14 @@ func (b *MetricsServiceBuilder) Build() *corev1.Service {
 		targetPort = intstr.FromString(b.targetPortName)
 	}
 
+	serviceName := b.resourceName + "-metrics"
+	if b.name != "" {
+		serviceName = b.name
+	}
+
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        b.resourceName + "-metrics",
+			Name:        serviceName,
 			Namespace:   b.namespace,
 			Labels:      serviceLabels,
 			Annotations: annotations,

--- a/pkg/builder/metrics_service_builder_test.go
+++ b/pkg/builder/metrics_service_builder_test.go
@@ -166,4 +166,64 @@ var _ = Describe("MetricsServiceBuilder", func() {
 			Expect(svc.Spec.Ports[0].TargetPort).To(Equal(intstr.FromString("jmx")))
 		})
 	})
+
+	Describe("WithName", func() {
+		It("should override the default derived name", func() {
+			svc := builder.NewMetricsServiceBuilder(resourceName, namespace, port, labels).
+				WithName(resourceName).
+				Build()
+
+			Expect(svc.Name).To(Equal(resourceName))
+			Expect(svc.Namespace).To(Equal(namespace))
+		})
+
+		It("should keep the derived name when not set", func() {
+			svc := builder.NewMetricsServiceBuilder(resourceName, namespace, port, labels).Build()
+
+			Expect(svc.Name).To(Equal(resourceName + "-metrics"))
+		})
+
+		It("should preserve the prometheus conventions under a custom name", func() {
+			svc := builder.NewMetricsServiceBuilder(resourceName, namespace, port, labels).
+				WithName("custom-metrics-svc").
+				Build()
+
+			Expect(svc.Name).To(Equal("custom-metrics-svc"))
+			Expect(svc.Spec.ClusterIP).To(Equal(corev1.ClusterIPNone))
+			Expect(svc.Annotations).To(HaveKeyWithValue("prometheus.io/scrape", "true"))
+			Expect(svc.Annotations).To(HaveKeyWithValue("prometheus.io/port", "9505"))
+			Expect(svc.Labels).To(HaveKeyWithValue("prometheus.io/scrape", "true"))
+		})
+	})
+
+	Describe("WithAnnotations", func() {
+		It("should merge extra annotations into the generated set", func() {
+			svc := builder.NewMetricsServiceBuilder(resourceName, namespace, port, labels).
+				WithAnnotations(map[string]string{"example.com/team": "data"}).
+				Build()
+
+			Expect(svc.Annotations).To(HaveKeyWithValue("example.com/team", "data"))
+			Expect(svc.Annotations).To(HaveKeyWithValue("prometheus.io/scrape", "true"))
+			Expect(svc.Annotations).To(HaveKeyWithValue("prometheus.io/port", "9505"))
+		})
+
+		It("should let caller entries win over generated defaults", func() {
+			svc := builder.NewMetricsServiceBuilder(resourceName, namespace, port, labels).
+				WithPath("/custom").
+				WithAnnotations(map[string]string{"prometheus.io/path": "/override"}).
+				Build()
+
+			Expect(svc.Annotations).To(HaveKeyWithValue("prometheus.io/path", "/override"))
+		})
+
+		It("should merge successive calls", func() {
+			svc := builder.NewMetricsServiceBuilder(resourceName, namespace, port, labels).
+				WithAnnotations(map[string]string{"a": "1"}).
+				WithAnnotations(map[string]string{"b": "2"}).
+				Build()
+
+			Expect(svc.Annotations).To(HaveKeyWithValue("a", "1"))
+			Expect(svc.Annotations).To(HaveKeyWithValue("b", "2"))
+		})
+	})
 })

--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -42,6 +42,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -1179,18 +1180,20 @@ func (r *GenericReconciler[CR]) applyResources(ctx context.Context, cr CR, resou
 	// 7. Apply the metrics Service, or reclaim it when metrics are turned off — mirroring the
 	// PDB branch above, so disabling metrics actually removes the stale Service instead of
 	// leaving a scrape target pointing at pods nobody exports metrics from.
-	metricsName := buildCtx.ResourceName + "-metrics"
 	if resources.MetricsService != nil {
-		// The reclaim below deletes by derived name, and "<resource>-metrics" is also a legal
-		// resource name for a role group literally called "<group>-metrics". Stamping the slot
-		// here is what lets the reclaim tell "the metrics Service this framework applied" apart
-		// from a sibling role group's Service, or a product's own object of the same name.
+		// The reclaim below finds the slot by its framework labels — not by name, because
+		// builder.WithName lets a product publish it under any name. Stamping the slot label and
+		// the role group identity here is what makes apply and reclaim agree on the same object,
+		// whatever labels (or name) the handler chose: a role group literally called
+		// "<group>-metrics" still has its own Services, and a product's own object under the
+		// default derived name is still untouched.
+		stampMetricsIdentity(resources.MetricsService, buildCtx)
 		markMetricsService(resources.MetricsService)
 		if err := r.applyResource(ctx, cr, resources.MetricsService); err != nil {
-			return NewResourceApplyError("Service", buildCtx.ClusterNamespace, metricsName, "failed to apply metrics service", err)
+			return NewResourceApplyError("Service", buildCtx.ClusterNamespace, resources.MetricsService.Name, "failed to apply metrics service", err)
 		}
-	} else if err := r.reclaimMetricsService(ctx, buildCtx.ClusterNamespace, metricsName, cr.GetUID(), buildCtx.ClusterName); err != nil {
-		return NewResourceApplyError("Service", buildCtx.ClusterNamespace, metricsName, "failed to delete disabled metrics service", err)
+	} else if err := r.reclaimMetricsService(ctx, buildCtx, cr.GetUID()); err != nil {
+		return NewResourceApplyError("Service", buildCtx.ClusterNamespace, buildCtx.ResourceName+"-metrics", "failed to delete disabled metrics service", err)
 	}
 
 	return nil
@@ -1206,6 +1209,19 @@ func markMetricsService(svc *corev1.Service) {
 		svc.Labels = map[string]string{}
 	}
 	svc.Labels[LabelMetricsService] = valueTrue
+}
+
+// stampMetricsIdentity puts the framework's role group identity labels — the cluster instance
+// label and the role group marker — on a handler-built metrics Service. The handler may have
+// built it with any descriptive label set (or with a custom name through builder.WithName), but
+// the reclaim path must be able to find exactly this role group's slot from the labels alone, so
+// the two labels only the framework knows are guaranteed here.
+func stampMetricsIdentity(svc *corev1.Service, buildCtx *RoleGroupBuildContext) {
+	if svc.Labels == nil {
+		svc.Labels = map[string]string{}
+	}
+	svc.Labels[constant.LabelKubernetesInstance] = buildCtx.ClusterName
+	svc.Labels[RoleGroupMarkerLabelKey(buildCtx.ClusterName, buildCtx.RoleName, buildCtx.RoleGroupName)] = valueTrue
 }
 
 // markRolePodDisruptionBudget stamps the role slot label, carrying the role the PDB covers, on a
@@ -1280,23 +1296,49 @@ func isFrameworkRoleGroupPDB(pdb *policyv1.PodDisruptionBudget, clusterName, rol
 		pdb.Labels[RoleGroupMarkerLabelKey(clusterName, roleName, roleGroupName)] == valueTrue
 }
 
-// reclaimMetricsService deletes the role group's metrics Service, but only when the live object
-// is one this framework applied as the metrics slot. Deleting purely by derived name would also
-// hit the client Service of a role group named "<group>-metrics", and any object a product ships
-// under that name through RoleGroupResources.ExtraResources — both of which carry this CR's
-// controller owner reference, so ownership alone does not distinguish them.
-func (r *GenericReconciler[CR]) reclaimMetricsService(ctx context.Context, namespace, name string, ownerUID types.UID, clusterName string) error {
-	svc := &corev1.Service{}
-	if err := r.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, svc); err != nil {
+// reclaimMetricsService deletes the role group's metrics Service when the handler stopped
+// supplying one. It finds the slot by the framework labels stamped on the apply path — the slot
+// label plus the role group marker — so a metrics Service published under a custom name
+// (builder.WithName) is reclaimed exactly like the default "<resource>-metrics" one. Deleting by
+// derived name alone would also hit the client Service of a role group literally called
+// "<group>-metrics", and any object a product ships under that name through
+// RoleGroupResources.ExtraResources — all of which carry this CR's controller owner reference,
+// so ownership alone does not distinguish them; the marker label is the precise filter.
+func (r *GenericReconciler[CR]) reclaimMetricsService(ctx context.Context, buildCtx *RoleGroupBuildContext, ownerUID types.UID) error {
+	markerKey := RoleGroupMarkerLabelKey(buildCtx.ClusterName, buildCtx.RoleName, buildCtx.RoleGroupName)
+	svcs := &corev1.ServiceList{}
+	if err := r.client.List(ctx, svcs,
+		client.InNamespace(buildCtx.ClusterNamespace),
+		client.MatchingLabels{LabelMetricsService: valueTrue, markerKey: valueTrue},
+	); err != nil {
+		return err
+	}
+	for i := range svcs.Items {
+		svc := &svcs.Items[i]
+		if ref := metav1.GetControllerOf(svc); ref == nil || ref.UID != ownerUID {
+			continue
+		}
+		if err := r.cleaner.deleteService(ctx, svc.Namespace, svc.Name, ownerUID, buildCtx.ClusterName); err != nil {
+			return err
+		}
+	}
+
+	// Legacy fallback: a metrics Service applied before identity stamping carries the slot label
+	// but no role group marker, so the List above does not see it. The historical derived-name
+	// lookup with the slot-label check keeps those reclaimable; it is a no-op for a Service the
+	// List path already deleted, and for a custom-named slot that never used the derived name.
+	legacy := &corev1.Service{}
+	legacyName := buildCtx.ResourceName + "-metrics"
+	if err := r.client.Get(ctx, types.NamespacedName{Namespace: buildCtx.ClusterNamespace, Name: legacyName}, legacy); err != nil {
 		if errors.IsNotFound(err) {
 			return nil
 		}
 		return err
 	}
-	if svc.Labels[LabelMetricsService] != valueTrue {
+	if legacy.Labels[LabelMetricsService] != valueTrue {
 		return nil
 	}
-	return r.cleaner.deleteService(ctx, namespace, name, ownerUID, clusterName)
+	return r.cleaner.deleteService(ctx, legacy.Namespace, legacyName, ownerUID, buildCtx.ClusterName)
 }
 
 // validateSidecars runs the registered sidecar providers' dependency checks for a role group.

--- a/pkg/reconciler/metrics_service_reclaim_test.go
+++ b/pkg/reconciler/metrics_service_reclaim_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
+	"github.com/zncdatadev/operator-go/pkg/builder"
+	"github.com/zncdatadev/operator-go/pkg/reconciler"
+	"github.com/zncdatadev/operator-go/pkg/testutil"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// The metrics slot is identified by framework-stamped labels, not by its name, so a handler that
+// publishes the metrics Service under a custom name (builder.WithName — the migration path for
+// products whose pre-framework operator named the metrics Service after the role group itself)
+// gets the same apply and reclaim guarantees as the default "<resource>-metrics" name.
+var _ = Describe("Metrics Service slot", func() {
+	var crName, namespace, resourceName string
+	var cr *testutil.MockCluster
+	var emitMetrics bool
+	var r *reconciler.GenericReconciler[*testutil.MockCluster]
+
+	BeforeEach(func() {
+		namespace = testNamespace
+		crName = fmt.Sprintf("metrics-cr-%d", time.Now().UnixNano())
+		resourceName = crName + "-test-role-default"
+		emitMetrics = true
+
+		mockHandler := testutil.NewMockRoleGroupHandler().WithBuildResourcesFunc(
+			func(ctx context.Context, k8sClient client.Client, mc *testutil.MockCluster, buildCtx *reconciler.RoleGroupBuildContext) (*reconciler.RoleGroupResources, error) {
+				res, err := testutil.NewMockRoleGroupHandler().BuildResources(ctx, k8sClient, mc, buildCtx)
+				if err != nil {
+					return nil, err
+				}
+				// Keep the role group's own name free for the custom-named metrics slot, like a
+				// product whose metrics Service shares the role group resource name.
+				res.Service = nil
+				if emitMetrics {
+					res.MetricsService = builder.NewMetricsServiceBuilder(buildCtx.ResourceName, buildCtx.ClusterNamespace, 9102, buildCtx.ClusterLabels).
+						WithName(buildCtx.ResourceName).
+						Build()
+				}
+				return res, nil
+			})
+
+		cr = testutil.NewMockCluster(crName, namespace).WithRoles(map[string]v1alpha1.RoleSpec{
+			"test-role": {
+				RoleGroups: map[string]v1alpha1.RoleGroupSpec{
+					"default": {Replicas: ptr.To(int32(1))},
+				},
+			},
+		})
+		Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+
+		cfg := &reconciler.GenericReconcilerConfig[*testutil.MockCluster]{
+			Client:           k8sClient,
+			Scheme:           testScheme,
+			Recorder:         recorder,
+			RoleGroupHandler: &handlerAdapter{handler: mockHandler},
+			Prototype:        cr,
+		}
+		var err error
+		r, err = reconciler.NewGenericReconciler(cfg)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		Expect(client.IgnoreNotFound(k8sClient.Delete(ctx, cr))).To(Succeed())
+	})
+
+	reconcileCR := func() {
+		_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: crName}})
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	It("stamps the slot and identity labels on a custom-named metrics service", func() {
+		reconcileCR()
+
+		svc := &corev1.Service{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: resourceName}, svc)).To(Succeed())
+		Expect(svc.Labels).To(HaveKeyWithValue(reconciler.LabelMetricsService, "true"))
+		Expect(svc.Labels).To(HaveKeyWithValue("app.kubernetes.io/instance", crName))
+		Expect(svc.Labels).To(HaveKeyWithValue(
+			reconciler.RoleGroupMarkerLabelKey(crName, "test-role", "default"), "true"))
+		Expect(metav1.GetControllerOf(svc)).NotTo(BeNil())
+	})
+
+	It("reclaims a custom-named metrics service when the handler stops shipping one", func() {
+		reconcileCR()
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: resourceName}, &corev1.Service{})).To(Succeed())
+
+		emitMetrics = false
+		reconcileCR()
+
+		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: resourceName}, &corev1.Service{})
+		Expect(errors.IsNotFound(err)).To(BeTrue(), "custom-named metrics service should be reclaimed")
+	})
+
+	It("leaves a product service under the derived name alone when it is not the slot", func() {
+		emitMetrics = false
+		reconcileCR()
+
+		// A product object under the derived "<resource>-metrics" name, owned by the CR but not
+		// carrying the slot label: reclaim must not touch it.
+		foreign := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{Name: resourceName + "-metrics", Namespace: namespace},
+			Spec:       corev1.ServiceSpec{Ports: []corev1.ServicePort{{Port: 1234}}},
+		}
+		Expect(controllerutil.SetControllerReference(cr, foreign, testScheme)).To(Succeed())
+		Expect(k8sClient.Create(ctx, foreign)).To(Succeed())
+
+		reconcileCR()
+
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: resourceName + "-metrics"}, &corev1.Service{})).To(Succeed())
+	})
+})


### PR DESCRIPTION
Closes #584.

## What

`pkg/builder`:
- `MetricsServiceBuilder.WithName(name)` — overrides the default `{resourceName}-metrics` Service name.
- `MetricsServiceBuilder.WithAnnotations(map)` — merges extra annotations into the generated Prometheus set; caller entries win on key collisions, so any default can be restated or replaced.

`pkg/reconciler`:
- The apply path now stamps the framework's role group identity (instance label + role group marker) on `RoleGroupResources.MetricsService` alongside the slot label, and `reclaimMetricsService` finds the slot by a label-selected List instead of the derived name — with the historical derived-name lookup retained as a fallback for slots applied before the stamping existed.
- A custom-named metrics Service is therefore applied and reclaimed exactly like the default one; the name-derived lookup alone would never have found it, leaking a scrape target when the handler stops shipping the slot.

## Why

Gen 3 migrations with YAML parity as the acceptance bar: airflow-operator's pre-framework code publishes the metrics Service under the role group resource name with `prometheus.io/*` annotations, and its e2e suite asserts both. Without this, the only migration path ships the Service through `RoleGroupResources.ExtraResources`, bypassing the slot lifecycle.

## Verification

- `pkg/builder` tests: name override, annotation merge + precedence, conventions preserved under custom names.
- `pkg/reconciler` envtest specs: slot + identity labels stamped on a custom-named slot; reclaim deletes it when the handler stops shipping one; a product Service under the derived name without the slot label is never touched.
- `make lint`, `make test` (18 packages green), `make verify-generate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)