### PR TITLE
fix(reconciler): make a role group slot's identity neither forgeable nor unaddressable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,6 +207,14 @@ reconciler passes a writable clone of `cr.GetLabels()` as `RoleGroupBuildContext
 restarter watches. Opting in is a **deployment** decision by whoever runs the cluster, not something
 the operator's author hardcodes.
 
+Three keys are withheld from that channel — `metrics.kubedoop.dev/service`, `pdb.kubedoop.dev/role`
+and `pdb.kubedoop.dev/role-group`. They are the framework's **slot markers**: a reclaim selects an
+object for deletion by their presence or value, and unlike the `app.kubernetes.io/*` set nothing
+overwrites them afterwards, so a CR carrying one would stamp it on every built resource and make
+each answer to a reclaim aimed at the slot. The filter is an enumerated set rather than a
+`kubedoop.dev` prefix rule precisely because `restarter.kubedoop.dev/enable` shows that domain is
+shared with the platform; every other CR label propagates unchanged.
+
 > **Caveat (upstream bug).** commons-operator's `getRefConfigMapRefs` returns after the *first*
 > ConfigMap volume it finds, so a pod mounting several ConfigMaps only ever gets one of them
 > watched — see zncdatadev/commons-operator#298. The secret path (`getRefSecretRefs`) is correct.
@@ -232,7 +240,7 @@ restarter involved.
 
 **Deletion uses owner-reference garbage collection, not finalizers.** The SDK registers **no** finalizer anywhere, so deleting a cluster CR runs **no SDK teardown code**. Everything the framework applies carries a controller owner reference and is reclaimed by Kubernetes GC. `Reconcile` detects deletion on two paths: background propagation (the `kubectl delete` default) removes the CR immediately and hits the `IsNotFound` branch, while foreground propagation (`--cascade=foreground`) and any product-registered finalizer leave the CR readable with a `deletionTimestamp` — checked right after the fetch, before the ClusterOperation gate and any mutating step. The second check is load-bearing: without it the pass re-creates every owned resource with `BlockOwnerDeletion: true`, which foreground deletion can never get past, producing a permanently `Terminating` CR in an un-backed-off recreate loop. The `operator.zncdata.dev/delete-pvcs` annotation (`reconciler.AnnotationDeletePVCs`) therefore only affects the **orphan** path — PVCs of a StatefulSet whose role group was removed or renamed in the spec. On cluster deletion those PVCs remain, because the SDK sets no `persistentVolumeClaimRetentionPolicy` and StatefulSet-managed PVCs carry no owner reference. Products with state outside owner-reference GC must clean it up themselves.
 
-**Validation failures are loud.** Registered, enabled sidecar providers are validated before the StatefulSet is applied; a failure aborts the role group with `*reconciler.ValidationError` (`NewValidationError` / `IsValidationError`). A `podOverrides` layer that fails to decode is recorded on `config.MergedConfig.PodOverrideErrors` and re-emitted as a `PodOverrideIgnored` Warning event rather than being dropped silently.
+**Validation failures are loud.** Registered, enabled sidecar providers are validated before the StatefulSet is applied; a failure aborts the role group with `*reconciler.ValidationError` (`NewValidationError` / `IsValidationError`). A `podOverrides` layer that fails to decode is recorded on `config.MergedConfig.PodOverrideErrors` and re-emitted as a `PodOverrideIgnored` Warning event rather than being dropped silently. A fixed `RoleGroupResources` slot built under a name or namespace the framework does not own fails the same way, **before anything is applied** (§3).
 
 **A `podOverrides` volumeMount at a framework-owned `mountPath` replaces it — and that is now a build failure.** Strategic merge patch keys `volumeMounts` by **`mountPath`**, not by `name`, so a mount declared at a path the framework already owns (`/kubedoop/config`, a CSI secret/listener path, the shared log volume) does not sit alongside the framework's — it rewrites the framework's entry to point at a different volume. When the override also declares that volume the resulting pod spec is **completely valid**, the API server accepts it, and the pods come up with the generated ConfigMap mounted nowhere: the product reads an empty config directory and crash-loops or silently runs on its built-in defaults. When it declares only the mount, the API server rejects the StatefulSet naming `spec.template.spec.containers[0].volumeMounts[0].name` — a field the user never wrote, with no mention of `podOverrides`. `StatefulSetBuilder` records both on `PodOverrideViolations()` and `BaseRoleGroupHandler` turns them into a `*reconciler.ValidationError` naming the mountPath, the displaced volume and `podOverrides`. Mounting at a *new* path is unaffected, which is what users normally mean.
 
@@ -309,6 +317,17 @@ inheritance was tried and reverted: it invented a semantic users would have to l
 the only way to say "this group has no affinity", which a single-node development group needs.
 
 `RoleGroupHandlerFuncs` is a function adapter for simple handlers that don't need a full struct.
