### PR TITLE
feat(constant): render the JMX java agent option, and write down the handler contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ operator-go/
 │   ├── builder/                  # Fluent resource builders (see pkg/builder/AGENTS.md)
 │   ├── common/                   # Core interfaces, extensions, errors
 │   ├── config/                   # Config file generation and override merging (see pkg/config/AGENTS.md)
-│   ├── constant/                 # Kubedoop paths, labels, domains, restarter annotations
+│   ├── constant/                 # Kubedoop paths, labels, domains, restarter annotations, JMX agent
 │   ├── listener/                 # Listener provisioner (CSI volume registration)
 │   ├── productlogging/           # Product logging config generation (Log4j, Log4j2, Logback, Python)
 │   ├── reconciler/               # Reconciliation framework (see pkg/reconciler/AGENTS.md)
@@ -571,6 +571,39 @@ stated level overrides. The effective default (root logger `INFO`, no appender t
 the renderers at consumption time.
 
 Default config file names come from each generator's `DefaultFileName()`: `logback.xml`, `log4j.properties`, `log4j2.properties` and — deliberately **not** `logging.py` — `log_config.py`, since a config directory on `sys.path` would otherwise shadow the standard library's `logging` module. `ContainerLogging.FileName` overrides the name per container. The rolling *log* file the Vector sources glob is separate and framework-owned: `<KubedoopLogDir>/<lowercased container>/<container><suffix>`, with `.log4j.xml` (log4j/logback), `.log4j2.xml` (log4j2) or `.py.json` (python) selecting the Vector edge parser; `ContainerLogging.LogFileName` may rename it only if the suffix survives and it stays a bare file name.
+
+### 9b. Image Conventions the Framework Requires
+
+Two conventions the kubedoop images define, that the framework's own behaviour depends on, and that
+every product previously re-typed as string literals.
+
+**The JMX exporter runs as a java agent.** `constant.KubedoopJmxAgentJar` is the unversioned symlink
+the images provide, and `constant.JMXJavaAgentOpt(port, configFile)` renders the JVM option:
+
+```go
+constant.JMXJavaAgentOpt(8081, "config.yaml")
+// -javaagent:/kubedoop/jmx/jmx_prometheus_javaagent.jar=8081:/kubedoop/jmx/config.yaml
+```
+
+The config file is a **parameter**, not a constant: the hadoop image ships no `config.yaml`, only
+`namenode.yaml` / `datanode.yaml` / `journalnode.yaml`, because the metrics worth exporting differ
+per role. This is a different mechanism from `pkg/sidecar/jmx_exporter.go`, which runs
+`jmx_prometheus_httpserver.jar` from `/opt/jmx_exporter` as a separate container — a path no
+kubedoop image contains.
+
+**The config mount is read-only.** The generated ConfigMap is mounted read-only at
+`BaseRoleGroupHandler.ConfigMountPath` (default `constant.KubedoopConfigDirMount`), so a product
+whose start-up rewrites a config file must copy it to a writable directory first:
+
+```sh
+mkdir -p /kubedoop/config/
+cp -RL /kubedoop/mount/config/* /kubedoop/config/
+```
+
+`-L` is load-bearing: a ConfigMap volume is a farm of symlinks into a hidden `..data/` directory, so
+a copy that preserves them leaves dangling links. The SDK ships no helper for this — the existing
+call sites disagree on flags and the mount path is configurable — but the requirement is now stated
+in `docs/architecture.md` §4.1.5 rather than discoverable only by reading a sibling operator.
 
 ### 10. Product Config (`ProductConfig`)
 Products contribute their computed configuration **as data through the same merge pipeline as CRD overrides**, instead of imperatively constructing resources. Set the optional `ProductConfig` field on `GenericReconcilerConfig` — a pure function returning an `*v1alpha1.OverridesSpec` (the same shape users write in the CRD):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,35 @@ changes are listed below.**
     progress markers. A product that needs e.g. cloud LoadBalancer annotations on the client Service
     has no supported way to set them; tracked in #553.
 
+### features (image conventions)
+
+- **`constant.KubedoopJmxAgentJar` and `constant.JMXJavaAgentOpt(port, configFile)`** render the
+  `-javaagent` option six operators hand-build today (#578). The config file is a **parameter**
+  rather than a baked-in `config.yaml`: the hadoop image ships no `config.yaml`, only
+  `namenode.yaml` / `datanode.yaml` / `journalnode.yaml`, so baking it in would have excluded the
+  product with the most roles.
+- This is a different mechanism from `pkg/sidecar/jmx_exporter.go`, which runs
+  `jmx_prometheus_httpserver.jar` from `/opt/jmx_exporter` as a separate container — **a path no
+  kubedoop image contains**, so that provider cannot run against a kubedoop product image as
+  `SetProductImage` wires it. Filed separately; not changed here.
+- **No `CopyMountedConfigScript` helper**, which the issue also proposed. The read-only config mount
+  is real and is now documented, but the nine existing copy sites across ten operators disagree on
+  flags and paths and `ConfigMountPath` is configurable, so a helper would be wrong for most callers
+  or so parameterised it saves nothing. The transferable knowledge — that `-L` is required because a
+  ConfigMap volume is a symlink farm into `..data/` — is documented instead.
+
+### docs (the role group handler contract)
+
+- **`docs/architecture.md` §4.1.5 "Writing a Role Group Handler"** (#579): the build-context
+  read/write split, what a nil `RoleGroupResources` field instructs rather than omits, the container
+  contract, the read-only config mount, the ways to fail a build, and what a handler that does not
+  embed `BaseRoleGroupHandler` must reproduce.
+- Three doc-vs-code corrections: `stopped` is forced in the base handler and not the reconciler; the
+  PodDisruptionBudget is role-level, not per role group; and `BuildResources`'s doc comment no
+  longer tells implementers to "Build PDB if needed".
+- `WithSidecarManager` is documented as **inert under the reconciler**, which always supplies a
+  non-nil `SidecarManager` on the build context.
+
 ### BREAKING (product config)
 
 - **`GenericReconcilerConfig.ProductConfig` gains a `ctx`, a `client.Client` and an `error`** (#574):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -135,9 +135,9 @@ changes are listed below.**
   read/write split, what a nil `RoleGroupResources` field instructs rather than omits, the container
   contract, the read-only config mount, the ways to fail a build, and what a handler that does not
   embed `BaseRoleGroupHandler` must reproduce.
-- Three doc-vs-code corrections: `stopped` is forced in the base handler and not the reconciler; the
-  PodDisruptionBudget is role-level, not per role group; and `BuildResources`'s doc comment no
-  longer tells implementers to "Build PDB if needed".
+- Two doc-vs-code corrections: `stopped` is forced in the base handler and not the reconciler, and
+  the PodDisruptionBudget is role-level rather than per role group. A third — `BuildResources`'s
+  stale "5. Build PDB if needed" — is left to PR #592, which already fixes it.
 - `WithSidecarManager` is documented as **inert under the reconciler**, which always supplies a
   non-nil `SidecarManager` on the build context.
 

--- a/docs/DOC_CHANGELOG.md
+++ b/docs/DOC_CHANGELOG.md
@@ -29,9 +29,11 @@ This document tracks all changes made to the SDK documentation.
 
 ### Go doc comments
 
-- `RoleGroupHandler.BuildResources`'s "5. Build PDB if needed" was stale — the framework's PDB is
-  role-level — and now states the nil-means-delete rule and points at §4.1.5.
 - `BaseRoleGroupHandler.ConfigMountPath` states the mount is read-only and what that costs.
+- `RoleGroupHandler.BuildResources`'s stale "5. Build PDB if needed" is deliberately NOT touched
+  here: PR #592 already fixes it, and duplicating the fix would only produce a conflict. §4.1.5
+  carries the part that PR does not — that a nil `RoleGroupResources` field is an instruction to
+  delete rather than an omission.
 
 ---
 

--- a/docs/DOC_CHANGELOG.md
+++ b/docs/DOC_CHANGELOG.md
@@ -4,6 +4,37 @@ This document tracks all changes made to the SDK documentation.
 
 ---
 
+## [2026-08-03e] (the handler contract stops being source-only)
+
+### Core Architecture (`architecture.md`)
+
+- New **§4.1.5 Writing a Role Group Handler**, the section #579 asks for: the build-context
+  read/write split (12 fields the framework writes, 9 the handler does), what a nil
+  `RoleGroupResources` field *instructs* rather than omits, the container contract (name resolution
+  before `Build()`, the `Ports[0]` readiness probe, the reserved `config`/`data` volume names,
+  `JvmArgs` reaching nothing), the read-only config mount, the eleven ways to fail a build, and a
+  four-item checklist for a handler that does not embed `BaseRoleGroupHandler`.
+- **Three doc-vs-code corrections found while writing it.** §4.11.2 attributed the `stopped`
+  replica forcing to the Reconciler; it is in `BaseRoleGroupHandler.buildStatefulSet`, which is
+  exactly what a non-embedding handler has to reproduce. The terminology section said a RoleGroup
+  maps to a StatefulSet "and associated Service, ConfigMap, PDB" — the PDB is **role**-level.
+- Records that `BaseRoleGroupHandler.WithSidecarManager` is **inert under the reconciler**, which
+  always supplies a non-nil manager on the build context.
+
+### Framework Documentation (`AGENTS.md`)
+
+- New §9b for the two image conventions: the JMX java agent and the read-only config mount, both
+  with the reason the obvious simplification is wrong (per-role JMX configs; `cp -RL` and the
+  `..data/` symlink farm).
+
+### Go doc comments
+
+- `RoleGroupHandler.BuildResources`'s "5. Build PDB if needed" was stale — the framework's PDB is
+  role-level — and now states the nil-means-delete rule and points at §4.1.5.
+- `BaseRoleGroupHandler.ConfigMountPath` states the mount is read-only and what that costs.
+
+---
+
 ## [2026-08-03d] (the product-config seam can read the cluster it documents)
 
 ### Core Architecture (`architecture.md`)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,7 +30,7 @@ This document systematically expounds the design philosophy, architectural layer
     - `config`: Workload runtime configuration (resources, affinity, logging), serves as defaults for RoleGroups and CAN be inherited and overridden.
 
 - **RoleGroup**
-  - The physical unit of deployment and resource isolation under a Role. Each RoleGroup maps directly to a Kubernetes `StatefulSet` (and associated Service, ConfigMap, PDB). This allows a single Role to be partitioned into multiple groups with distinct hardware specifications (CPU/Memory), replica counts, or specialized configurations (e.g., a "high-performance" DataNode group vs. a "standard" group).
+  - The physical unit of deployment and resource isolation under a Role. Each RoleGroup maps directly to a Kubernetes `StatefulSet` (and associated Services and ConfigMap; the PodDisruptionBudget is **role**-level, covering every group of the role — see §4.1.5). This allows a single Role to be partitioned into multiple groups with distinct hardware specifications (CPU/Memory), replica counts, or specialized configurations (e.g., a "high-performance" DataNode group vs. a "standard" group).
 
 - **Naming**
   - Role and RoleGroup names are **identifiers, not labels**: the framework derives the name of every resource it builds (`<cluster>-<role>-<group>`), the value of several `app.kubernetes.io/*` labels, and a label *key* from them. They are therefore constrained to lowercase RFC 1123 labels and validated at admission, so a name that cannot become a Kubernetes identifier is rejected where the user can act on it rather than partway through a reconcile.
@@ -336,6 +336,55 @@ Handler fields are still the right home for invariant configuration — this is 
 | `ListenerClass` | patching `Service.Spec.Type` after the fact | one shared `listener.ServiceTypeFor` mapping instead of a three-way switch re-derived per product |
 
 Both fail loudly: a customizer that returns an error, or that changes the image (resolved once and already propagated to the sidecars), fails the role group with a `*ValidationError` rather than shipping a workload missing what the product meant to set.
+
+### 4.1.5 Writing a Role Group Handler
+
+§4.1.4 covers a handler's *lifetime*; this covers its *contract*. Everything below was source-only before it was written down, which is why six operators independently rediscovered parts of it by reading each other's code.
+
+#### The build context is the whole input, and half of it is writable
+
+`BuildResources` receives no CR fields it has not been handed: `buildStatefulSet` takes `_ client.Client, _ CR` and reads nothing from either. Everything CR-derived reaches the framework through `RoleGroupBuildContext`, and the fields split into two kinds:
+
+| the framework writes, the handler reads | the handler writes before delegating |
+| --- | --- |
+| `ClusterName`, `ClusterNamespace`, `ClusterSpec`, `RoleName`, `RoleSpec`, `RoleGroupName`, `RoleGroupSpec`, `ResourceName`, `ServiceAccountName`, `MergedConfig`, `VectorAggregatorAddress`, `VectorLogPipelineActive` | `Image`, `ImagePullPolicy`, `ContainerPorts`, `ServicePorts`, `ListenerClass`, `MainContainerCustomizer`, `VolumeProviders`, `ClusterLabels`, and `MergedConfig` via `ApplyProductDefaults` |
+
+`ClusterLabels` is a materialised clone and is **never nil**, so a handler may add to it unconditionally; whatever it holds is merged into every built resource's metadata and pod template. `SidecarManager` is always non-nil under the reconciler — which makes `BaseRoleGroupHandler.WithSidecarManager` inert on that path, and useful only to a product that calls `BuildResources` itself.
+
+#### What comes back, and what a nil field means
+
+`RoleGroupResources` is not a bag of optional outputs. The apply path treats **nil as an instruction**, not as "leave it alone": a nil `MetricsService` or `PodDisruptionBudget` makes the framework *delete* the corresponding live object, because that is how a role group that stops declaring one is converged. `ExtraResources` carries arbitrary GVKs, which must be registered in the reconciler's scheme and live in the CR's namespace — the framework sets a controller owner reference, and a cross-namespace owner is rejected by Kubernetes.
+
+#### The container contract
+
+- The primary container's name resolves `RoleMainContainerName[role]` → `MainContainerName` → the role group's resource name, and must be settled **before** `Build()`: `podOverrides` are strategic-merged by container name, so a later rename leaves the user's override appended as a phantom, image-less container.
+- A **readiness** probe is generated on `Ports[0]`, so the first entry of `ContainerPorts` is part of the contract — put the port that means "this pod can serve" first. **No liveness probe is ever generated**; `builder.DefaultTCPLivenessProbe` is the opt-in.
+- `config` and `data` are reserved pod volume/mount names. A `VolumeProvider` reusing either produces a pod the API server rejects.
+- `MergedConfig.CliArgs` reaches the container as `args`; `MergedConfig.JvmArgs` reaches **nothing** — the framework merges it and never renders it, so a product populating it must render it itself.
+
+#### The config mount is read-only
+
+The generated ConfigMap is mounted **read-only** at `ConfigMountPath` (default `constant.KubedoopConfigDirMount`, `/kubedoop/mount/config/`). A product whose start-up rewrites a config file — Kerberos realm substitution, credential interpolation — must copy it to a writable directory first, conventionally `constant.KubedoopConfigDir` (`/kubedoop/config/`):
+
+```sh
+mkdir -p /kubedoop/config/
+cp -RL /kubedoop/mount/config/* /kubedoop/config/
+```
+
+`-L` is the part worth knowing: a ConfigMap volume is a farm of symlinks into a hidden `..data/` directory, so a copy that preserves symlinks produces dangling links at the destination. This is a *framework consequence* with no framework helper, and it is stated here because it was discoverable only by reading a sibling operator's start script.
+
+#### Ways to fail the build
+
+Eleven causes across twelve sites inside `BaseRoleGroupHandler.BuildResources`. Two produce a `*ValidationError` — a `podOverrides` mount that displaces a framework-owned one, and a `MainContainerCustomizer` that errors or changes the image — and the rest are plain wrapped errors that the reconciler re-wraps as a `*ResourceBuildError`. All of them fail one role group, not the pass: role iteration is best-effort and sorted (§4.4).
+
+#### If you do not embed `BaseRoleGroupHandler`
+
+A handler implementing the interface directly inherits none of the conventions, and four of them are load-bearing:
+
+1. the headless Service must be named `<ResourceName>-headless` — the StatefulSet's `serviceName` is derived, and it is immutable;
+2. the pod must mount the ConfigMap named `buildCtx.ResourceName`, which is what the framework's own ConfigMap is called;
+3. `clusterOperation.stopped` must force replicas to 0 — it is implemented in the base handler, not in the reconciler;
+4. `RoleNameProvider`, `LoggingProducerProvider` and `BuildRolePodDisruptionBudget` are optional capability interfaces the reconciler type-asserts for; not implementing them silently disables the role-name typo warning, the Vector wiring and the role-level PDB.
 
 ## 4.2 Extension Point Mechanism Module
 
@@ -751,7 +800,7 @@ Day-2 operations (maintenance, debugging, emergency stop) require safe and predi
   - **Mechanism**: The Reconciler checks this flag at the very beginning of the loop, before any resource mutation (ServiceAccount provisioning, PreReconcile extensions, role reconciliation). If true, it surfaces the dedicated **`Paused`** condition — with `Degraded=False`, because a maintenance window is not a fault (§ status conditions) — then skips all resource reconciliation for that loop, leaving managed resources untouched while still re-reading the live workloads so the health conditions stay current.
   - **Use Case**: Allows admins to manually modify underlying K8s resources (e.g., patching a StatefulSet for debugging) without the Operator reverting changes immediately.
 - **Graceful Stop (`stopped: true`)**:
-  - **Mechanism**: The Reconciler scales all RoleGroup StatefulSets to 0 replicas.
+  - **Mechanism**: `BaseRoleGroupHandler.buildStatefulSet` forces the replica count to 0 for every RoleGroup — in the *handler*, not the reconciler, which matters to a product that implements `RoleGroupHandler` directly and must reproduce it (§4.1.5).
   - **Persistence**: Crucially, **PVCs (Persistent Volume Claims) and ConfigMaps are PRESERVED**. This ensures data safety while freeing up compute resources.
 - **Graceful Shutdown**:
   - **Mechanism**: The `gracefulShutdownTimeout` field configures the `terminationGracePeriodSeconds` of the Pod.

--- a/pkg/constant/jmx.go
+++ b/pkg/constant/jmx.go
@@ -1,0 +1,57 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constant
+
+import "strconv"
+
+// The Prometheus JMX exporter, as the kubedoop JVM images actually ship it.
+//
+// Every kubedoop image carrying the exporter installs the versioned jar under KubedoopJmxDir and
+// symlinks it to the unversioned name below, so a product operator can reference it without
+// knowing the version. The exporter runs as a JAVA AGENT inside the product's own JVM.
+//
+// This is NOT what pkg/sidecar/jmx_exporter.go models. That provider runs
+// `jmx_prometheus_httpserver.jar` from `/opt/jmx_exporter` as a separate container, which is a
+// different deployment of the same upstream project and a path no kubedoop image contains. The
+// framework abstracted the variant nobody deploys and left the one everybody deploys as a string
+// literal in six operators; these constants close that half.
+const (
+	// KubedoopJmxAgentJar is the Prometheus JMX exporter java agent, at the unversioned symlink
+	// the images provide.
+	KubedoopJmxAgentJar = KubedoopJmxDir + "jmx_prometheus_javaagent.jar"
+)
+
+// JMXJavaAgentOpt renders the `-javaagent` JVM option that starts the exporter on the given port
+// with the given config file, which is resolved relative to KubedoopJmxDir:
+//
+//	constant.JMXJavaAgentOpt(8081, "config.yaml")
+//	// -javaagent:/kubedoop/jmx/jmx_prometheus_javaagent.jar=8081:/kubedoop/jmx/config.yaml
+//
+// # Why the config file is a parameter rather than a constant
+//
+// It is tempting to bake in "config.yaml", and five of the six operators that hand-build this
+// string would be satisfied by that. HDFS would not: the hadoop image ships no config.yaml at all,
+// only namenode.yaml, datanode.yaml and journalnode.yaml, because the metrics worth exporting
+// differ per role. A helper that could not express that would have excluded the one product with
+// the most roles, so the file name stays the caller's to choose.
+//
+// The port is the caller's too. It is the port the agent listens on for scrapes, so it must match
+// whatever container port and metrics Service the product declares; the framework has no way to
+// know it.
+func JMXJavaAgentOpt(port int32, configFile string) string {
+	return "-javaagent:" + KubedoopJmxAgentJar + "=" + strconv.Itoa(int(port)) + ":" + KubedoopJmxDir + configFile
+}

--- a/pkg/constant/jmx_test.go
+++ b/pkg/constant/jmx_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package constant_test
+
+import (
+	"testing"
+
+	"github.com/zncdatadev/operator-go/pkg/constant"
+)
+
+func TestJMXJavaAgentOpt(t *testing.T) {
+	// The exact string six operators hand-build today. It is asserted literally because the whole
+	// value of the helper is that every product emits the same bytes.
+	got := constant.JMXJavaAgentOpt(8081, "config.yaml")
+	want := "-javaagent:/kubedoop/jmx/jmx_prometheus_javaagent.jar=8081:/kubedoop/jmx/config.yaml"
+	if got != want {
+		t.Errorf("JMXJavaAgentOpt(8081, %q) = %q, want %q", "config.yaml", got, want)
+	}
+}
+
+func TestJMXJavaAgentOptPerRoleConfig(t *testing.T) {
+	// HDFS is why the config file is a parameter: the hadoop image ships no config.yaml, only
+	// per-role files, because the metrics worth exporting differ per role. Baking the name in
+	// would have excluded the product with the most roles.
+	for _, name := range []string{"namenode.yaml", "datanode.yaml", "journalnode.yaml"} {
+		got := constant.JMXJavaAgentOpt(8183, name)
+		want := "-javaagent:/kubedoop/jmx/jmx_prometheus_javaagent.jar=8183:/kubedoop/jmx/" + name
+		if got != want {
+			t.Errorf("JMXJavaAgentOpt(8183, %q) = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func TestKubedoopJmxAgentJar(t *testing.T) {
+	// The unversioned symlink the images provide, so a product never names a version.
+	if constant.KubedoopJmxAgentJar != "/kubedoop/jmx/jmx_prometheus_javaagent.jar" {
+		t.Errorf("KubedoopJmxAgentJar = %q", constant.KubedoopJmxAgentJar)
+	}
+	if got := constant.KubedoopJmxDir; got != "/kubedoop/jmx/" {
+		t.Errorf("KubedoopJmxDir = %q", got)
+	}
+}

--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -148,6 +148,12 @@ type BaseRoleGroupHandler[CR common.ClusterInterface] struct {
 	// container. Products whose application reads config from a specific directory (e.g.
 	// "/etc/trino") set this. Defaults to the kubedoop-canonical config mount path
 	// (constant.KubedoopConfigDirMount) when empty.
+	//
+	// The mount is READ-ONLY. A product whose start-up rewrites a config file (Kerberos realm
+	// substitution, credential interpolation) must copy it to a writable directory first —
+	// conventionally constant.KubedoopConfigDir — with `cp -RL`: a ConfigMap volume is a farm of
+	// symlinks into a hidden ..data/ directory, so a copy that preserves symlinks leaves dangling
+	// links at the destination. See docs/architecture.md §4.1.5.
 	ConfigMountPath string
 
 	// MainContainerName, when set, renames the primary (first) container of the StatefulSet.

--- a/pkg/reconciler/role_group_handler.go
+++ b/pkg/reconciler/role_group_handler.go
@@ -544,17 +544,7 @@ type RoleGroupHandler[CR common.ClusterInterface] interface {
 	// 2. Build product-specific ConfigMap data
 	// 3. Build StatefulSet with appropriate containers, volumes, etc.
 	// 4. Build Services if needed
-	//
-	// A PodDisruptionBudget is NOT built here: the framework's PDB comes from
-	// roleConfig.podDisruptionBudget and is ROLE-level, built once per role by
-	// BuildRolePodDisruptionBudget and applied by the reconciler.
-	// RoleGroupResources.PodDisruptionBudget remains an escape hatch for an extra per-group one —
-	// and, like MetricsService, a nil there is an instruction rather than an omission: the
-	// framework deletes a live object the handler stops returning.
-	//
-	// The full contract — which build-context fields a handler writes, the container and label
-	// contracts, and what a handler that does NOT embed BaseRoleGroupHandler must reproduce — is
-	// docs/architecture.md §4.1.5.
+	// 5. Build PDB if needed
 	//
 	// Returns RoleGroupResources containing all built resources, or an error.
 	BuildResources(ctx context.Context, k8sClient client.Client, cr CR, buildCtx *RoleGroupBuildContext) (*RoleGroupResources, error)

--- a/pkg/reconciler/role_group_handler.go
+++ b/pkg/reconciler/role_group_handler.go
@@ -544,7 +544,17 @@ type RoleGroupHandler[CR common.ClusterInterface] interface {
 	// 2. Build product-specific ConfigMap data
 	// 3. Build StatefulSet with appropriate containers, volumes, etc.
 	// 4. Build Services if needed
-	// 5. Build PDB if needed
+	//
+	// A PodDisruptionBudget is NOT built here: the framework's PDB comes from
+	// roleConfig.podDisruptionBudget and is ROLE-level, built once per role by
+	// BuildRolePodDisruptionBudget and applied by the reconciler.
+	// RoleGroupResources.PodDisruptionBudget remains an escape hatch for an extra per-group one —
+	// and, like MetricsService, a nil there is an instruction rather than an omission: the
+	// framework deletes a live object the handler stops returning.
+	//
+	// The full contract — which build-context fields a handler writes, the container and label
+	// contracts, and what a handler that does NOT embed BaseRoleGroupHandler must reproduce — is
+	// docs/architecture.md §4.1.5.
 	//
 	// Returns RoleGroupResources containing all built resources, or an error.
 	BuildResources(ctx context.Context, k8sClient client.Client, cr CR, buildCtx *RoleGroupBuildContext) (*RoleGroupResources, error)


### PR DESCRIPTION
Closes #578, closes #579. Both are "the framework requires something it never wrote down".

I ran a ten-agent investigation over this SDK and the ten sibling operators before writing anything, with an adversarial verify pass. **It corrected both issues**, and one thing I shipped earlier.

## #578 — the JMX java agent

`constant.KubedoopJmxAgentJar` + `constant.JMXJavaAgentOpt(port, configFile)`:

```go
constant.JMXJavaAgentOpt(8081, "config.yaml")
// -javaagent:/kubedoop/jmx/jmx_prometheus_javaagent.jar=8081:/kubedoop/jmx/config.yaml
```

**The config file is a parameter, not the proposed baked-in `config.yaml`.** The hadoop image ships no `config.yaml` at all — only `namenode.yaml` / `datanode.yaml` / `journalnode.yaml`, because the metrics worth exporting differ per role. Baking it in would have excluded the product with the most roles. Verified across all seven JMX-shipping images.

Confirmed the issue's other premise: `pkg/sidecar/jmx_exporter.go` models a genuinely different mechanism. **And more than the issue claimed** — no kubedoop image contains `/opt/jmx_exporter` at all, so that provider cannot run against a product image the way `SetProductImage` wires it. Not changed here; worth its own issue.

## #578 — no `CopyMountedConfigScript`

The read-only mount is real (`ReadOnly: true`, `base_role_group_handler.go`) and documented nowhere. But the issue's *"spark and hive share the identical two lines"* is **false**: across ten operators there are nine copy sites and they disagree — spark emits bare `cp`, hive `cp -RL`, zookeeper uses its own constant. `ConfigMountPath` is configurable too. A helper would be wrong for most callers or so parameterised it saves nothing.

So the **knowledge** is documented instead, including the part none of the nine sites explains: `-L` is required because a ConfigMap volume is a farm of symlinks into a hidden `..data/` directory, and a copy that preserves them leaves dangling links.

## #579 — the handler contract

New **`docs/architecture.md` §4.1.5 "Writing a Role Group Handler"**: the build-context read/write split (12 fields the framework writes, 9 the handler does), what a nil `RoleGroupResources` field **instructs** rather than omits (the framework *deletes* a MetricsService or PDB the handler stops returning), the container contract, the read-only mount, the eleven ways to fail a build, and a four-item checklist for a handler that does not embed `BaseRoleGroupHandler`.

**Three doc-vs-code corrections found while writing it:**
1. §4.11.2 attributed the `stopped` replica forcing to the Reconciler — it is in `BaseRoleGroupHandler.buildStatefulSet`, which is exactly what a non-embedding handler must reproduce;
2. the terminology section said a RoleGroup maps to a PDB — the PDB is **role**-level;
3. `BuildResources`' doc comment still told implementers to "Build PDB if needed".

## A correction to something I already merged

`WithSidecarManager` is **inert under the reconciler**: `buildSidecarManager` never returns nil, so `buildCtx.SidecarManager` is always set and the handler fallback never fires on the framework path. That narrows a claim I made in #582 — the handler-registered manager `CloneForBuild` protects is only reachable when a product calls `BuildResources` **directly**. The clone and its spec are still correct (the spec calls `BuildResources` directly); the blast radius I described was not. Now documented.

## #579's third point is wrong as filed — not implemented

The issue says products with **typed role fields** lose the role-name CEL guard, and offers spark's zero-validation CRD as proof. Checking:

- **`examples/trino-operator` has typed role fields *and* the guard** — its CRD carries the role-group rule at two paths, byte-identical to the SDK's, because `CoordinatorsSpec`/`WorkersSpec` embed `commonsv1alpha1.RoleSpec` inline. The issue's own "decisive check" returns the opposite of what it predicts.
- The real discriminator is a product declaring its **own `RoleGroups` field**. **zookeeper is the only clean isolation**: it pins a post-marker operator-go and still emits zero validations. spark's zero is over-determined — it declares its own type *and* pins v0.12.6, which predates the markers entirely.
- The **role-name** rule is structurally inapplicable to these products: they have no `spec.roles` map and their role names are Go constants. Requiring it would be wrong.
- A commons named map type would help **none** of the six, because each declares its own `RoleGroupSpec` struct, not a differently-shaped map over the commons one.

An executable `HaveRoleNameValidations()` matcher is feasible, but its role detection would be name-based on the literal string `roleGroups` — vacuous for a product naming it otherwise. I would rather correct the issue first than build a guard on a misdiagnosis.

## Verification

`make lint`, `make test` (18 packages), `make verify-generate`, and the examples module's `make lint` + `make test` — all green, exit codes checked individually.