### PR TITLE
feat(reconciler)!: let the product-config seam read the cluster it documents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -578,17 +578,43 @@ Products contribute their computed configuration **as data through the same merg
 ```go
 reconcilerCfg := &reconciler.GenericReconcilerConfig[*v1alpha1.TrinoCluster]{
     // ...
-    ProductConfig: func(cr *v1alpha1.TrinoCluster, roleName, roleGroupName string) *commonsv1alpha1.OverridesSpec {
+    ProductConfig: func(ctx context.Context, c client.Client, cr *v1alpha1.TrinoCluster,
+        roleName, roleGroupName string) (*commonsv1alpha1.OverridesSpec, error) {
         overrides := map[string]map[string]string{
             "config.properties": {"http-server.http.port": "8080"},
         }
         if roleName == "coordinators" {
             overrides["config.properties"]["coordinator"] = "true"
         }
-        return &commonsv1alpha1.OverridesSpec{ConfigOverrides: overrides}
+        return &commonsv1alpha1.OverridesSpec{ConfigOverrides: overrides}, nil
     },
 }
 ```
+
+**The `ctx` and client are what make "may derive from live cluster state" true.** Without them the
+hook could only be a pure function of the CR, so a product needing an API lookup — resolving an
+`S3Connection` reference to an endpoint — could not use it at all, and a `Get` failure could only be
+swallowed (rendering a silently wrong config) or panicked. A returned error fails the role group.
+
+**`RoleGroupBuildContext.ApplyProductDefaults(*OverridesSpec)` is the imperative counterpart**, for a
+product that performs its lookup inside `BuildResources` and does not want to repeat it:
+
+```go
+conn, err := s3.ResolveConnection(ctx, c, cr.Namespace, inline, ref)
+if err != nil { return nil, err }
+buildCtx.ApplyProductDefaults(&commonsv1alpha1.OverridesSpec{
+    ConfigOverrides: map[string]map[string]string{"hive-site.xml": conn.S3AProperties()},
+})
+```
+
+It folds the layer **beneath** everything already merged, using the merge's own per-dimension rules
+(`config.ConfigMerger.MergeBeneath`): config files and env vars per key, CLI/JVM args as a whole,
+podOverrides through the same strategic merge patch. Repeated calls accumulate, each landing beneath
+the last. hive-operator and spark-k8s-operator each hand-wrote the same "set only keys the user did
+not set" helper, and both then discovered the same second rule for env vars — that product defaults
+must not overwrite `envOverrides`, which they solved by prepending to the container's env list. Both
+rules are the framework's own precedence, and neither needs an ordering dance here because
+`MergedConfig.EnvVars` is a map.
 
 Precedence (low → high): **product config < role overrides < role group overrides**. Any value a user sets in the CRD always wins. `ConfigMerger.Merge` is variadic (`Merge(...*OverridesSpec)`) and folds layers in order; the previous two-argument call (`Merge(role, group)`) is still valid.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,6 +141,14 @@ changes are listed below.**
   `MergedConfig.EnvVars` is a map, so contributing beneath is simply "set what is absent".
 - `mergePodTemplates` is extracted so the `RawExtension` path and `MergeBeneath` share one strategic
   merge implementation rather than two that can drift.
+- **`reconciler.ConfigError` now carries a `Cause` and implements `Unwrap`**, with the new
+  `WrapConfigError(field, cause)` constructor. It was the only error type in the package without
+  one, so building it from another error flattened the chain to a string and callers lost
+  `errors.Is` / `errors.As` — which is exactly how a product tells "the S3Connection does not exist
+  yet" (`apierrors.IsNotFound`) from a real failure. `NewConfigError` is unchanged.
+- `MergedConfig.JvmArgs` has no `OverridesSpec` field, so a lower layer cannot contribute any;
+  `MergeBeneath` carries the higher config's through for callers that populated them imperatively
+  via `AddJvmArg`.
 
 ### features (declare intent before Build)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,36 @@ changes are listed below.**
     progress markers. A product that needs e.g. cloud LoadBalancer annotations on the client Service
     has no supported way to set them; tracked in #553.
 