+
+**The framework owns the NAME of every fixed slot; the handler owns its content.** `ConfigMap`,
+`Service`, `StatefulSet` and `PodDisruptionBudget` must be named `RoleGroupBuildContext.ResourceName`,
+`HeadlessService` and `MetricsService` that name plus `-headless` / `-metrics`, and all six must sit
+in the cluster's namespace. Both paths that *remove* a slot address it by that derived name — the
+in-spec reclaim and the orphan teardown — so a slot filled under another name used to be applied,
+owner-referenced and then reclaimed by nothing, surviving until the cluster CR itself was deleted (a
+metrics Service left as a Prometheus target with no endpoints). It is now a `*ValidationError`
+raised **before any resource is applied**, so a rejected declaration leaves nothing half-converged.
+`builder.MetricsServiceBuilder` therefore exposes no name override, and `ExtraResources` is the
+supported route for an object whose name the product chooses.
 
 Besides the fixed fields (ConfigMap, Services, StatefulSet, PDB, MetricsService), `RoleGroupResources.ExtraResources []client.Object` lets products ship arbitrary per-role-group resources (e.g. a `listeners.kubedoop.dev` Listener CR) through the framework's apply path: same controller owner reference, applied BEFORE the StatefulSet because extras are typically pod-scheduling prerequisites. **Extras of a removed role group are reclaimed too**, provided the product registers their kinds through `SetupWithManagerOptions.ExtraOwns` and labels them with the role group's labels; the teardown deletes them right after the StatefulSet, mirroring the apply order. Unregistered or unlabelled extras keep the old behaviour and wait for owner-reference GC on cluster deletion (see §13 and the field's doc comment).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,40 @@ builders, config/logging rendering and the CSI wiring, followed by three API red
 the contracts a product operator implements. **Downstream operators must migrate — the breaking
 changes are listed below.**
 
+### fixes (role group slot identity)
+
+- **A `RoleGroupResources` slot under a name the framework does not own is now a build failure**
+  instead of a permanent leak (#584). The six fixed slots must be named `<resource>` (ConfigMap,
+  Service, StatefulSet, PodDisruptionBudget), `<resource>-headless` or `<resource>-metrics`, and
+  must live in the cluster's namespace; anything else fails the role group with a
+  `*reconciler.ValidationError` **before any resource is applied**. Both paths that remove a slot
+  address it by that derived name — the in-spec reclaim and the orphan teardown — so a
+  differently named one was applied, owner-referenced, reported healthy and then survived every
+  teardown until the cluster CR was deleted (for the metrics slot: a Prometheus target with no
+  endpoints). Products needing their own name use `RoleGroupResources.ExtraResources` plus
+  `SetupWithManagerOptions.ExtraOwns`, whose reclaim is label-based for exactly that reason.
+  Nothing in any operator is affected today — every Gen 3 branch builds these names already.
+- **CR labels can no longer forge a framework slot marker.** `metrics.kubedoop.dev/service`,
+  `pdb.kubedoop.dev/role` and `pdb.kubedoop.dev/role-group` are dropped from the CR labels that
+  reach a handler. A reclaim selects objects for deletion by these keys' presence or value, and
+  nothing overwrote them downstream, so `kubectl label <cr> pdb.kubedoop.dev/role=anything` made
+  the role-PDB cleaner reap every per-group PDB shipped through the escape hatch, and
+  `metrics.kubedoop.dev/service=true` made a role group's reclaim delete the client Service of a
+  sibling group named `<x>-metrics`. `restarter.kubedoop.dev/enable` and every other CR label are
+  unaffected — the filter is an enumerated set, not a domain rule.
+- **A 429 from a reclaim backs off instead of degrading the cluster.** `reclaimMetricsService`,
+  `reclaimRolePDB` and `reclaimRoleGroupPDB` returned the raw API error, so throttling was
+  reported as a resource-apply failure. These are the branches every role group of every product
+  takes, since nothing in the SDK fills the metrics slot.
+
+### features
+
+- `builder.MetricsServiceBuilder.WithAnnotations(map[string]string)` merges extra annotations into
+  the generated Prometheus set, with caller entries winning on key collisions, so a product can add
+  its own scrape hints or correct a generated value. The builder still exposes no name or ClusterIP
+  override: the reconciler's metrics slot is addressed by derived name (above), and the Service is
+  always headless.
+
 ### BREAKING CHANGES
 
 - `common.ClusterInterface` shrank from twelve methods to `client.Object` plus `GetSpec` and

--- a/docs/DOC_CHANGELOG.md
+++ b/docs/DOC_CHANGELOG.md
@@ -4,6 +4,35 @@ This document tracks all changes made to the SDK documentation.
 
 ---
 
+## [2026-08-04] (slot identity: neither forgeable nor unaddressable)
+
+### Core Architecture (`architecture.md`)
+
+- **§4.1.5** now states the fixed-slot name and namespace contract as a rule with a reason, next to
+  the "nil is an instruction to delete" paragraph it follows from: that instruction only works if
+  the framework can find the object it refers to, and it finds all six fixed slots by derived name.
+  Generalised to the design rule — *an optional, product-supplied resource slot must have either a
+  framework-owned name or a framework-stamped identity, never neither* — with why the fixed slots
+  take the first branch (a name is checkable at build time, an identity label only against a live
+  List whose stale answer is terminal) and `ExtraResources` the second.
+- Records that three CR label keys are withheld from `ClusterLabels`, and the principle behind it:
+  a marker a user can set is a delete instruction a user can forge. Notes why the filter is an
+  enumerated set rather than a `kubedoop.dev` prefix rule.
+- The non-embedding-handler checklist item 1 was "the headless Service must be named
+  `<ResourceName>-headless`" as a convention; it is now checked and rejected.
+
+### Package guides
+
+- `pkg/reconciler/AGENTS.md`: new §18 on slot names (which names, why pre-flight rather than
+  per-step, why a hard failure); §16 gains the reserved-label paragraph with the concrete
+  `pdb.kubedoop.dev/role` failure it prevents.
+- `pkg/builder/AGENTS.md`: `WithAnnotations` semantics, and why `MetricsServiceBuilder` exposes no
+  name or ClusterIP override.
+- Root `AGENTS.md`: the contract in §3, the reserved keys next to the restarter-label passage, and
+  a pointer from the "Validation failures are loud" paragraph.
+
+---
+
 ## [2026-08-03e] (the handler contract stops being source-only)
 
 ### Core Architecture (`architecture.md`)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -355,6 +355,14 @@ Both fail loudly: a customizer that returns an error, or that changes the image 
 
 `RoleGroupResources` is not a bag of optional outputs. The apply path treats **nil as an instruction**, not as "leave it alone": a nil `MetricsService` or `PodDisruptionBudget` makes the framework *delete* the corresponding live object, because that is how a role group that stops declaring one is converged. `ExtraResources` carries arbitrary GVKs, which must be registered in the reconciler's scheme and live in the CR's namespace — the framework sets a controller owner reference, and a cross-namespace owner is rejected by Kubernetes.
 
+**The framework owns the fixed slots' names, and the handler owns their content.** `ConfigMap`, `Service`, `StatefulSet` and `PodDisruptionBudget` must be named `buildCtx.ResourceName`; `HeadlessService` and `MetricsService` that name plus `-headless` and `-metrics`; all six must live in `buildCtx.ClusterNamespace`. A slot that breaks either rule fails the role group with a `*ValidationError` *before any resource is applied*.
+
+This is the direct consequence of the paragraph above. "Nil is an instruction to delete" only works if the framework can find the object the instruction refers to, and it finds all six by their derived names — in the in-spec reclaims and, when the role group leaves the spec, in `RoleGroupCleaner`. Nothing recovers a slot filled under a different name: live-orphan discovery rejects any object whose name is not the derived one, and the teardown's final confirmation re-checks the same fixed list before pruning the group's status entry. Such an object is applied, owner-referenced, reported healthy, and then outlives every teardown until the cluster CR is deleted.
+
+The general rule this encodes: **an optional, product-supplied resource slot must have either a framework-owned name or a framework-stamped identity — never neither.** The framework picks the name for the fixed slots because a name is checkable at build time, against no cluster and in one reconcile; an identity label is only checkable against a live List, on a path where a stale cache answering "nothing here" is terminal. `ExtraResources` takes the other branch deliberately, because there the names are the product's: its reclaim is label-selected and opt-in through `SetupWithManagerOptions.ExtraOwns`. A product that needs a metrics Service under its own name uses that door.
+
+The same reasoning bounds what a CR label may say. Labels are the one channel from a cluster's *deployer* to the built resources (§4.1.4), but three keys — `metrics.kubedoop.dev/service`, `pdb.kubedoop.dev/role`, `pdb.kubedoop.dev/role-group` — are the framework's own slot markers, and a reclaim deletes by their presence or value. They are filtered out of `ClusterLabels` for that reason: a marker that a user can set is a delete instruction that a user can forge. The filter is an enumerated set, not a domain prefix rule, because `restarter.kubedoop.dev/enable` establishes that `kubedoop.dev` is shared with the platform rather than private to this framework.
+
 #### The container contract
 
 - The primary container's name resolves `RoleMainContainerName[role]` → `MainContainerName` → the role group's resource name, and must be settled **before** `Build()`: `podOverrides` are strategic-merged by container name, so a later rename leaves the user's override appended as a phantom, image-less container.
@@ -381,7 +389,7 @@ Eleven causes across twelve sites inside `BaseRoleGroupHandler.BuildResources`. 
 
 A handler implementing the interface directly inherits none of the conventions, and four of them are load-bearing:
 
-1. the headless Service must be named `<ResourceName>-headless` — the StatefulSet's `serviceName` is derived, and it is immutable;
+1. every fixed slot must carry its derived name — the headless Service `<ResourceName>-headless` above all, since the StatefulSet's `serviceName` is derived from it and immutable. This one the framework now checks and rejects rather than leaving to convention;
 2. the pod must mount the ConfigMap named `buildCtx.ResourceName`, which is what the framework's own ConfigMap is called;
 3. `clusterOperation.stopped` must force replicas to 0 — it is implemented in the base handler, not in the reconciler;
 4. `RoleNameProvider`, `LoggingProducerProvider` and `BuildRolePodDisruptionBudget` are optional capability interfaces the reconciler type-asserts for; not implementing them silently disables the role-name typo warning, the Vector wiring and the role-level PDB.

--- a/pkg/builder/AGENTS.md
+++ b/pkg/builder/AGENTS.md
@@ -36,6 +36,17 @@ extension).
 - **`WithLabels` / `WithAnnotations` merge, they do not replace.** This holds for every builder
   that has them (StatefulSet, Service, ConfigMap, PDB, RBAC, ServiceAccount); calling them twice
   unions the entries.
+- **`MetricsServiceBuilder.WithAnnotations` merges into the generated Prometheus set**, with caller
+  entries winning on key collisions, so a product can add its own scrape hints or correct a
+  generated value (`prometheus.io/port` for a sidecar exporter's port, say). Repeated calls
+  accumulate; the map is copied.
+- **`MetricsServiceBuilder` exposes no name or ClusterIP override, deliberately.** The Service is
+  always `{resourceName}-metrics` and always headless. The reconciler addresses the per-role-group
+  metrics slot by that derived name on both paths that remove it — the in-spec reclaim and the
+  orphan teardown — so a Service under another name would be applied and owner-referenced but
+  reclaimed by neither, and `reconciler.RoleGroupResources` now rejects one at build time. A
+  product that needs its own name ships the Service through `RoleGroupResources.ExtraResources`,
+  where the reclaim is label-based because the names are the product's.
 - **`PDBBuilder.Build()` panics without a selector.** An empty `LabelSelector` is accepted by the
   API server and selects *every* pod in the namespace, so a PDB built without `WithSelector` would
   silently block node drains for workloads the operator does not own. It is the only object in

--- a/pkg/builder/metrics_service_builder.go
+++ b/pkg/builder/metrics_service_builder.go
@@ -33,7 +33,15 @@ import (
 //   - Service labels: input labels + "prometheus.io/scrape=true"
 //   - Selector: input labels (without prometheus annotation)
 //
-// Override defaults with WithScheme() and WithPath().
+// Override defaults with WithScheme(), WithPath() and WithAnnotations().
+//
+// The name and the headless ClusterIP are deliberately NOT overridable. The reconciler addresses
+// the per-role-group metrics slot (RoleGroupResources.MetricsService) by the derived name on both
+// of its lifecycle paths — the in-spec reclaim when a handler stops shipping one, and the orphan
+// teardown when the role group leaves the spec — so a Service under any other name would be
+// applied and owner-referenced but reclaimed by neither. A product that genuinely needs a
+// differently named metrics Service ships it through RoleGroupResources.ExtraResources, whose
+// reclaim is label-based (see SetupWithManagerOptions.ExtraOwns).
 type MetricsServiceBuilder struct {
 	resourceName   string
 	namespace      string
@@ -42,6 +50,7 @@ type MetricsServiceBuilder struct {
 	targetPortName string
 	labels         map[string]string
 	selector       map[string]string
+	annotations    map[string]string
 	scheme         string
 	path           string
 }
@@ -73,6 +82,22 @@ func (b *MetricsServiceBuilder) WithScheme(scheme string) *MetricsServiceBuilder
 // WithPath sets the Prometheus metrics path (default: "" which means /metrics).
 func (b *MetricsServiceBuilder) WithPath(path string) *MetricsServiceBuilder {
 	b.path = path
+	return b
+}
+
+// WithAnnotations merges extra annotations into the generated Prometheus set. Caller entries win
+// on key collisions, so any generated default can be restated or replaced; repeated calls
+// accumulate. The map is copied entry-wise, so a caller that keeps mutating the map it passed does
+// not change what this builder produces later.
+//
+// This is the channel for the scrape configuration the framework does not model — a
+// `prometheus.io/param_*` key, a product's own scrape hints, or a relabelling marker a downstream
+// ServiceMonitor keys off.
+func (b *MetricsServiceBuilder) WithAnnotations(annotations map[string]string) *MetricsServiceBuilder {
+	if b.annotations == nil {
+		b.annotations = make(map[string]string, len(annotations))
+	}
+	maps.Copy(b.annotations, annotations)
 	return b
 }
 
@@ -114,6 +139,8 @@ func (b *MetricsServiceBuilder) Build() *corev1.Service {
 	if b.path != "" {
 		annotations["prometheus.io/path"] = b.path
 	}
+	// Applied last so a caller entry wins over the generated default for the same key.
+	maps.Copy(annotations, b.annotations)
 
 	selectorSource := b.selector
 	if selectorSource == nil {

--- a/pkg/builder/metrics_service_builder_test.go
+++ b/pkg/builder/metrics_service_builder_test.go
@@ -166,4 +166,61 @@ var _ = Describe("MetricsServiceBuilder", func() {
 			Expect(svc.Spec.Ports[0].TargetPort).To(Equal(intstr.FromString("jmx")))
 		})
 	})
+
+	Describe("WithAnnotations", func() {
+		It("should merge extra annotations into the generated Prometheus set", func() {
+			svc := builder.NewMetricsServiceBuilder(resourceName, namespace, port, labels).
+				WithAnnotations(map[string]string{"example.com/team": "data"}).
+				Build()
+
+			Expect(svc.Annotations).To(HaveKeyWithValue("example.com/team", "data"))
+			// Merged, not replaced: the generated set has to survive alongside the caller's.
+			Expect(svc.Annotations).To(HaveKeyWithValue("prometheus.io/scrape", "true"))
+			Expect(svc.Annotations).To(HaveKeyWithValue("prometheus.io/port", "9505"))
+			Expect(svc.Annotations).To(HaveKeyWithValue("prometheus.io/scheme", "http"))
+		})
+
+		It("should let a caller entry win over the generated default for the same key", func() {
+			svc := builder.NewMetricsServiceBuilder(resourceName, namespace, port, labels).
+				WithPath("/generated").
+				WithAnnotations(map[string]string{
+					"prometheus.io/path": "/override",
+					"prometheus.io/port": "19505",
+				}).
+				Build()
+
+			// Merging in the other order would silently discard the override, which is the whole
+			// reason this method exists — a product cannot otherwise correct a generated value.
+			Expect(svc.Annotations).To(HaveKeyWithValue("prometheus.io/path", "/override"))
+			Expect(svc.Annotations).To(HaveKeyWithValue("prometheus.io/port", "19505"))
+		})
+
+		It("should accumulate across calls", func() {
+			svc := builder.NewMetricsServiceBuilder(resourceName, namespace, port, labels).
+				WithAnnotations(map[string]string{"a": "1"}).
+				WithAnnotations(map[string]string{"b": "2"}).
+				Build()
+
+			Expect(svc.Annotations).To(HaveKeyWithValue("a", "1"))
+			Expect(svc.Annotations).To(HaveKeyWithValue("b", "2"))
+		})
+
+		It("should copy the caller's map rather than alias it", func() {
+			caller := map[string]string{"a": "1"}
+			b := builder.NewMetricsServiceBuilder(resourceName, namespace, port, labels).WithAnnotations(caller)
+			caller["a"] = "mutated"
+			caller["late"] = "entry"
+
+			svc := b.Build()
+			Expect(svc.Annotations).To(HaveKeyWithValue("a", "1"))
+			Expect(svc.Annotations).NotTo(HaveKey("late"))
+		})
+
+		It("should leave the generated set untouched when never called", func() {
+			svc := builder.NewMetricsServiceBuilder(resourceName, namespace, port, labels).Build()
+
+			Expect(svc.Annotations).To(HaveLen(3))
+			Expect(svc.Name).To(Equal(resourceName + "-metrics"))
+		})
+	})
 })

--- a/pkg/reconciler/AGENTS.md
+++ b/pkg/reconciler/AGENTS.md
@@ -223,6 +223,20 @@ There is no `reconciler.go`, `status.go` or `finalizer.go` in this package — s
     *user* wants on the workloads — above all the platform opt-ins the SDK does not own, such as
     `restarter.kubedoop.dev/enable` — is set by labelling the CR.
 
+    **Three label keys are withheld from that channel** (`reservedSlotLabelKeys` in
+    `generic_reconciler.go`): `metrics.kubedoop.dev/service`, `pdb.kubedoop.dev/role` and
+    `pdb.kubedoop.dev/role-group`. These are the framework's *slot markers* — labels whose presence,
+    or whose value, makes a reclaim SELECT an object for deletion — and unlike the
+    `app.kubernetes.io/*` set nothing downstream overwrites them, so a CR carrying one would stamp
+    it on every resource the handler builds and make each of them answer to a reclaim aimed at the
+    slot. A CR labelled `pdb.kubedoop.dev/role=anything` was enough to make
+    `cleanupOrphanedRolePDBs` reap every per-group PDB shipped through the
+    `RoleGroupResources.PodDisruptionBudget` escape hatch, since it reads the role name from the
+    label's value and deletes any PDB naming a role the spec does not declare. The filter is an
+    enumerated set rather than a `kubedoop.dev` prefix rule precisely because
+    `restarter.kubedoop.dev/enable` proves that domain is shared with the platform, not
+    framework-private; every other CR label still propagates unchanged.
+
     `BaseRoleGroupHandler.ExtraLabels` and `ExtraAnnotations` are **gone**. They were compile-time
     fields on a handler, i.e. a decision frozen when the operator was built, for something decided
     when a cluster is deployed; and `ExtraLabels` specifically existed to paper over the three
@@ -259,6 +273,30 @@ There is no `reconciler.go`, `status.go` or `finalizer.go` in this package — s
     it is retiring, and reports the rest in log lines, so a role group stuck mid-teardown for three
     days produces no error, no failing reconcile and no condition transition. Do not grow this file
     into a second copy of tools that already exist.
+
+18. **The framework owns the NAME of every fixed `RoleGroupResources` slot; the handler owns its
+    content.** `validateRoleGroupResources` runs before step 1 of `applyResources` and fails the
+    role group with a `*ValidationError` when a slot's name is not the derived one —
+    `<resource>` for `ConfigMap`, `Service`, `StatefulSet` and `PodDisruptionBudget`,
+    `<resource>-headless` and `<resource>-metrics` for the two suffixed Services — or when its
+    namespace is not the cluster's.
+
+    The rule is not stylistic. Both paths that REMOVE a slot address it by that derived name: the
+    in-spec reclaims (`reclaimMetricsService`, `reclaimRoleGroupPDB`) and `RoleGroupCleaner`'s
+    teardown. Nothing recovers a slot filled under another name — `discoverLiveOrphans` rejects any
+    object whose name is not what `RoleGroupResourceName` produces, and `confirmRoleGroupReclaimed`
+    re-checks the same fixed list before pruning the group's status entry — so such an object was
+    applied, owner-referenced, reported healthy, and then survived every teardown until the cluster
+    CR itself was deleted. For the metrics slot that is a Prometheus target with no endpoints; for
+    the ConfigMap and StatefulSet it is a workload nothing will ever look at again.
+
+    The check is **pre-flight** rather than at each slot's apply step, so a rejected declaration
+    leaves nothing half-converged. It is a hard failure rather than a warning for the same reason
+    the `podOverrides` mountPath violation is (§10): the alternative reinstates the leak.
+
+    `ExtraResources` takes the other branch of the same trade — the product owns those names, so
+    their reclaim is label-based and opt-in through `SetupWithManagerOptions.ExtraOwns`. That is
+    the supported route for a differently named metrics Service.
 
 ## Reconcile Flow
 

--- a/pkg/reconciler/cleaner.go
+++ b/pkg/reconciler/cleaner.go
@@ -442,6 +442,13 @@ func setOrphanCleanupCondition(status *v1alpha1.GenericClusterStatus, pending []
 // the framework's slot apart from it. An empty ownerUID disables the reclaim entirely — without an
 // owner to match, every labelled PDB in the namespace (including a sibling cluster's) would look
 // like this cluster's.
+//
+// The role name is read from the label's VALUE, and a value naming no declared role is what selects
+// a PDB for deletion. That is only safe because LabelRolePodDisruptionBudget is in
+// reservedSlotLabelKeys and so never reaches a built resource from the CR's own labels: otherwise
+// `kubectl label <cr> pdb.kubedoop.dev/role=anything` would stamp it on every per-group PDB a
+// product ships through the RoleGroupResources.PodDisruptionBudget escape hatch and this List would
+// reap all of them.
 func (c *RoleGroupCleaner) cleanupOrphanedRolePDBs(
 	ctx context.Context,
 	namespace, clusterName string,

--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -1320,11 +1320,16 @@ func validateRoleGroupResources(resources *RoleGroupResources, buildCtx *RoleGro
 					"register its kind in SetupWithManagerOptions.ExtraOwns so it is reclaimed by label",
 					name, slot.want))
 		}
-		if ns := slot.obj.GetNamespace(); ns != "" && ns != buildCtx.ClusterNamespace {
+		// An UNSET namespace is rejected along with a wrong one. Nothing downstream fills it in:
+		// applyResource hands the object straight to CreateOrUpdate, and SetControllerReference
+		// refuses any namespace that is not the owner's — including the empty one. Letting it
+		// through would fail at this slot's own apply step, which for a late slot means the
+		// earlier ones are already applied: exactly the half-converged state this check prevents.
+		if ns := slot.obj.GetNamespace(); ns != buildCtx.ClusterNamespace {
 			return NewValidationError("RoleGroupResources."+slot.field, buildCtx.RoleName, buildCtx.RoleGroupName,
 				fmt.Errorf("the slot must live in the cluster's namespace: got %q, want %q. "+
-					"A cross-namespace owner reference is ignored by Kubernetes garbage collection, so the "+
-					"object would outlive even the cluster CR", ns, buildCtx.ClusterNamespace))
+					"Kubernetes disallows a cross-namespace owner reference, and an unset namespace is "+
+					"not filled in by the framework", ns, buildCtx.ClusterNamespace))
 		}
 	}
 