+### BREAKING (product config)
+
+- **`GenericReconcilerConfig.ProductConfig` gains a `ctx`, a `client.Client` and an `error`** (#574):
+
+  ```go
+  ProductConfig func(ctx context.Context, c client.Client, cr CR,
+      roleName, roleGroupName string) (*v1alpha1.OverridesSpec, error)
+  ```
+
+  Adopters add the two parameters and `, nil` to the return. `examples/trino-operator` is migrated
+  in this change.
+- **Why.** The hook's own doc says it "may derive from live cluster state", but the signature had no
+  `ctx`, no client and no error return — so it could only be a pure function of the CR, and a failed
+  lookup could only be swallowed (rendering a silently wrong config) or panicked. The products that
+  most needed a product-config layer were exactly the ones it could not serve, which is why **zero**
+  operators used it while two hand-wrote the same workaround.
+- **New: `RoleGroupBuildContext.ApplyProductDefaults(*OverridesSpec)`**, the imperative counterpart
+  for a product that performs its lookup inside `BuildResources` and does not want to repeat it. It
+  folds the layer **beneath** everything already merged.
+- **New: `config.ConfigMerger.MergeBeneath(*MergedConfig, *OverridesSpec)`** implements that fold
+  once, by the merge's own per-dimension rules — config files and env vars per key, CLI/JVM args as
+  a whole, podOverrides through the same strategic merge patch. `Merge` could not express it: it
+  folds left to right, so the lowest layer must be known before the merge runs, which a product
+  computing from a live lookup cannot promise.
+- The env-var half needs no ordering dance. Both operators had discovered that product defaults must
+  not overwrite `envOverrides` and both solved it by **prepending** to the container's env list;
+  `MergedConfig.EnvVars` is a map, so contributing beneath is simply "set what is absent".
+- `mergePodTemplates` is extracted so the `RawExtension` path and `MergeBeneath` share one strategic
+  merge implementation rather than two that can drift.
+
 ### features (declare intent before Build)
 
 - **`RoleGroupBuildContext.MainContainerCustomizer`** (#577) hands a product the assembled primary

--- a/docs/DOC_CHANGELOG.md
+++ b/docs/DOC_CHANGELOG.md
@@ -4,6 +4,23 @@ This document tracks all changes made to the SDK documentation.
 
 ---
 
+## [2026-08-03d] (the product-config seam can read the cluster it documents)
+
+### Core Architecture (`architecture.md`)
+
+- §2.6 records that `ProductConfig` now receives a `ctx` and a client and may fail — "recomputed
+  every reconcile, and may reflect the current state of the cluster" was only true if the hook could
+  *read* the cluster — and that zero adoption was the symptom rather than the disease.
+- Documents `ApplyProductDefaults` as the imperative counterpart for products that already perform
+  the lookup inside `BuildResources`.
+
+### Framework Documentation (`AGENTS.md`)
+
+- §10 carries the new signature, both entry points, and why the env-var precedence rule two
+  operators hand-wrote needs no ordering dance here.
+
+---
+
 ## [2026-08-03c] (declaring intent before Build, instead of patching after)
 
 ### Core Architecture (`architecture.md`)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -167,6 +167,10 @@ convention, and three migrated operators consequently hand-rolled image resoluti
 silent fall back to the handler's static image: running a version nobody asked for is not a safe
 default for a stateful product (the same call as `config.affinity` above).
 
+**The `ProductConfig` hook receives a `ctx` and a client, and may fail.** "Recomputed every reconcile, and may reflect the current state of the cluster" is only true if the hook can *read* the cluster; without those parameters it was a pure function of the CR, so the products that most needed a product-config layer — anything resolving an `S3Connection` reference or a ZooKeeper address — could not use it, and a failed lookup had nowhere to go but a swallowed error or a panic. Zero operators used the hook, which was the symptom rather than the disease.
+
+Products that already perform the lookup inside `BuildResources` use the imperative counterpart, `RoleGroupBuildContext.ApplyProductDefaults`, rather than repeating it: it folds an overrides layer **beneath** everything already merged, by the merge's own per-dimension rules. Two operators had hand-written that fold, identically, along with a second rule for environment variables that the framework can express directly because `MergedConfig.EnvVars` is a map rather than an ordered list.
+
 - **`ProductDefaulter`** is the right place for stable, user-facing **typed Spec defaults** (see §4.3). The value becomes part of the user's persisted Spec and is visible via `kubectl get`.
 - **`ProductConfig`** is the right place for **product-intrinsic and derived config-file content** — e.g. a ZooKeeper connection string built from the actual resources, a quorum peer list from pod ordinals, or a JVM heap sized from the role group's resources. It is *config generation, not defaulting*: computing it at reconcile time (rather than freezing it into the Spec at admission) means an operator upgrade **recomputes** the configuration for existing clusters, and values derived from mutable state stay fresh. It is injected as the lowest merge layer (§2.5), so user overrides still win.
 

--- a/examples/trino-operator/README.md
+++ b/examples/trino-operator/README.md
@@ -301,7 +301,9 @@ per-role container and service ports).
 // ComputeConfig is merged as the LOWEST layer (product < role < role group), so a user's
 // configOverrides always win over it. It is recomputed every reconcile and may derive from
 // live cluster state — here, the discovery URI of the coordinator Service.
-func ComputeConfig(cr *trinov1alpha1.TrinoCluster, roleName, _ string) *commonsv1alpha1.OverridesSpec {
+func ComputeConfig(
+    _ context.Context, _ client.Client, cr *trinov1alpha1.TrinoCluster, roleName, _ string,
+) (*commonsv1alpha1.OverridesSpec, error) {
     port := CoordinatorPort(cr)
 
     props := map[string]string{
@@ -320,7 +322,7 @@ func ComputeConfig(cr *trinov1alpha1.TrinoCluster, roleName, _ string) *commonsv
         ConfigOverrides: map[string]map[string]string{
             "config.properties": props,
         },
-    }
+    }, nil
 }
 ```
 

--- a/examples/trino-operator/internal/controller/trino_handler_test.go
+++ b/examples/trino-operator/internal/controller/trino_handler_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package controller
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -36,7 +38,9 @@ import (
 func buildCtxFor(cr *trinov1alpha1.TrinoCluster, role string, crdOverrides *commonsv1alpha1.OverridesSpec) *reconciler.RoleGroupBuildContext {
 	const group = "default"
 	merger := config.NewConfigMerger()
-	merged := merger.Merge(product.ComputeConfig(cr, role, group), crdOverrides)
+	productCfg, err := product.ComputeConfig(context.Background(), nil, cr, role, group)
+	Expect(err).NotTo(HaveOccurred())
+	merged := merger.Merge(productCfg, crdOverrides)
 
 	return &reconciler.RoleGroupBuildContext{
 		ClusterName:      cr.Name,

--- a/examples/trino-operator/internal/product/config.go
+++ b/examples/trino-operator/internal/product/config.go
@@ -19,8 +19,11 @@ limitations under the License.
 package product
 
 import (
+	"context"
 	"fmt"
 	"slices"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	trinov1alpha1 "github.com/zncdatadev/operator-go/examples/trino-operator/api/v1alpha1"
 	"github.com/zncdatadev/operator-go/examples/trino-operator/internal/constants"
@@ -43,7 +46,13 @@ const (
 // role-specific product knowledge lives (coordinator vs worker) and where values are derived
 // from live cluster state (the discovery URI is built from the coordinator Service the
 // framework will create). It contains no imperative resource construction — purely data.
-func ComputeConfig(cr *trinov1alpha1.TrinoCluster, roleName, _ string) *commonsv1alpha1.OverridesSpec {
+// The ctx and client are unused here — trino's configuration is a pure function of the CR — but
+// they are what the seam exists for: a product resolving an S3Connection reference or a ZooKeeper
+// address does that lookup here and reports a failure through the error return, rather than
+// swallowing it and rendering a silently wrong config.
+func ComputeConfig(
+	_ context.Context, _ client.Client, cr *trinov1alpha1.TrinoCluster, roleName, _ string,
+) (*commonsv1alpha1.OverridesSpec, error) {
 	port := CoordinatorPort(cr)
 
 	props := map[string]string{
@@ -64,7 +73,7 @@ func ComputeConfig(cr *trinov1alpha1.TrinoCluster, roleName, _ string) *commonsv
 		ConfigOverrides: map[string]map[string]string{
 			"config.properties": props,
 		},
-	}
+	}, nil
 }
 
 // CoordinatorPort returns the coordinator HTTP port from the CR or the product default.

--- a/examples/trino-operator/internal/product/config_test.go
+++ b/examples/trino-operator/internal/product/config_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package product_test
 
 import (
+	"context"
+
 	"strings"
 	"testing"
 
@@ -38,7 +40,10 @@ func testCR() *trinov1alpha1.TrinoCluster {
 
 func configProps(t *testing.T, cr *trinov1alpha1.TrinoCluster, role string) map[string]string {
 	t.Helper()
-	ov := product.ComputeConfig(cr, role, "default")
+	ov, err := product.ComputeConfig(context.Background(), nil, cr, role, "default")
+	if err != nil {
+		t.Fatalf("ComputeConfig failed: %v", err)
+	}
 	if ov == nil || ov.ConfigOverrides["config.properties"] == nil {
 		t.Fatalf("ComputeConfig returned no config.properties for role %q", role)
 	}

--- a/pkg/config/merger.go
+++ b/pkg/config/merger.go
@@ -130,6 +130,51 @@ func (m *ConfigMerger) Merge(overrides ...*v1alpha1.OverridesSpec) *MergedConfig
 	return result
 }
 
+// MergeBeneath folds an overrides layer UNDERNEATH an already-merged config: a value the higher
+// layers set is kept, and only what they left unset is contributed.
+//
+// Merge itself cannot express this. It folds *OverridesSpec layers left to right, so the lowest
+// layer must be known before the merge runs — which is exactly what a product computing its config
+// from a live API lookup cannot promise, because the lookup happens inside BuildResources. Both
+// hive-operator and spark-k8s-operator hand-wrote the same "set only keys the user did not set"
+// helper for that reason, byte for byte including its doc comment.
+//
+// The per-dimension rules are the merge's own, applied with the product's layer as the base:
+// config files fold per key, env vars per key, CLI/JVM args as a whole (an empty higher slice means
+// "unset", so the product's is used), and podOverrides through the same strategic merge patch.
+//
+// `higher` is not mutated; the result is a new MergedConfig.
+func (m *ConfigMerger) MergeBeneath(higher *MergedConfig, lower *v1alpha1.OverridesSpec) *MergedConfig {
+	base := m.Merge(lower)
+	if higher == nil {
+		return base
+	}
+
+	result := NewMergedConfig()
+	result.ConfigFiles = m.mergeConfigFiles(base.ConfigFiles, higher.ConfigFiles)
+	result.EnvVars = m.mergeMaps(base.EnvVars, higher.EnvVars)
+	result.CliArgs = m.mergeSlices(base.CliArgs, higher.CliArgs)
+	result.JvmArgs = m.mergeSlices(base.JvmArgs, higher.JvmArgs)
+
+	// The product's pod template is the base and the already-merged one is the patch, which is
+	// what puts the user's podOverrides on top.
+	result.PodOverrides = higher.PodOverrides
+	if base.PodOverrides != nil {
+		merged, err := m.mergePodTemplates(base.PodOverrides, higher.PodOverrides)
+		if err != nil {
+			result.PodOverrideErrors = append(result.PodOverrideErrors, err)
+		} else {
+			result.PodOverrides = merged
+		}
+	}
+
+	// Carry both layers' recorded failures: the caller surfaces them as one set.
+	result.PodOverrideErrors = append(result.PodOverrideErrors, base.PodOverrideErrors...)
+	result.PodOverrideErrors = append(result.PodOverrideErrors, higher.PodOverrideErrors...)
+	result.Logging = higher.Logging
+	return result
+}
+
 // mergeMaps performs deep merge of two maps.
 // Values in the second map override values in the first map.
 func (m *ConfigMerger) mergeMaps(base, override map[string]string) map[string]string {
@@ -222,6 +267,16 @@ func (m *ConfigMerger) mergePodOverrideInto(base *corev1.PodTemplateSpec, overri
 		overridePod = &parsed
 	}
 
+	return m.mergePodTemplates(base, overridePod)
+}
+
+// mergePodTemplates strategic-merges override onto base. Both callers need this — the RawExtension
+// path above after it has decoded its layer, and MergeBeneath, whose "override" is an
+// already-merged template rather than raw JSON — so it lives in one place rather than two that can
+// drift.
+func (m *ConfigMerger) mergePodTemplates(
+	base, overridePod *corev1.PodTemplateSpec,
+) (*corev1.PodTemplateSpec, error) {
 	switch {
 	case base == nil && overridePod == nil:
 		return nil, nil

--- a/pkg/config/merger.go
+++ b/pkg/config/merger.go
@@ -140,8 +140,11 @@ func (m *ConfigMerger) Merge(overrides ...*v1alpha1.OverridesSpec) *MergedConfig
 // helper for that reason, byte for byte including its doc comment.
 //
 // The per-dimension rules are the merge's own, applied with the product's layer as the base:
-// config files fold per key, env vars per key, CLI/JVM args as a whole (an empty higher slice means
+// config files fold per key, env vars per key, CLI args as a whole (an empty higher slice means
 // "unset", so the product's is used), and podOverrides through the same strategic merge patch.
+//
+// JvmArgs has no OverridesSpec field, so the lower layer cannot contribute any; the higher config's
+// are carried through unchanged for callers that populated them imperatively (MergedConfig.AddJvmArg).
 //
 // `higher` is not mutated; the result is a new MergedConfig.
 func (m *ConfigMerger) MergeBeneath(higher *MergedConfig, lower *v1alpha1.OverridesSpec) *MergedConfig {

--- a/pkg/reconciler/errors.go
+++ b/pkg/reconciler/errors.go
@@ -26,18 +26,38 @@ import (
 type ConfigError struct {
 	Field   string
 	Message string
+	// Cause is the underlying failure, when there is one. It was the only error type in this
+	// package without one, so a ConfigError built from another error had to flatten it to a
+	// string — and callers lost errors.Is/errors.As, which is exactly how a product tells an
+	// apierrors.IsNotFound lookup failure from a real one.
+	Cause error
 }
 
 // Error implements error.
 func (e *ConfigError) Error() string {
+	if e.Cause != nil && e.Message == "" {
+		return fmt.Sprintf("config error in field %q: %s", e.Field, e.Cause.Error())
+	}
 	return fmt.Sprintf("config error in field %q: %s", e.Field, e.Message)
 }
+
+// Unwrap exposes the underlying failure to errors.Is and errors.As.
+func (e *ConfigError) Unwrap() error { return e.Cause }
 
 // NewConfigError creates a new ConfigError.
 func NewConfigError(field, message string) *ConfigError {
 	return &ConfigError{
 		Field:   field,
 		Message: message,
+	}
+}
+
+// WrapConfigError creates a ConfigError that carries cause, so errors.Is and errors.As still see
+// through it. Prefer this over NewConfigError(field, err.Error()), which flattens the chain.
+func WrapConfigError(field string, cause error) *ConfigError {
+	return &ConfigError{
+		Field: field,
+		Cause: cause,
 	}
 }
 

--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -170,10 +170,23 @@ type GenericReconcilerConfig[CR common.ClusterResource[CR]] struct {
 	// string built from the actual resources, a quorum peer list from pod ordinals, or a JVM
 	// heap sized from the role group's resources. Computing here, rather than freezing values
 	// into the spec at admission, means operator upgrades propagate config changes to existing
-	// clusters. It is a pure function of the CR and the role/role group identity; returning nil
-	// contributes nothing for that role group.
+	// clusters. Returning a nil spec contributes nothing for that role group.
+	//
+	// The ctx and client are what make "may derive from live cluster state" true rather than
+	// aspirational. Without them the hook could only be a pure function of the CR, so a product
+	// needing an API lookup — resolving an S3Connection reference to an endpoint — could not use
+	// it at all, and had no way to report a failed lookup either: a Get error could only be
+	// swallowed, rendering a silently wrong config, or panicked. Zero operators used the hook,
+	// which was the symptom; the products that needed a product-config layer were exactly the
+	// ones it could not serve.
+	//
+	// A returned error fails the role group. For a product that already performs its lookup
+	// inside BuildResources and does not want to repeat it here, the imperative counterpart is
+	// RoleGroupBuildContext.ApplyProductDefaults.
 	// +optional
-	ProductConfig func(cr CR, roleName, roleGroupName string) *v1alpha1.OverridesSpec
+	ProductConfig func(
+		ctx context.Context, c client.Client, cr CR, roleName, roleGroupName string,
+	) (*v1alpha1.OverridesSpec, error)
 
 	// Dependencies, when set, returns the external objects the CR references (ConfigMaps and
 	// Secrets that the product does not create itself, e.g. a Kerberos keytab Secret or an
@@ -252,7 +265,7 @@ type GenericReconciler[CR common.ClusterResource[CR]] struct {
 	// serviceAccountNameFunc, when set, resolves a per-CR SA name that takes precedence over
 	// the static serviceAccountName (see resolveServiceAccountName).
 	serviceAccountNameFunc func(cr CR) string
-	productConfig          func(cr CR, roleName, roleGroupName string) *v1alpha1.OverridesSpec
+	productConfig          func(ctx context.Context, c client.Client, cr CR, roleName, roleGroupName string) (*v1alpha1.OverridesSpec, error)
 	dependencies           func(cr CR) []Dependency
 }
 
@@ -798,7 +811,10 @@ func (r *GenericReconciler[CR]) reconcileRoleGroup(ctx context.Context, cr CR, r
 	}
 
 	// Build context
-	buildCtx := r.buildRoleGroupContext(cr, roleName, roleSpec, groupName, groupSpec)
+	buildCtx, err := r.buildRoleGroupContext(ctx, cr, roleName, roleSpec, groupName, groupSpec)
+	if err != nil {
+		return NewConfigError(fmt.Sprintf("role %s group %s", roleName, groupName), err.Error())
+	}
 
 	// A podOverrides layer that fails to decode is dropped by the merger so the rest of the
 	// configuration still applies, but dropping a user's override silently is worse than a
@@ -911,13 +927,18 @@ func RoleGroupMarkerLabelKey(clusterName, roleName, roleGroupName string) string
 }
 
 // buildRoleGroupContext creates the build context for a role group.
-func (r *GenericReconciler[CR]) buildRoleGroupContext(cr CR, roleName string, roleSpec *v1alpha1.RoleSpec, groupName string, groupSpec *v1alpha1.RoleGroupSpec) *RoleGroupBuildContext {
+func (r *GenericReconciler[CR]) buildRoleGroupContext(ctx context.Context, cr CR, roleName string, roleSpec *v1alpha1.RoleSpec, groupName string, groupSpec *v1alpha1.RoleGroupSpec) (*RoleGroupBuildContext, error) {
 	// Merge configurations in increasing precedence: product config (lowest) < role < role
 	// group (highest). The product's computed config flows through the same merge pipeline as
 	// CRD overrides, so a value set anywhere in the CRD always wins over it.
 	var productConfig *v1alpha1.OverridesSpec
 	if r.productConfig != nil {
-		productConfig = r.productConfig(cr, roleName, groupName)
+		var err error
+		productConfig, err = r.productConfig(ctx, r.client, cr, roleName, groupName)
+		if err != nil {
+			return nil, fmt.Errorf("computing the product config for role %s group %s: %w",
+				roleName, groupName, err)
+		}
 	}
 	mergedConfig := r.configMerger.Merge(productConfig, roleSpec.GetOverrides(), groupSpec.GetOverrides())
 	// Deep-merge logging (role + role group) once, so both Vector enablement and per-container
@@ -948,7 +969,7 @@ func (r *GenericReconciler[CR]) buildRoleGroupContext(cr CR, roleName string, ro
 		// the SA the reconciler creates. Resolved per CR (per-CR func over static name), and
 		// empty when no SA is configured (backward compatible).
 		ServiceAccountName: r.resolveServiceAccountName(cr),
-	}
+	}, nil
 }
 
 // buildSidecarManager creates a SidecarManager based on CRD configuration.

--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -813,7 +813,7 @@ func (r *GenericReconciler[CR]) reconcileRoleGroup(ctx context.Context, cr CR, r
 	// Build context
 	buildCtx, err := r.buildRoleGroupContext(ctx, cr, roleName, roleSpec, groupName, groupSpec)
 	if err != nil {
-		return NewConfigError(fmt.Sprintf("role %s group %s", roleName, groupName), err.Error())
+		return WrapConfigError(fmt.Sprintf("role %s group %s", roleName, groupName), err)
 	}
 
 	// A podOverrides layer that fails to decode is dropped by the merger so the rest of the

--- a/pkg/reconciler/generic_reconciler_test.go
+++ b/pkg/reconciler/generic_reconciler_test.go
@@ -18,6 +18,7 @@ package reconciler_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -35,6 +36,7 @@ import (
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/tools/record"
@@ -2041,6 +2043,36 @@ var _ = Describe("GenericReconciler ProductConfig", func() {
 			NamespacedName: types.NamespacedName{Namespace: namespace, Name: crName}})
 		Expect(err).To(MatchError(ContainSubstring("could not be resolved")))
 		Expect(captured).To(BeNil(), "no workload is built from a config that failed to compute")
+	})
+
+	It("keeps the lookup's error chain intact", func() {
+		// A product distinguishes "the S3Connection does not exist yet" from a real failure with
+		// k8serrors.IsNotFound. Flattening the cause to a string — which ConfigError forced, being
+		// the one error type in the package without an Unwrap — takes that away.
+		var captured *config.MergedConfig
+		notFound := k8serrors.NewNotFound(
+			schema.GroupResource{Group: "s3.kubedoop.dev", Resource: "s3connections"}, "warehouse")
+
+		cfg := &reconciler.GenericReconcilerConfig[*testutil.MockCluster]{
+			Client:           k8sClient,
+			Scheme:           testScheme,
+			Recorder:         recorder,
+			RoleGroupHandler: newCapturingHandler(&captured),
+			Prototype:        testutil.NewMockCluster("proto", namespace),
+			ProductConfig: func(context.Context, client.Client, *testutil.MockCluster,
+				string, string) (*v1alpha1.OverridesSpec, error) {
+				return nil, fmt.Errorf("resolving the warehouse connection: %w", notFound)
+			},
+		}
+
+		r, err := reconciler.NewGenericReconciler(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = r.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{Namespace: namespace, Name: crName}})
+
+		Expect(err).To(HaveOccurred())
+		Expect(k8serrors.IsNotFound(err)).To(BeTrue(), "errors.As must still reach the cause")
+		Expect(errors.Is(err, notFound)).To(BeTrue())
 	})
 })
 

--- a/pkg/reconciler/generic_reconciler_test.go
+++ b/pkg/reconciler/generic_reconciler_test.go
@@ -1913,7 +1913,8 @@ var _ = Describe("GenericReconciler ProductConfig", func() {
 			Recorder:         recorder,
 			RoleGroupHandler: newCapturingHandler(&captured),
 			Prototype:        testutil.NewMockCluster("proto", namespace),
-			ProductConfig: func(_ *testutil.MockCluster, roleName, _ string) *v1alpha1.OverridesSpec {
+			ProductConfig: func(_ context.Context, _ client.Client, _ *testutil.MockCluster,
+				roleName, _ string) (*v1alpha1.OverridesSpec, error) {
 				overrides := map[string]map[string]string{
 					"config.properties": {
 						"shared":       "from-product",
@@ -1924,7 +1925,7 @@ var _ = Describe("GenericReconciler ProductConfig", func() {
 				if roleName == "coordinator" {
 					overrides["config.properties"]["coordinator"] = "true"
 				}
-				return &v1alpha1.OverridesSpec{ConfigOverrides: overrides}
+				return &v1alpha1.OverridesSpec{ConfigOverrides: overrides}, nil
 			},
 		}
 
@@ -1968,6 +1969,78 @@ var _ = Describe("GenericReconciler ProductConfig", func() {
 		props := captured.ConfigFiles["config.properties"]
 		Expect(props).To(HaveKeyWithValue("shared", "from-crd"))
 		Expect(props).NotTo(HaveKey("product-only"))
+	})
+
+	It("is handed a ctx and a client, so it can read the cluster it is documented to read", func() {
+		// The hook's doc has always said it "may derive from live cluster state". Without a ctx or
+		// a client it could only be a pure function of the CR, so the products that needed a
+		// product-config layer — an S3Connection reference resolved to an endpoint — were exactly
+		// the ones it could not serve. Two of them hand-wrote the same workaround instead.
+		source := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{Name: crName + "-source", Namespace: namespace},
+			Data:       map[string]string{"endpoint": "resolved-from-cluster"},
+		}
+		Expect(k8sClient.Create(ctx, source)).To(Succeed())
+		DeferCleanup(func() { _ = k8sClient.Delete(ctx, source) })
+
+		var captured *config.MergedConfig
+		cfg := &reconciler.GenericReconcilerConfig[*testutil.MockCluster]{
+			Client:           k8sClient,
+			Scheme:           testScheme,
+			Recorder:         recorder,
+			RoleGroupHandler: newCapturingHandler(&captured),
+			Prototype:        testutil.NewMockCluster("proto", namespace),
+			ProductConfig: func(hookCtx context.Context, c client.Client, cr *testutil.MockCluster,
+				_, _ string) (*v1alpha1.OverridesSpec, error) {
+				cm := &corev1.ConfigMap{}
+				if err := c.Get(hookCtx, types.NamespacedName{
+					Namespace: cr.Namespace, Name: cr.Name + "-source"}, cm); err != nil {
+					return nil, err
+				}
+				return &v1alpha1.OverridesSpec{ConfigOverrides: map[string]map[string]string{
+					"config.properties": {
+						"shared":       cm.Data["endpoint"],
+						"product-only": "p",
+					},
+				}}, nil
+			},
+		}
+
+		r, err := reconciler.NewGenericReconciler(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = r.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{Namespace: namespace, Name: crName}})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(captured).NotTo(BeNil())
+		props := captured.ConfigFiles["config.properties"]
+		Expect(props).To(HaveKeyWithValue("product-only", "p"), "the lookup's result reaches the config")
+		Expect(props).To(HaveKeyWithValue("shared", "from-crd"),
+			"and still sits beneath what the user wrote")
+	})
+
+	It("fails the role group when the lookup fails", func() {
+		// Previously a Get error could only be swallowed — rendering a silently wrong config — or
+		// panicked, because the signature had nowhere to put it.
+		var captured *config.MergedConfig
+		cfg := &reconciler.GenericReconcilerConfig[*testutil.MockCluster]{
+			Client:           k8sClient,
+			Scheme:           testScheme,
+			Recorder:         recorder,
+			RoleGroupHandler: newCapturingHandler(&captured),
+			Prototype:        testutil.NewMockCluster("proto", namespace),
+			ProductConfig: func(context.Context, client.Client, *testutil.MockCluster,
+				string, string) (*v1alpha1.OverridesSpec, error) {
+				return nil, fmt.Errorf("the S3Connection reference could not be resolved")
+			},
+		}
+
+		r, err := reconciler.NewGenericReconciler(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		_, err = r.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{Namespace: namespace, Name: crName}})
+		Expect(err).To(MatchError(ContainSubstring("could not be resolved")))
+		Expect(captured).To(BeNil(), "no workload is built from a config that failed to compute")
 	})
 })
 

--- a/pkg/reconciler/role_group_handler.go
+++ b/pkg/reconciler/role_group_handler.go
@@ -491,6 +491,41 @@ func mergeResources(role, group *v1alpha1.ResourcesSpec) *v1alpha1.ResourcesSpec
 	return merged
 }
 
+// ApplyProductDefaults folds an overrides layer UNDERNEATH the already-merged config: a value the
+// user set anywhere in the CRD is kept, and only what they left unset is contributed.
+//
+// It is the imperative half of the product-config seam, for the case GenericReconcilerConfig's
+// ProductConfig hook cannot serve: a product whose configuration depends on an API lookup — an
+// S3Connection reference resolved to an endpoint, a ZooKeeper connection string built from the
+// live resources — does that lookup inside BuildResources, where a ctx and a client already exist,
+// and only then knows what to contribute.
+//
+//	func (h *MyHandler) BuildResources(ctx context.Context, c client.Client, cr *MyCluster,
+//	    buildCtx *reconciler.RoleGroupBuildContext) (*reconciler.RoleGroupResources, error) {
+//	    conn, err := s3.ResolveConnection(ctx, c, cr.Namespace, inline, ref)
+//	    if err != nil {
+//	        return nil, err
+//	    }
+//	    buildCtx.ApplyProductDefaults(&commonsv1alpha1.OverridesSpec{
+//	        ConfigOverrides: map[string]map[string]string{"hive-site.xml": conn.S3AProperties()},
+//	    })
+//	    return h.BaseRoleGroupHandler.BuildResources(ctx, c, cr, buildCtx)
+//	}
+//
+// hive-operator and spark-k8s-operator each hand-wrote the same "set only keys the user did not
+// set" helper for exactly this, byte for byte including its doc comment, and both then discovered
+// the same second rule for environment variables — that product defaults must not overwrite
+// envOverrides. Both rules are the framework's own merge precedence, so they belong here rather
+// than being re-derived per product.
+//
+// A nil layer, or a nil MergedConfig, is a no-op.
+func (c *RoleGroupBuildContext) ApplyProductDefaults(defaults *v1alpha1.OverridesSpec) {
+	if c == nil || defaults == nil || c.MergedConfig == nil {
+		return
+	}
+	c.MergedConfig = config.NewConfigMerger().MergeBeneath(c.MergedConfig, defaults)
+}
+
 // RoleGroupHandler is the interface that product operators must implement
 // to define how resources are built for each role group.
 //

--- a/pkg/reconciler/role_group_handler_test.go
+++ b/pkg/reconciler/role_group_handler_test.go
@@ -20,6 +20,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
+	"github.com/zncdatadev/operator-go/pkg/config"
 	"github.com/zncdatadev/operator-go/pkg/reconciler"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/utils/ptr"
@@ -132,5 +133,101 @@ var _ = Describe("MergeRoleGroupConfig leaf granularity", func() {
 		// handler edit corrupt the object the reconciler later compares against.
 		Expect(role.Resources.CPU.Max.String()).To(Equal("2"))
 		Expect(group.Resources.CPU.Min).NotTo(BeNil())
+	})
+})
+
+var _ = Describe("ApplyProductDefaults", func() {
+	// The imperative half of the product-config seam: for a product whose configuration depends on
+	// an API lookup, which happens inside BuildResources where a ctx and a client already exist.
+	// hive-operator and spark-k8s-operator each hand-wrote the same "set only keys the user did not
+	// set" helper, byte for byte including its doc comment.
+
+	newCtx := func(user *v1alpha1.OverridesSpec) *reconciler.RoleGroupBuildContext {
+		return &reconciler.RoleGroupBuildContext{
+			MergedConfig: config.NewConfigMerger().Merge(user),
+		}
+	}
+
+	It("contributes only what the user left unset", func() {
+		buildCtx := newCtx(&v1alpha1.OverridesSpec{
+			ConfigOverrides: map[string]map[string]string{
+				"hive-site.xml": {"fs.s3a.endpoint": "from-user"},
+			},
+		})
+
+		buildCtx.ApplyProductDefaults(&v1alpha1.OverridesSpec{
+			ConfigOverrides: map[string]map[string]string{
+				"hive-site.xml": {
+					"fs.s3a.endpoint":          "from-product",
+					"fs.s3a.path.style.access": "true",
+				},
+				"core-site.xml": {"hadoop.tmp.dir": "/tmp"},
+			},
+		})
+
+		hive := buildCtx.MergedConfig.ConfigFiles["hive-site.xml"]
+		Expect(hive).To(HaveKeyWithValue("fs.s3a.endpoint", "from-user"), "the user always wins")
+		Expect(hive).To(HaveKeyWithValue("fs.s3a.path.style.access", "true"), "and the rest is contributed")
+		Expect(buildCtx.MergedConfig.ConfigFiles).To(HaveKey("core-site.xml"), "a whole new file too")
+	})
+
+	It("applies the same rule to env vars, with no ordering dance", func() {
+		// Both operators independently discovered that product env must not overwrite envOverrides,
+		// and both solved it by PREPENDING to the container's env list. Contributing beneath the
+		// merged config is a map operation, so the ordering question never arises.
+		buildCtx := newCtx(&v1alpha1.OverridesSpec{
+			EnvOverrides: map[string]string{"JAVA_OPTS": "from-user"},
+		})
+
+		buildCtx.ApplyProductDefaults(&v1alpha1.OverridesSpec{
+			EnvOverrides: map[string]string{"JAVA_OPTS": "from-product", "HIVE_HOME": "/opt/hive"},
+		})
+
+		Expect(buildCtx.MergedConfig.EnvVars).To(HaveKeyWithValue("JAVA_OPTS", "from-user"))
+		Expect(buildCtx.MergedConfig.EnvVars).To(HaveKeyWithValue("HIVE_HOME", "/opt/hive"))
+	})
+
+	It("supplies CLI args only when the user set none", func() {
+		// cliOverrides replace rather than accumulate (§15), and an empty override means "unset".
+		withUser := newCtx(&v1alpha1.OverridesSpec{CliOverrides: []string{"--from-user"}})
+		withUser.ApplyProductDefaults(&v1alpha1.OverridesSpec{CliOverrides: []string{"--from-product"}})
+		Expect(withUser.MergedConfig.CliArgs).To(Equal([]string{"--from-user"}))
+
+		withoutUser := newCtx(nil)
+		withoutUser.ApplyProductDefaults(&v1alpha1.OverridesSpec{CliOverrides: []string{"--from-product"}})
+		Expect(withoutUser.MergedConfig.CliArgs).To(Equal([]string{"--from-product"}))
+	})
+
+	It("is a no-op for a nil layer or a context with no merged config", func() {
+		buildCtx := newCtx(&v1alpha1.OverridesSpec{
+			EnvOverrides: map[string]string{"KEEP": "me"},
+		})
+		buildCtx.ApplyProductDefaults(nil)
+		Expect(buildCtx.MergedConfig.EnvVars).To(HaveKeyWithValue("KEEP", "me"))
+
+		bare := &reconciler.RoleGroupBuildContext{}
+		Expect(func() {
+			bare.ApplyProductDefaults(&v1alpha1.OverridesSpec{EnvOverrides: map[string]string{"X": "1"}})
+		}).NotTo(Panic())
+		Expect(bare.MergedConfig).To(BeNil())
+	})
+
+	It("accumulates across calls, each landing beneath what is already merged", func() {
+		// A product resolving two independent things (an S3 endpoint, a metastore URI) contributes
+		// each as it learns it, and neither may displace the user or the earlier contribution.
+		buildCtx := newCtx(&v1alpha1.OverridesSpec{
+			ConfigOverrides: map[string]map[string]string{"hive-site.xml": {"a": "from-user"}},
+		})
+		buildCtx.ApplyProductDefaults(&v1alpha1.OverridesSpec{
+			ConfigOverrides: map[string]map[string]string{"hive-site.xml": {"a": "first", "b": "first"}},
+		})
+		buildCtx.ApplyProductDefaults(&v1alpha1.OverridesSpec{
+			ConfigOverrides: map[string]map[string]string{"hive-site.xml": {"b": "second", "c": "second"}},
+		})
+
+		hive := buildCtx.MergedConfig.ConfigFiles["hive-site.xml"]
+		Expect(hive).To(HaveKeyWithValue("a", "from-user"))
+		Expect(hive).To(HaveKeyWithValue("b", "first"), "the earlier contribution outranks the later one")
+		Expect(hive).To(HaveKeyWithValue("c", "second"))
 	})
 })

--- a/pkg/reconciler/role_group_handler_test.go
+++ b/pkg/reconciler/role_group_handler_test.go
@@ -198,6 +198,20 @@ var _ = Describe("ApplyProductDefaults", func() {
 		Expect(withoutUser.MergedConfig.CliArgs).To(Equal([]string{"--from-product"}))
 	})
 
+	It("carries JVM args through, which no overrides layer can contribute", func() {
+		// OverridesSpec has no JVM-args field, so the lower layer cannot supply any; a caller that
+		// populated them imperatively (MergedConfig.AddJvmArg) must not lose them.
+		buildCtx := newCtx(nil)
+		buildCtx.MergedConfig.AddJvmArg("-Xmx4g")
+
+		buildCtx.ApplyProductDefaults(&v1alpha1.OverridesSpec{
+			EnvOverrides: map[string]string{"HIVE_HOME": "/opt/hive"},
+		})
+
+		Expect(buildCtx.MergedConfig.JvmArgs).To(Equal([]string{"-Xmx4g"}))
+		Expect(buildCtx.MergedConfig.EnvVars).To(HaveKeyWithValue("HIVE_HOME", "/opt/hive"))
+	})
+
 	It("is a no-op for a nil layer or a context with no merged config", func() {
 		buildCtx := newCtx(&v1alpha1.OverridesSpec{
 			EnvOverrides: map[string]string{"KEEP": "me"},


### PR DESCRIPTION
Closes #574.

## The gap

`ProductConfig`'s own doc says it "may derive from live cluster state". The signature made that impossible:

```go
ProductConfig func(cr CR, roleName, roleGroupName string) *v1alpha1.OverridesSpec
```

No `ctx`, no client, no `error`. So it could only be a pure function of the CR, and a failed lookup could only be **swallowed** — rendering a silently wrong config — or panicked. The products that most needed a product-config layer were exactly the ones it could not serve, which is why **zero** operators used the hook while **two** hand-wrote the same workaround, byte for byte including its doc comment.

## Both halves, one implementation

**Declarative** — the hook, now able to do what it documents:

```go
ProductConfig func(ctx context.Context, c client.Client, cr CR,
    roleName, roleGroupName string) (*v1alpha1.OverridesSpec, error)
```

**Imperative** — `RoleGroupBuildContext.ApplyProductDefaults(*OverridesSpec)`, for a product that already performs its lookup inside `BuildResources` and should not repeat it:

```go
conn, err := s3.ResolveConnection(ctx, c, cr.Namespace, inline, ref)
if err != nil { return nil, err }
buildCtx.ApplyProductDefaults(&commonsv1alpha1.OverridesSpec{
    ConfigOverrides: map[string]map[string]string{"hive-site.xml": conn.S3AProperties()},
})
```

Two entry points, **one fold**: `config.ConfigMerger.MergeBeneath`. `Merge` cannot express "beneath" — it folds `*OverridesSpec` layers left to right, so the lowest layer must be known *before* the merge runs, which a product computing from a live lookup cannot promise. `MergeBeneath` applies the merge's own per-dimension rules with the product's layer as the base.

**The env-var half needs no ordering dance.** Both operators discovered that product defaults must not overwrite `envOverrides`, and both solved it by **prepending** to the container's env list. `MergedConfig.EnvVars` is a map, so contributing beneath is simply "set what is absent" — the workaround becomes unnecessary rather than blessed.

## Migration

`examples/trino-operator` **is** an adopter (the issue's "zero operators" counted downstream only), so it is migrated here: the handler, both call sites in its tests, and the README, which showed the old signature. Adopters add the two parameters and `, nil`.

## Verification

- Two specs for the hook (a real API read landing beneath the user's overrides; a lookup failure failing the role group and building nothing) and five for `ApplyProductDefaults`, including repeated calls accumulating with the earlier contribution outranking the later.
- **Two mutations killed**: `MergeBeneath` applying the layer on top (precedence inverted), and the `ProductConfig` error swallowed.
- All six gates green with exit codes checked: `make lint`, `make test` (18 packages), `make verify-generate`, plus the examples module's `make lint` and `make test`.

## Refactor worth noting

`mergePodTemplates` is extracted from `mergePodOverrideInto` so the `RawExtension` path and `MergeBeneath` share **one** strategic merge implementation rather than two that can drift.