--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -735,17 +735,52 @@ func (r *GenericReconciler[CR]) reconcileRole(ctx context.Context, cr CR, roleNa
 	return nil
 }
 
-// handlerWritableLabels returns the CR's labels as a map a handler may both read and write.
+// reservedSlotLabelKeys are the framework's slot markers: labels whose presence (or value) makes
+// the framework SELECT an object for deletion. They are excluded from the CR labels that reach a
+// handler, because nothing downstream overwrites them.
+//
+// Every other CR label is deliberately propagated — that is the documented channel for platform
+// opt-ins the framework does not own, restarter.kubedoop.dev/enable above all — and the
+// app.kubernetes.io/* set is safe to propagate because recommendedLabels and
+// frameworkSelectorLabels are applied over it. These three have no such backstop: BaseRoleGroupHandler
+// stamps them only on the objects that really are the slot, so a CR label using one of these keys
+// would travel to every built resource and make each of them answer to a reclaim aimed at the slot.
+//
+//   - LabelMetricsService on the client Service of a role group named "<x>-metrics" makes the
+//     reclaim of role group "<x>" delete it, every reconcile.
+//   - LabelRolePodDisruptionBudget carries the ROLE NAME in its value, and cleanupOrphanedRolePDBs
+//     deletes every PDB whose value names a role the spec does not declare — so one CR label with a
+//     bogus value reaps the per-group PDBs a product ships through the escape hatch.
+//
+// Filtering here rather than at each List keeps the rule in one place and makes it true for any
+// future reclaim that keys off a marker.
+var reservedSlotLabelKeys = []string{
+	LabelMetricsService,
+	LabelRolePodDisruptionBudget,
+	LabelRoleGroupPodDisruptionBudget,
+}
+
+// handlerWritableLabels returns the CR's labels as a map a handler may both read and write, minus
+// the framework's own slot markers (see reservedSlotLabelKeys).
 //
 // It is cloned because cr.GetLabels() hands out the live object's map, and a handler that adds an
 // entry to ClusterLabels would otherwise mutate the object this cycle's status write is computed
 // from. It is materialized because maps.Clone preserves nil and a CR carrying no labels is
 // perfectly ordinary: RoleGroupBuildContext.ClusterLabels and RoleBuildContext.ClusterLabels are
 // documented as the handler's to build on, and writing to a nil map panics.
-func handlerWritableLabels(labels map[string]string) map[string]string {
+func handlerWritableLabels(ctx context.Context, labels map[string]string) map[string]string {
 	cloned := maps.Clone(labels)
 	if cloned == nil {
 		cloned = make(map[string]string)
+	}
+	for _, key := range reservedSlotLabelKeys {
+		if _, present := cloned[key]; !present {
+			continue
+		}
+		delete(cloned, key)
+		log.FromContext(ctx).V(1).Info(
+			"Dropped a reserved framework label from the CR's labels: it marks a resource slot for reclaim and is not propagated to built resources",
+			"label", key)
 	}
 	return cloned
 }
@@ -775,7 +810,7 @@ func (r *GenericReconciler[CR]) reconcileRolePodDisruptionBudget(ctx context.Con
 	pdb := handler.BuildRolePodDisruptionBudget(&RoleBuildContext{
 		ClusterName:      cr.GetName(),
 		ClusterNamespace: cr.GetNamespace(),
-		ClusterLabels:    handlerWritableLabels(cr.GetLabels()),
+		ClusterLabels:    handlerWritableLabels(ctx, cr.GetLabels()),
 		ClusterSpec:      cr.GetSpec(),
 		RoleName:         roleName,
 		RoleSpec:         roleSpec,
@@ -957,7 +992,7 @@ func (r *GenericReconciler[CR]) buildRoleGroupContext(ctx context.Context, cr CR
 	return &RoleGroupBuildContext{
 		ClusterName:      cr.GetName(),
 		ClusterNamespace: cr.GetNamespace(),
-		ClusterLabels:    handlerWritableLabels(cr.GetLabels()),
+		ClusterLabels:    handlerWritableLabels(ctx, cr.GetLabels()),
 		ClusterSpec:      cr.GetSpec(),
 		RoleName:         roleName,
 		RoleSpec:         roleSpec,
@@ -1129,6 +1164,12 @@ func (r *GenericReconciler[CR]) resolveVectorAggregatorAddress(ctx context.Conte
 // already exists (see applyResource / copyDesiredState for the exact update semantics).
 func (r *GenericReconciler[CR]) applyResources(ctx context.Context, cr CR, resources *RoleGroupResources, buildCtx *RoleGroupBuildContext) error {
 
+	// 0. Reject a declaration the lifecycle cannot honour, BEFORE anything is applied — a role
+	// group that half-converged and then failed is worse than one that did not start.
+	if err := validateRoleGroupResources(resources, buildCtx); err != nil {
+		return err
+	}
+
 	// 1. Apply ConfigMap
 	if resources.ConfigMap != nil {
 		if err := r.applyResource(ctx, cr, resources.ConfigMap); err != nil {
@@ -1217,6 +1258,93 @@ func (r *GenericReconciler[CR]) applyResources(ctx context.Context, cr CR, resou
 	return nil
 }
 
+// apiError maps an API-server error the framework cannot act on into the framework's own type. A
+// 429 becomes a *RateLimitError, which aborts the pass and backs off rather than marking the
+// cluster Degraded: pushing the remaining roles through a throttled API server only deepens the
+// backlog, and a throttled cluster is not a broken one. Everything else is returned unchanged.
+//
+// It is a method rather than an inline check because the mapping used to live only inside
+// applyResource, so every reclaim path added afterwards reported a throttled Get as a resource
+// failure — and the reclaims run on EVERY role group of EVERY cluster, being the branch taken when
+// a handler ships no metrics Service or no per-group PDB. RoleGroupCleaner carries its own copy
+// (RoleGroupCleaner.apiError) for the teardown side.
+func (r *GenericReconciler[CR]) apiError(err error) error {
+	if errors.IsTooManyRequests(err) {
+		return NewRateLimitError(r.rateLimitRetryAfter, err)
+	}
+	return err
+}
+
+// validateRoleGroupResources rejects a RoleGroupResources the lifecycle cannot honour.
+//
+// The six fixed slots are addressed BY DERIVED NAME on every path that removes them: the in-spec
+// reclaims here in applyResources, and the orphan teardown in RoleGroupCleaner when the role group
+// leaves the spec. Nothing recovers a slot filled under a different name — discoverLiveOrphans
+// rejects any object whose name is not what RoleGroupResourceName produces, and confirmRoleGroupReclaimed
+// re-checks the same fixed list before the group's status entry is pruned. Such an object is
+// applied, owner-referenced, reported healthy, and then survives every teardown until the cluster
+// CR itself is deleted: a Service that keeps a Prometheus target with no endpoints, a ConfigMap and
+// a StatefulSet nothing will ever look at again.
+//
+// So the framework owns these names and says so at build time, where the answer is checkable
+// without a live cluster and costs one reconcile instead of a silent leak. A product that needs to
+// choose its own name ships the object through RoleGroupResources.ExtraResources, whose reclaim is
+// label-based precisely because its names are the product's (see SetupWithManagerOptions.ExtraOwns).
+//
+// The namespace is checked for the same reason and one more: a cross-namespace owner reference is
+// not honoured by Kubernetes garbage collection, so the object would outlive even the CR.
+func validateRoleGroupResources(resources *RoleGroupResources, buildCtx *RoleGroupBuildContext) error {
+	slots := []struct {
+		field string
+		want  string
+		obj   client.Object
+	}{
+		{"ConfigMap", buildCtx.ResourceName, objectOrNil(resources.ConfigMap)},
+		{"HeadlessService", buildCtx.ResourceName + "-headless", objectOrNil(resources.HeadlessService)},
+		{"Service", buildCtx.ResourceName, objectOrNil(resources.Service)},
+		{"StatefulSet", buildCtx.ResourceName, objectOrNil(resources.StatefulSet)},
+		{"PodDisruptionBudget", buildCtx.ResourceName, objectOrNil(resources.PodDisruptionBudget)},
+		{"MetricsService", buildCtx.ResourceName + "-metrics", objectOrNil(resources.MetricsService)},
+	}
+
+	for _, slot := range slots {
+		if slot.obj == nil {
+			continue
+		}
+		if name := slot.obj.GetName(); name != slot.want {
+			return NewValidationError("RoleGroupResources."+slot.field, buildCtx.RoleName, buildCtx.RoleGroupName,
+				fmt.Errorf("the framework owns the name of this slot: got %q, want %q. "+
+					"A slot filled under any other name is applied but reclaimed by neither the in-spec "+
+					"reclaim nor the orphan teardown, both of which address it by that name. Ship a "+
+					"differently named object through RoleGroupResources.ExtraResources instead, and "+
+					"register its kind in SetupWithManagerOptions.ExtraOwns so it is reclaimed by label",
+					name, slot.want))
+		}
+		if ns := slot.obj.GetNamespace(); ns != "" && ns != buildCtx.ClusterNamespace {
+			return NewValidationError("RoleGroupResources."+slot.field, buildCtx.RoleName, buildCtx.RoleGroupName,
+				fmt.Errorf("the slot must live in the cluster's namespace: got %q, want %q. "+
+					"A cross-namespace owner reference is ignored by Kubernetes garbage collection, so the "+
+					"object would outlive even the cluster CR", ns, buildCtx.ClusterNamespace))
+		}
+	}
+
+	return nil
+}
+
+// objectOrNil converts a typed slot pointer to client.Object without the typed-nil trap: a nil
+// *corev1.Service assigned to a client.Object interface is non-nil, so `obj == nil` on the
+// interface would be false and every unset slot would be validated as an object with an empty name.
+func objectOrNil[T interface {
+	client.Object
+	comparable
+}](obj T) client.Object {
+	var zero T
+	if obj == zero {
+		return nil
+	}
+	return obj
+}
+
 // LabelMetricsService marks a Service as the framework's per-role-group metrics slot. Only
 // Services carrying it are reclaimed when a role group stops producing a MetricsService.
 const LabelMetricsService = "metrics." + constant.KubedoopDomain + "/service"
@@ -1259,7 +1387,7 @@ func (r *GenericReconciler[CR]) reclaimRolePDB(ctx context.Context, namespace, n
 		if errors.IsNotFound(err) {
 			return nil
 		}
-		return err
+		return r.apiError(err)
 	}
 	if pdb.Labels[LabelRolePodDisruptionBudget] != roleName {
 		return nil
@@ -1280,7 +1408,7 @@ func (r *GenericReconciler[CR]) reclaimRoleGroupPDB(ctx context.Context, buildCt
 		if errors.IsNotFound(err) {
 			return nil
 		}
-		return err
+		return r.apiError(err)
 	}
 	if !isFrameworkRoleGroupPDB(pdb, buildCtx.ClusterName, buildCtx.RoleName, buildCtx.RoleGroupName) {
 		return nil
@@ -1306,13 +1434,19 @@ func isFrameworkRoleGroupPDB(pdb *policyv1.PodDisruptionBudget, clusterName, rol
 // hit the client Service of a role group named "<group>-metrics", and any object a product ships
 // under that name through RoleGroupResources.ExtraResources — both of which carry this CR's
 // controller owner reference, so ownership alone does not distinguish them.
+//
+// That separation holds only because LabelMetricsService cannot arrive on an object by any route
+// other than this framework stamping it: it is in reservedSlotLabelKeys, so a CR carrying it does
+// not propagate it to the resources a handler builds. Without that filter one `kubectl label` on
+// the cluster CR puts the slot label on every built object, and this Get finds the neighbouring
+// role group's client Service wearing it.
 func (r *GenericReconciler[CR]) reclaimMetricsService(ctx context.Context, namespace, name string, ownerUID types.UID, clusterName string) error {
 	svc := &corev1.Service{}
 	if err := r.client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, svc); err != nil {
 		if errors.IsNotFound(err) {
 			return nil
 		}
-		return err
+		return r.apiError(err)
 	}
 	if svc.Labels[LabelMetricsService] != valueTrue {
 		return nil
@@ -1389,10 +1523,7 @@ func (r *GenericReconciler[CR]) applyResource(ctx context.Context, owner client.
 		return copyErr
 	})
 	if err != nil {
-		if errors.IsTooManyRequests(err) {
-			return NewRateLimitError(r.rateLimitRetryAfter, err)
-		}
-		return err
+		return r.apiError(err)
 	}
 
 	// Tell the user their change was dropped. The framework preserving an immutable field is

--- a/pkg/reconciler/role_group_handler.go
+++ b/pkg/reconciler/role_group_handler.go
@@ -38,6 +38,19 @@ import (
 
 // RoleGroupResources contains all Kubernetes resources for a role group.
 // Each role group maps to exactly one StatefulSet and its associated resources.
+//
+// The framework owns the NAME and NAMESPACE of every fixed slot below; the handler owns their
+// content. The names are derived from RoleGroupBuildContext.ResourceName —
+// "<resource>" for the ConfigMap, Service, StatefulSet and PodDisruptionBudget,
+// "<resource>-headless" and "<resource>-metrics" for the two suffixed Services — and both paths
+// that REMOVE a slot address it by that name: the in-spec reclaim when a handler stops shipping
+// one, and RoleGroupCleaner's teardown when the role group leaves the spec. A slot filled under a
+// different name is therefore applied and owner-referenced but reclaimed by nothing, surviving
+// until the cluster CR itself is deleted. Rather than leak it silently, the framework fails the
+// role group with a *ValidationError before applying anything (see validateRoleGroupResources).
+//
+// ExtraResources takes the other branch of that trade: the product owns those names, so their
+// reclaim is label-based and opt-in.
 type RoleGroupResources struct {
 	// StatefulSet is the main workload resource.
 	StatefulSet *appsv1.StatefulSet

--- a/pkg/reconciler/role_group_slot_test.go
+++ b/pkg/reconciler/role_group_slot_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/zncdatadev/operator-go/pkg/constant"
 	"github.com/zncdatadev/operator-go/pkg/reconciler"
 	"github.com/zncdatadev/operator-go/pkg/testutil"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -103,6 +104,9 @@ func createSlotCR(ctx context.Context, name string, labels map[string]string, ro
 					_ = k8sClient.Delete(ctx, &corev1.Service{ObjectMeta: objMeta})
 					_ = k8sClient.Delete(ctx, &corev1.ConfigMap{ObjectMeta: objMeta})
 					_ = k8sClient.Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: objMeta})
+					// envtest runs no garbage collector, so owner references reclaim nothing here:
+					// every object a spec creates has to be deleted by name or it accumulates.
+					_ = k8sClient.Delete(ctx, &appsv1.StatefulSet{ObjectMeta: objMeta})
 				}
 			}
 		}
@@ -172,6 +176,31 @@ var _ = Describe("Fixed role group slot names", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(reconciler.IsValidationError(err)).To(BeTrue(), "want a *ValidationError, got %T: %v", err, err)
 		Expect(err.Error()).To(ContainSubstring("kube-system"))
+	})
+
+	It("fails the role group when a slot carries no namespace at all", func() {
+		name := slotCRName("slot-nons")
+		createSlotCR(ctx, name, nil, map[string]v1alpha1.RoleSpec{"worker": defaultGroupRole()})
+		resourceName := reconciler.RoleGroupResourceName(name, "worker", "default")
+
+		// Unset is rejected like wrong: nothing downstream fills it in, so this would fail at the
+		// metrics slot's own apply step — with the ConfigMap, Services and StatefulSet of the same
+		// role group already applied.
+		r := slotReconciler(k8sClient, nil, func(buildCtx *reconciler.RoleGroupBuildContext, res *reconciler.RoleGroupResources) {
+			res.MetricsService = &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: buildCtx.ResourceName + "-metrics"},
+				Spec:       corev1.ServiceSpec{ClusterIP: corev1.ClusterIPNone, Ports: []corev1.ServicePort{{Name: "m", Port: 9505}}},
+			}
+		})
+
+		err := reconcileSlotCR(ctx, r, name)
+		Expect(err).To(HaveOccurred())
+		Expect(reconciler.IsValidationError(err)).To(BeTrue(), "want a *ValidationError, got %T: %v", err, err)
+		Expect(err.Error()).To(ContainSubstring(testNamespace))
+
+		cm := &corev1.ConfigMap{}
+		getErr := k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: resourceName}, cm)
+		Expect(k8serrors.IsNotFound(getErr)).To(BeTrue(), "no resource may be applied when the declaration is rejected")
 	})
 
 	It("accepts everything BaseRoleGroupHandler builds, including the suffixed Services", func() {

--- a/pkg/reconciler/role_group_slot_test.go
+++ b/pkg/reconciler/role_group_slot_test.go
@@ -1,0 +1,401 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
+	"github.com/zncdatadev/operator-go/pkg/constant"
+	"github.com/zncdatadev/operator-go/pkg/reconciler"
+	"github.com/zncdatadev/operator-go/pkg/testutil"
+	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// slotCRCounter keeps generated cluster names unique and short: the longest name these specs
+// derive is "<cr>-<role>-<group>-metrics", which must stay inside the 63-byte DNS label limit.
+var slotCRCounter int
+
+func slotCRName(prefix string) string {
+	slotCRCounter++
+	return fmt.Sprintf("%s-%d", prefix, slotCRCounter)
+}
+
+// slotReconciler builds a reconciler over the real BaseRoleGroupHandler, wrapped so a spec can
+// post-process what the handler produced. The real handler is used rather than the mock because
+// these specs are about labels and names the base handler derives — buildLabels copying
+// ClusterLabels in particular, which the mock does not do.
+func slotReconciler(
+	c client.Client,
+	configure func(*reconciler.BaseRoleGroupHandler[*testutil.MockCluster]),
+	post func(*reconciler.RoleGroupBuildContext, *reconciler.RoleGroupResources),
+) *reconciler.GenericReconciler[*testutil.MockCluster] {
+	base := reconciler.NewBaseRoleGroupHandler[*testutil.MockCluster]("product:1", testScheme)
+	if configure != nil {
+		configure(base)
+	}
+	handler := &reconciler.RoleGroupHandlerFuncs[*testutil.MockCluster]{
+		BuildResourcesFunc: func(ctx context.Context, k8sClient client.Client, cr *testutil.MockCluster,
+			buildCtx *reconciler.RoleGroupBuildContext) (*reconciler.RoleGroupResources, error) {
+			res, err := base.BuildResources(ctx, k8sClient, cr, buildCtx)
+			if err != nil {
+				return nil, err
+			}
+			if post != nil {
+				post(buildCtx, res)
+			}
+			return res, nil
+		},
+	}
+	r, err := reconciler.NewGenericReconciler(&reconciler.GenericReconcilerConfig[*testutil.MockCluster]{
+		Client:           c,
+		Scheme:           testScheme,
+		Recorder:         recorder,
+		RoleGroupHandler: handler,
+		Prototype:        testutil.NewMockCluster("proto", testNamespace),
+	})
+	Expect(err).NotTo(HaveOccurred())
+	return r
+}
+
+// createSlotCR creates a cluster CR with the given roles and registers a best-effort teardown of
+// everything the framework derives from it.
+func createSlotCR(ctx context.Context, name string, labels map[string]string, roles map[string]v1alpha1.RoleSpec) *testutil.MockCluster {
+	cr := testutil.NewMockCluster(name, testNamespace).WithRoles(roles)
+	if labels != nil {
+		cr.SetLabels(labels)
+	}
+	Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+	DeferCleanup(func() {
+		_ = k8sClient.Delete(ctx, cr)
+		for roleName, role := range roles {
+			for groupName := range role.RoleGroups {
+				base := reconciler.RoleGroupResourceName(name, roleName, groupName)
+				for _, n := range []string{base, base + "-headless", base + "-metrics"} {
+					objMeta := metav1.ObjectMeta{Name: n, Namespace: testNamespace}
+					_ = k8sClient.Delete(ctx, &corev1.Service{ObjectMeta: objMeta})
+					_ = k8sClient.Delete(ctx, &corev1.ConfigMap{ObjectMeta: objMeta})
+					_ = k8sClient.Delete(ctx, &policyv1.PodDisruptionBudget{ObjectMeta: objMeta})
+				}
+			}
+		}
+	})
+	return cr
+}
+
+func reconcileSlotCR(ctx context.Context, r *reconciler.GenericReconciler[*testutil.MockCluster], name string) error {
+	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: name}})
+	return err
+}
+
+// defaultGroupRole is a role with the single role group these specs use throughout. The group
+// name is fixed rather than a parameter: the one spec that needs two groups declares them inline,
+// because the names have to collide in a specific way.
+func defaultGroupRole() v1alpha1.RoleSpec {
+	return v1alpha1.RoleSpec{
+		RoleGroups: map[string]v1alpha1.RoleGroupSpec{"default": {Replicas: ptr.To(int32(1))}},
+	}
+}
+
+// The framework addresses every fixed slot of RoleGroupResources by a name it derives, on both
+// paths that remove one. A slot filled under a different name used to be applied, owner-referenced
+// and then reclaimed by nothing — surviving every teardown until the cluster CR itself was deleted.
+var _ = Describe("Fixed role group slot names", func() {
+	var ctx context.Context
+
+	BeforeEach(func() { ctx = context.Background() })
+
+	It("fails the role group when a slot carries a name the framework does not own", func() {
+		name := slotCRName("slot-name")
+		createSlotCR(ctx, name, nil, map[string]v1alpha1.RoleSpec{"worker": defaultGroupRole()})
+		resourceName := reconciler.RoleGroupResourceName(name, "worker", "default")
+
+		r := slotReconciler(k8sClient, nil, func(buildCtx *reconciler.RoleGroupBuildContext, res *reconciler.RoleGroupResources) {
+			res.MetricsService = &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: buildCtx.ResourceName + "-prom", Namespace: buildCtx.ClusterNamespace},
+				Spec:       corev1.ServiceSpec{ClusterIP: corev1.ClusterIPNone, Ports: []corev1.ServicePort{{Name: "m", Port: 9505}}},
+			}
+		})
+
+		err := reconcileSlotCR(ctx, r, name)
+		Expect(err).To(HaveOccurred())
+		Expect(reconciler.IsValidationError(err)).To(BeTrue(), "want a *ValidationError, got %T: %v", err, err)
+		// Both names have to appear: "wrong name" without saying what the right one is leaves the
+		// product author guessing at a convention the framework never wrote down.
+		Expect(err.Error()).To(ContainSubstring(resourceName + "-prom"))
+		Expect(err.Error()).To(ContainSubstring(resourceName + "-metrics"))
+		Expect(err.Error()).To(ContainSubstring("ExtraResources"))
+
+		// The check runs BEFORE anything is applied. Failing at step 7 instead would leave the
+		// role group half-converged — a ConfigMap and a StatefulSet for a build that was rejected.
+		cm := &corev1.ConfigMap{}
+		getErr := k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: resourceName}, cm)
+		Expect(k8serrors.IsNotFound(getErr)).To(BeTrue(), "no resource may be applied when the declaration is rejected")
+	})
+
+	It("fails the role group when a slot is built in another namespace", func() {
+		name := slotCRName("slot-ns")
+		createSlotCR(ctx, name, nil, map[string]v1alpha1.RoleSpec{"worker": defaultGroupRole()})
+
+		r := slotReconciler(k8sClient, nil, func(buildCtx *reconciler.RoleGroupBuildContext, res *reconciler.RoleGroupResources) {
+			res.ConfigMap.Namespace = "kube-system"
+		})
+
+		err := reconcileSlotCR(ctx, r, name)
+		Expect(err).To(HaveOccurred())
+		Expect(reconciler.IsValidationError(err)).To(BeTrue(), "want a *ValidationError, got %T: %v", err, err)
+		Expect(err.Error()).To(ContainSubstring("kube-system"))
+	})
+
+	It("accepts everything BaseRoleGroupHandler builds, including the suffixed Services", func() {
+		name := slotCRName("slot-ok")
+		createSlotCR(ctx, name, nil, map[string]v1alpha1.RoleSpec{"worker": defaultGroupRole()})
+		resourceName := reconciler.RoleGroupResourceName(name, "worker", "default")
+
+		// Declaring service ports makes the base handler emit the client Service too, so this
+		// control covers all four names the handler produces plus a metrics slot at the fifth.
+		r := slotReconciler(k8sClient,
+			func(b *reconciler.BaseRoleGroupHandler[*testutil.MockCluster]) {
+				b.SetRoleServicePorts("worker", []corev1.ServicePort{{Name: "http", Port: 8080, TargetPort: intstr.FromInt32(8080)}})
+			},
+			func(buildCtx *reconciler.RoleGroupBuildContext, res *reconciler.RoleGroupResources) {
+				res.MetricsService = &corev1.Service{
+					ObjectMeta: metav1.ObjectMeta{Name: buildCtx.ResourceName + "-metrics", Namespace: buildCtx.ClusterNamespace},
+					Spec:       corev1.ServiceSpec{ClusterIP: corev1.ClusterIPNone, Ports: []corev1.ServicePort{{Name: "m", Port: 9505}}},
+				}
+			})
+
+		Expect(reconcileSlotCR(ctx, r, name)).To(Succeed())
+		for _, n := range []string{resourceName, resourceName + "-headless", resourceName + "-metrics"} {
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: n}, &corev1.Service{})).
+				To(Succeed(), "Service %q should have been applied", n)
+		}
+	})
+})
+
+// A label on the cluster CR reaches every resource the base handler builds. Three of the
+// framework's own label keys SELECT an object for deletion, so a CR carrying one of them would
+// make ordinary resources answer to a reclaim aimed at a slot.
+var _ = Describe("Reserved framework labels on the cluster CR", func() {
+	var ctx context.Context
+
+	BeforeEach(func() { ctx = context.Background() })
+
+	It("does not let the metrics slot label reach a sibling role group's client Service", func() {
+		name := slotCRName("resv-metrics")
+		// Role group "g" derives its metrics name as "<cr>-w-g-metrics", which is exactly role
+		// group "g-metrics"'s own resource name. Only the slot label tells the two apart.
+		createSlotCR(ctx, name, map[string]string{reconciler.LabelMetricsService: "true"},
+			map[string]v1alpha1.RoleSpec{"w": {RoleGroups: map[string]v1alpha1.RoleGroupSpec{
+				"g":         {Replicas: ptr.To(int32(1))},
+				"g-metrics": {Replicas: ptr.To(int32(1))},
+			}}})
+		victim := reconciler.RoleGroupResourceName(name, "w", "g-metrics")
+		Expect(victim).To(Equal(reconciler.RoleGroupResourceName(name, "w", "g")+"-metrics"),
+			"the spec only bites if the two names really collide")
+
+		r := slotReconciler(k8sClient, func(b *reconciler.BaseRoleGroupHandler[*testutil.MockCluster]) {
+			b.SetRoleServicePorts("w", []corev1.ServicePort{{Name: "http", Port: 8080, TargetPort: intstr.FromInt32(8080)}})
+		}, nil)
+
+		Expect(reconcileSlotCR(ctx, r, name)).To(Succeed())
+		svc := &corev1.Service{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: victim}, svc)).To(Succeed())
+		uid := svc.UID
+
+		// The UID is the assertion that bites. Role groups are reconciled in sorted order, so "g"'s
+		// reclaim runs before "g-metrics" is applied: a deletion here is immediately papered over by
+		// the recreate later in the same pass, and only the churn is observable — a Service whose
+		// endpoints and virtual IP are rebuilt every reconcile, which nothing ever reports.
+		Expect(reconcileSlotCR(ctx, r, name)).To(Succeed())
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: victim}, svc)).
+			To(Succeed(), "role group g-metrics' client Service was deleted by role group g's metrics reclaim")
+		Expect(svc.UID).To(Equal(uid),
+			"role group g-metrics' client Service was deleted and recreated by role group g's metrics reclaim")
+		Expect(svc.Labels).NotTo(HaveKey(reconciler.LabelMetricsService))
+	})
+
+	It("does not let the role PDB label reach an escape-hatch per-group PDB", func() {
+		name := slotCRName("resv-pdb")
+		// The value names a role the spec does not declare, which is precisely what
+		// cleanupOrphanedRolePDBs treats as "this role is gone, reclaim its PDB".
+		createSlotCR(ctx, name, map[string]string{reconciler.LabelRolePodDisruptionBudget: "ghost"},
+			map[string]v1alpha1.RoleSpec{"w": defaultGroupRole()})
+		resourceName := reconciler.RoleGroupResourceName(name, "w", "default")
+
+		r := slotReconciler(k8sClient, nil, func(buildCtx *reconciler.RoleGroupBuildContext, res *reconciler.RoleGroupResources) {
+			res.PodDisruptionBudget = &policyv1.PodDisruptionBudget{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      buildCtx.ResourceName,
+					Namespace: buildCtx.ClusterNamespace,
+					Labels:    buildCtx.ClusterLabels,
+				},
+				Spec: policyv1.PodDisruptionBudgetSpec{
+					MaxUnavailable: ptr.To(intstr.FromInt32(1)),
+					Selector:       &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+				},
+			}
+		})
+
+		Expect(reconcileSlotCR(ctx, r, name)).To(Succeed())
+		Expect(reconcileSlotCR(ctx, r, name)).To(Succeed())
+
+		pdb := &policyv1.PodDisruptionBudget{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: resourceName}, pdb)).
+			To(Succeed(), "the per-group PDB was reaped by the role-PDB cleaner")
+		Expect(pdb.Labels).NotTo(HaveKey(reconciler.LabelRolePodDisruptionBudget))
+	})
+
+	It("still propagates ordinary CR labels, including the restarter opt-in", func() {
+		name := slotCRName("resv-pass")
+		createSlotCR(ctx, name, map[string]string{
+			constant.LabelRestarterEnable:  constant.LabelRestarterEnableValue,
+			"example.com/team":             "data",
+			reconciler.LabelMetricsService: "true",
+		}, map[string]v1alpha1.RoleSpec{"w": defaultGroupRole()})
+
+		var seen map[string]string
+		r := slotReconciler(k8sClient, nil, func(buildCtx *reconciler.RoleGroupBuildContext, res *reconciler.RoleGroupResources) {
+			seen = buildCtx.ClusterLabels
+		})
+		Expect(reconcileSlotCR(ctx, r, name)).To(Succeed())
+
+		// The filter is an enumerated set, not a blanket ban on the kubedoop domain: the restarter
+		// opt-in is a documented, supported CR label and must survive.
+		Expect(seen).To(HaveKeyWithValue(constant.LabelRestarterEnable, constant.LabelRestarterEnableValue))
+		Expect(seen).To(HaveKeyWithValue("example.com/team", "data"))
+		Expect(seen).NotTo(HaveKey(reconciler.LabelMetricsService))
+	})
+})
+
+var _ = Describe("Metrics slot reclaim", func() {
+	var ctx context.Context
+
+	BeforeEach(func() { ctx = context.Background() })
+
+	It("leaves a sibling ROLE's metrics Service alone when this role ships none", func() {
+		name := slotCRName("mx-sibling")
+		// Two roles sharing one role group name. RoleGroupMarkerLabelKey is "<cluster>-<group>",
+		// with no role in it, so a reclaim selecting on that marker matches both roles' metrics
+		// Services — the reason the slot is addressed by its derived name, which does carry the role.
+		createSlotCR(ctx, name, nil, map[string]v1alpha1.RoleSpec{
+			"alpha": defaultGroupRole(),
+			"beta":  defaultGroupRole(),
+		})
+		betaMetrics := reconciler.RoleGroupResourceName(name, "beta", "default") + "-metrics"
+
+		r := slotReconciler(k8sClient, nil, func(buildCtx *reconciler.RoleGroupBuildContext, res *reconciler.RoleGroupResources) {
+			if buildCtx.RoleName != "beta" {
+				return // alpha ships no metrics Service: its reclaim branch runs every pass
+			}
+			res.MetricsService = &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: buildCtx.ResourceName + "-metrics", Namespace: buildCtx.ClusterNamespace},
+				Spec:       corev1.ServiceSpec{ClusterIP: corev1.ClusterIPNone, Ports: []corev1.ServicePort{{Name: "m", Port: 9505}}},
+			}
+		})
+
+		Expect(reconcileSlotCR(ctx, r, name)).To(Succeed())
+		svc := &corev1.Service{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: betaMetrics}, svc)).To(Succeed())
+		uid := svc.UID
+
+		// Deleted-and-recreated is as broken as deleted: a scrape target that churns its
+		// endpoints every reconcile loses data without ever looking absent.
+		for i := range 2 {
+			Expect(reconcileSlotCR(ctx, r, name)).To(Succeed())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: betaMetrics}, svc)).
+				To(Succeed(), "alpha's reclaim deleted beta's metrics Service on pass %d", i+2)
+			Expect(svc.UID).To(Equal(uid), "beta's metrics Service was deleted and recreated on pass %d", i+2)
+		}
+	})
+
+	It("deletes this role group's metrics Service once the handler stops shipping one", func() {
+		name := slotCRName("mx-off")
+		createSlotCR(ctx, name, nil, map[string]v1alpha1.RoleSpec{"w": defaultGroupRole()})
+		metricsName := reconciler.RoleGroupResourceName(name, "w", "default") + "-metrics"
+
+		emit := true
+		r := slotReconciler(k8sClient, nil, func(buildCtx *reconciler.RoleGroupBuildContext, res *reconciler.RoleGroupResources) {
+			if !emit {
+				return
+			}
+			res.MetricsService = &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{Name: buildCtx.ResourceName + "-metrics", Namespace: buildCtx.ClusterNamespace},
+				Spec:       corev1.ServiceSpec{ClusterIP: corev1.ClusterIPNone, Ports: []corev1.ServicePort{{Name: "m", Port: 9505}}},
+			}
+		})
+
+		Expect(reconcileSlotCR(ctx, r, name)).To(Succeed())
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: metricsName}, &corev1.Service{})).To(Succeed())
+
+		emit = false
+		Expect(reconcileSlotCR(ctx, r, name)).To(Succeed())
+		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: metricsName}, &corev1.Service{})
+		Expect(k8serrors.IsNotFound(err)).To(BeTrue(),
+			"turning metrics off must remove the Service, or Prometheus keeps a target with no exporter")
+	})
+
+	It("backs off instead of degrading the cluster when the reclaim is throttled", func() {
+		name := slotCRName("mx-429")
+		cr := createSlotCR(ctx, name, nil, map[string]v1alpha1.RoleSpec{"w": defaultGroupRole()})
+		metricsName := reconciler.RoleGroupResourceName(name, "w", "default") + "-metrics"
+
+		// The reclaim branch is the one EVERY role group of EVERY product takes, since nothing in
+		// the SDK fills the metrics slot. A 429 there used to be reported as a resource-apply
+		// failure: the cluster went Degraded and the operator kept hammering a throttled API
+		// server, which is the opposite of what a 429 asks for.
+		throttled := &throttleServiceGetClient{Client: k8sClient, name: metricsName}
+		r := slotReconciler(throttled, nil, nil)
+
+		result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: name}})
+		Expect(err).NotTo(HaveOccurred(), "throttling is not a reconcile failure")
+		Expect(result.RequeueAfter).To(Equal(10*time.Second), "the pass must back off on the rate-limit interval")
+
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: name}, cr)).To(Succeed())
+		degraded := meta.FindStatusCondition(cr.GetStatus().Conditions, string(v1alpha1.ConditionDegraded))
+		if degraded != nil {
+			Expect(degraded.Status).NotTo(Equal(metav1.ConditionTrue), "a throttled operator is not a broken cluster")
+		}
+	})
+})
+
+// throttleServiceGetClient answers 429 for a Get of one named Service and delegates everything
+// else, standing in for an API server that is rate-limiting this controller.
+type throttleServiceGetClient struct {
+	client.Client
+	name string
+}
+
+func (c *throttleServiceGetClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+	if _, isSvc := obj.(*corev1.Service); isSvc && key.Name == c.name {
+		return k8serrors.NewTooManyRequests("slow down", 1)
+	}
+	return c.Client.Get(ctx, key, obj, opts...)
+}


### PR DESCRIPTION
Closes #584. Supersedes #586 — see **Why not #586** below.

## What

**`pkg/reconciler`**

1. **The framework owns the name and namespace of every fixed `RoleGroupResources` slot.** New `validateRoleGroupResources` runs before step 1 of `applyResources` and fails the role group with a `*ValidationError` when a slot is not named `<resource>` (ConfigMap, Service, StatefulSet, PodDisruptionBudget), `<resource>-headless`, `<resource>-metrics`, or is built in another namespace.
2. **Three label keys are withheld from the CR-labels channel** (`reservedSlotLabelKeys`): `metrics.kubedoop.dev/service`, `pdb.kubedoop.dev/role`, `pdb.kubedoop.dev/role-group`.
3. **429 is mapped in the three reclaim paths.** Extracted as `GenericReconciler.apiError`, now shared with `applyResource`.

**`pkg/builder`**

4. `MetricsServiceBuilder.WithAnnotations(map[string]string)` — merged into the generated Prometheus set, caller wins on key collisions, repeated calls accumulate, the map is copied.

## Why

### 1. A slot under another name is applied and reclaimed by nothing

Both paths that *remove* a fixed slot address it by derived name — the in-spec reclaim (`reclaimMetricsService`, `reclaimRoleGroupPDB`) and `RoleGroupCleaner`'s teardown. Nothing recovers one under a different name: `discoverLiveOrphans` rejects any object whose name is not what `RoleGroupResourceName` produces, and `confirmRoleGroupReclaimed` re-checks the same fixed list before pruning the group's status entry. So the object is applied, owner-referenced, reported healthy, and survives every teardown until the cluster CR itself is deleted — for the metrics slot, a Prometheus target with no endpoints, forever.

A name is checkable at build time against no cluster; an identity label is only checkable against a live List, on a path where a stale cache answering "nothing here" is terminal. Hence the name. `ExtraResources` takes the other branch deliberately — the product owns those names, so its reclaim is label-selected and opt-in through `SetupWithManagerOptions.ExtraOwns` — and stays the supported route for a differently named metrics Service.

The check is **pre-flight** rather than at each slot's apply step, so a rejected declaration leaves nothing half-converged.

### 2. A CR label could forge a slot marker (live on `main`)

`buildLabels` copies `ClusterLabels` onto every built resource, and nothing downstream overwrites these three keys — unlike the `app.kubernetes.io/*` set, which `recommendedLabels` and `frameworkSelectorLabels` re-stamp. They are precisely the keys whose presence, or whose value, makes a reclaim **select an object for deletion**:

- `kubectl label <cr> pdb.kubedoop.dev/role=anything` → `cleanupOrphanedRolePDBs` lists on `HasLabels{LabelRolePodDisruptionBudget}`, reads the role name from the label's **value**, and deletes any PDB naming a role the spec does not declare. Every per-group PDB shipped through the `RoleGroupResources.PodDisruptionBudget` escape hatch inherits the label and is reaped.
- `kubectl label <cr> metrics.kubedoop.dev/service=true` → role group `g`'s reclaim Gets `<cr>-<role>-g-metrics`, which is role group `g-metrics`'s **client Service**, now wearing the slot label, and deletes it. The reclaim's own doc comment claims this cannot happen.

Enumerated set, not a `kubedoop.dev` prefix rule: `restarter.kubedoop.dev/enable` establishes that domain is shared with the platform, not private to this framework. Every other CR label propagates unchanged.

### 3. A throttled reclaim degraded the cluster

The mapping lived only inside `applyResource`, so every reclaim added afterwards returned the raw error. These branches are what **every** role group of **every** product takes, since nothing in the SDK fills the metrics slot.

## Why not #586

| | |
|---|---|
| `WithName` | `Build()` also hardcodes `ClusterIP: None`. Adopting an existing non-headless Service's name keeps that Service's virtual IP forever (`copyServiceState`) and emits an `ImmutableFieldIgnored` Warning every reconcile — so a migrated cluster differs from a fresh one exactly where the e2e asserts parity, and annotation-based SD scrapes one load-balanced endpoint instead of every pod. It also collides with the client-Service slot at the same name. |
| The label-selected reclaim | It selects on `RoleGroupMarkerLabelKey`, which returns `<cluster>-<group>` — **no role**. In any multi-role cluster sharing a role group name (every multi-role Gen 3 branch; all use `default`) the first role that stops shipping a metrics Service deletes its siblings'. The role cannot be added to that key: it lands in the immutable StatefulSet `.spec.selector`. Pinned by a regression spec here. |

For #584's actual need: `WithAnnotations` ships. `prometheus.io/path` — the fourth annotation the airflow assert wants — already comes from the existing `WithPath`. For the name, the answer is to rename in the e2e; note also that the name being preserved is the output of a Gen 2 collision (`webserver.go` registers a client Service and a metrics Service at the same `GetFullName()`, last wins).

## Blast radius

**Zero today.** All five Gen 3 branches using the metrics slot (hdfs #319, zookeeper #362, hive #344, kafka #291, spark-k8s #277) call `NewMetricsServiceBuilder(buildCtx.ResourceName, ...)`; none renames a fixed slot; nifi #92 uses no metrics slot. `WithName` does not exist upstream, so nothing can already depend on it.

## Verification

`make lint`, `make test` (18 packages), `make verify-generate`, plus `examples/trino-operator`'s `make lint` and `make test` — all green, exit codes checked individually.

**Every guarantee is mutation-tested** — each mutation makes its spec fail, for the right reason:

| mutation | spec that dies |
|---|---|
| drop the name check | no error raised at all |
| move the check from pre-flight to after the ConfigMap applies | "no resource may be applied when the declaration is rejected" |
| drop the namespace check | namespace spec |
| empty `reservedSlotLabelKeys` | both reserved-label specs |
| remove only `LabelRolePodDisruptionBudget` | PDB spec only — proves the set is enumerated, not incidental |
| revert the reclaim to `return err` | "the pass must back off on the rate-limit interval" |
| merge the builder's generated set last | "caller entry wins" spec |
| swap the derived-name reclaim for #586's marker List | **"beta's metrics Service was deleted and recreated on pass 2"** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)