### PR TITLE
fix(reconciler): stop wiping the restarter's pod-template annotation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,7 +179,7 @@ customizable extension points. It is built from a `GenericReconcilerConfig[CR]` 
 10. PostReconcile Extensions
 11. Final Status Update, then requeue
 
-Each "Apply" is create-OR-UPDATE (issue #526): when the resource already exists, the live object is updated to the handler-built desired state every reconcile — labels are replaced wholesale, annotations are merged (foreign annotations survive), and spec/data is copied per kind while preserving Kubernetes immutable/allocated fields (StatefulSet `selector`/`serviceName`/`volumeClaimTemplates`/`podManagementPolicy`; Service `clusterIP(s)`/`ipFamilies` and allocated NodePorts). Arbitrary-GVK extras get a generic top-level field copy. See `copyDesiredState` in `pkg/reconciler/apply.go`. Changing an immutable field for an existing cluster requires a manual delete/recreate migration — and the framework now **says so**: when a handler's desired value for a preserved field differs from the live one, `applyResource` emits an `ImmutableFieldIgnored` Warning event on the CR naming the resource and the field paths. Preserving those fields silently is what let a storage resize be accepted, reported as `ReconcileComplete=True`, and never applied. Only a field the handler actually set is reported (an unset field is declining to have an opinion, not a change request), and among the Service's preserved fields only `clusterIP` is — the others are API-server allocations, so a difference there would be noise on every reconcile.
+Each "Apply" is create-OR-UPDATE (issue #526): when the resource already exists, the live object is updated to the handler-built desired state every reconcile — labels are replaced wholesale, annotations are merged (foreign annotations survive, at both the object level and inside the StatefulSet's pod template), and spec/data is copied per kind while preserving Kubernetes immutable/allocated fields (StatefulSet `selector`/`serviceName`/`volumeClaimTemplates`/`podManagementPolicy`; Service `clusterIP(s)`/`ipFamilies` and allocated NodePorts). Arbitrary-GVK extras get a generic top-level field copy. See `copyDesiredState` in `pkg/reconciler/apply.go`. Changing an immutable field for an existing cluster requires a manual delete/recreate migration — and the framework now **says so**: when a handler's desired value for a preserved field differs from the live one, `applyResource` emits an `ImmutableFieldIgnored` Warning event on the CR naming the resource and the field paths. Preserving those fields silently is what let a storage resize be accepted, reported as `ReconcileComplete=True`, and never applied. Only a field the handler actually set is reported (an unset field is declining to have an opinion, not a change request), and among the Service's preserved fields only `clusterIP` is — the others are API-server allocations, so a difference there would be noise on every reconcile.
 
 **A `configOverrides` change does not roll the pods by itself — the platform restarter does.**
 Editing `configOverrides` makes the framework rewrite the role group ConfigMap, and stop there: the
@@ -222,6 +222,17 @@ shared with the platform; every other CR label propagates unchanged.
 The framework already satisfies the restarter's precondition: the role group ConfigMap is mounted as
 the `config` volume. What it does **not** do is set the label, and without it a `configOverrides`
 change simply does not roll.
+
+**The apply path preserves the restarter's stamp.** The pod template's annotations are MERGED, not
+replaced — the same rule the object's own annotations follow, for the same reason: another controller
+writes there. `copyStatefulSetState` assigns `live.Spec = desired.Spec` wholesale so that new mutable
+fields converge by default, and the pod template lives inside that spec, so before this rule a
+handler that never builds `configmap.restarter.kubedoop.dev/<name>` silently removed it on the next
+reconcile. That Update woke the restarter — its predicate matches the label on every Update, not only
+on Create — which re-stamped, which woke the reconciler through its own `Owns(&appsv1.StatefulSet{})`
+watch. Neither side is failing, so the workqueue `Forget`s each pass and nothing backs off: the pods
+rolled for as long as the label was set. Pod-template *labels* are still replaced wholesale, because
+they must match the StatefulSet's immutable `.spec.selector`.
 
 This applies to `configOverrides` alone. `envOverrides` and `cliOverrides` reach the container as
 env vars and args through `MergedConfig` (`StatefulSetBuilder.WithConfig`), and `podOverrides`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,22 @@ changes are listed below.**
   override: the reconciler's metrics slot is addressed by derived name (above), and the Service is
   always headless.
 
+### fixes (config propagation)
+
+- **The apply path no longer wipes the restarter's pod-template annotation**, which made a cluster
+  that opted into `restarter.kubedoop.dev/enable` roll its pods indefinitely. `copyStatefulSetState`
+  assigns `live.Spec = desired.Spec` wholesale — deliberately, so new mutable fields converge — and
+  the pod template is inside that spec, so the `configmap.restarter.kubedoop.dev/<name>` key
+  commons-operator stamps there was removed on the next reconcile. The resulting Update woke the
+  restarter (its predicate matches the label on every Update, not only on Create), which re-stamped,
+  which woke the reconciler through its own `Owns(&appsv1.StatefulSet{})` watch. Neither side errors,
+  so the workqueue `Forget`s every pass and nothing backs off. Pod-template annotations are now
+  merged with desired winning per key — the same rule the object's own annotations already followed —
+  while pod-template *labels* stay replaced wholesale, because they must match the StatefulSet's
+  immutable `.spec.selector`. This is the framework's only documented mechanism for delivering a
+  `configOverrides` change to running pods, so it was broken for exactly the users who followed the
+  documentation.
+
 ### BREAKING (log producer declarations)
 
 - **`vector.WithProducers` takes `[]productlogging.ContainerLogging` instead of `[]string`.** The

--- a/pkg/reconciler/apply.go
+++ b/pkg/reconciler/apply.go
@@ -18,6 +18,7 @@ package reconciler
 
 import (
 	"fmt"
+	"maps"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -162,14 +163,47 @@ func copyStatefulSetState(desired, live *appsv1.StatefulSet) []string {
 		ignored = append(ignored, "spec.podManagementPolicy")
 	}
 
+	// The pod template's annotations are merged, not replaced — the same rule copyDesiredState
+	// applies to the object's own annotations, and for the same reason: another controller writes
+	// there and the framework must not undo it.
+	//
+	// This is not hypothetical tidiness. commons-operator's restarter delivers a configOverrides
+	// change to running pods by writing "configmap.restarter.kubedoop.dev/<name>: <uid>/<rv>" into
+	// exactly this map, which rolls the pods — and AGENTS.md documents that as the ONLY mechanism
+	// that does so, since a ConfigMap rewrite leaves the pod template byte-identical. The handler
+	// never builds that key, so a wholesale spec assignment removes it; the resulting Update wakes
+	// the restarter (its predicate matches the label on every Update, not only on Create), which
+	// re-stamps, which wakes this reconciler through its own Owns(&appsv1.StatefulSet{}) watch.
+	// Neither side is failing, so the workqueue Forgets each pass and nothing backs off: the pods
+	// roll for as long as the label is set.
+	//
+	// Labels are deliberately NOT given the same treatment. The pod template's labels have to match
+	// the StatefulSet's immutable .spec.selector, so they are framework-owned and come from
+	// desired, exactly like the object's labels.
+	templateAnnotations := live.Spec.Template.Annotations
+
 	live.Spec = desired.Spec
 
 	live.Spec.Selector = selector
 	live.Spec.ServiceName = serviceName
 	live.Spec.VolumeClaimTemplates = volumeClaimTemplates
 	live.Spec.PodManagementPolicy = podManagementPolicy
+	live.Spec.Template.Annotations = mergeAnnotations(templateAnnotations, desired.Spec.Template.Annotations)
 
 	return ignored
+}
+
+// mergeAnnotations returns live's annotations with desired's merged over them, desired winning per
+// key. A nil result is preserved when both are empty, so an object that never had annotations does
+// not gain an empty map and churn its resourceVersion.
+func mergeAnnotations(live, desired map[string]string) map[string]string {
+	if len(live) == 0 {
+		return desired
+	}
+	merged := make(map[string]string, len(live)+len(desired))
+	maps.Copy(merged, live)
+	maps.Copy(merged, desired)
+	return merged
 }
 
 // copyServiceState copies the desired Service spec onto the live one, preserving the fields the

--- a/pkg/reconciler/apply_pod_template_test.go
+++ b/pkg/reconciler/apply_pod_template_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"testing"
+
+	"github.com/zncdatadev/operator-go/pkg/constant"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func stsWithTemplateAnnotations(annotations map[string]string) *appsv1.StatefulSet {
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster-role-default", Namespace: "ns"},
+		Spec: appsv1.StatefulSetSpec{
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Annotations: annotations},
+			},
+		},
+	}
+}
+
+// The restarter's annotation is the framework's ONLY documented mechanism for delivering a
+// configOverrides change to running pods: a ConfigMap rewrite leaves the pod template
+// byte-identical, so commons-operator stamps "configmap.restarter.kubedoop.dev/<name>" into the pod
+// template and the StatefulSet controller rolls. The handler never builds that key, so a wholesale
+// spec assignment removes it — and the resulting Update wakes the restarter, which re-stamps, which
+// wakes this reconciler through its own Owns(&appsv1.StatefulSet{}) watch. Neither side errors, so
+// the workqueue Forgets every pass and nothing backs off.
+func TestCopyStatefulSetState_KeepsRestarterPodTemplateAnnotation(t *testing.T) {
+	restarterKey := constant.AnnotationConfigMapRestarterPrefix + "cluster-role-default"
+	live := stsWithTemplateAnnotations(map[string]string{restarterKey: "uid-1/12345"})
+	desired := stsWithTemplateAnnotations(nil)
+
+	ignored, err := copyDesiredState(desired, live)
+	if err != nil {
+		t.Fatalf("copyDesiredState() error = %v", err)
+	}
+	// Touching the pod template is not an immutable-field change, so nothing may be reported to
+	// the user as dropped.
+	if len(ignored) != 0 {
+		t.Errorf("ignored = %v, want none", ignored)
+	}
+
+	got, ok := live.Spec.Template.Annotations[restarterKey]
+	if !ok {
+		t.Fatalf("the restarter's pod-template annotation was removed; the pods roll on every reconcile")
+	}
+	if got != "uid-1/12345" {
+		t.Errorf("annotation value = %q, want it untouched", got)
+	}
+}
+
+func TestCopyStatefulSetState_DesiredPodTemplateAnnotationWins(t *testing.T) {
+	// Same precedence the object-level merge uses: the handler's value beats the live one, so a
+	// product can still change an annotation it owns.
+	live := stsWithTemplateAnnotations(map[string]string{"product/a": "old", "foreign/b": "keep"})
+	desired := stsWithTemplateAnnotations(map[string]string{"product/a": "new"})
+
+	ignored, err := copyDesiredState(desired, live)
+	if err != nil {
+		t.Fatalf("copyDesiredState() error = %v", err)
+	}
+	// Touching the pod template is not an immutable-field change, so nothing may be reported to
+	// the user as dropped.
+	if len(ignored) != 0 {
+		t.Errorf("ignored = %v, want none", ignored)
+	}
+
+	if got := live.Spec.Template.Annotations["product/a"]; got != "new" {
+		t.Errorf("desired must win: got %q, want %q", got, "new")
+	}
+	if got := live.Spec.Template.Annotations["foreign/b"]; got != "keep" {
+		t.Errorf("a foreign annotation must survive: got %q", got)
+	}
+}
+
+func TestCopyStatefulSetState_NoAnnotationsStaysNil(t *testing.T) {
+	// An object that never had pod-template annotations must not gain an empty map: that is a spec
+	// difference, so it would bump the resourceVersion and roll the pods on the first reconcile
+	// after this change ships.
+	live := stsWithTemplateAnnotations(nil)
+	desired := stsWithTemplateAnnotations(nil)
+
+	ignored, err := copyDesiredState(desired, live)
+	if err != nil {
+		t.Fatalf("copyDesiredState() error = %v", err)
+	}
+	// Touching the pod template is not an immutable-field change, so nothing may be reported to
+	// the user as dropped.
+	if len(ignored) != 0 {
+		t.Errorf("ignored = %v, want none", ignored)
+	}
+	if live.Spec.Template.Annotations != nil {
+		t.Errorf("annotations = %v, want nil", live.Spec.Template.Annotations)
+	}
+}
+
+func TestCopyStatefulSetState_PodTemplateLabelsStillReplaced(t *testing.T) {
+	// Labels are NOT given the annotation treatment: the pod template's labels have to match the
+	// StatefulSet's immutable .spec.selector, so they are framework-owned and come from desired —
+	// exactly like the object's own labels.
+	live := stsWithTemplateAnnotations(nil)
+	live.Spec.Template.Labels = map[string]string{"stale": "yes", "app": "old"}
+	desired := stsWithTemplateAnnotations(nil)
+	desired.Spec.Template.Labels = map[string]string{"app": "new"}
+
+	ignored, err := copyDesiredState(desired, live)
+	if err != nil {
+		t.Fatalf("copyDesiredState() error = %v", err)
+	}
+	// Touching the pod template is not an immutable-field change, so nothing may be reported to
+	// the user as dropped.
+	if len(ignored) != 0 {
+		t.Errorf("ignored = %v, want none", ignored)
+	}
+
+	if _, present := live.Spec.Template.Labels["stale"]; present {
+		t.Error("pod template labels must be replaced wholesale, not merged")
+	}
+	if got := live.Spec.Template.Labels["app"]; got != "new" {
+		t.Errorf("app label = %q, want %q", got, "new")
+	}
+}


### PR DESCRIPTION
Found while investigating #598. This is **not** what that issue asks for — it is a live defect in the very apply path the issue wants to export. #598 itself gets a separate reply.

## The loop

`copyStatefulSetState` assigns `live.Spec = desired.Spec` wholesale. That is deliberate — it is what makes a mutable field a future Kubernetes version adds converge by default instead of sticking at its live value — and the four restores that follow cover `Selector`, `ServiceName`, `VolumeClaimTemplates`, `PodManagementPolicy`. The **pod template is inside that spec**, and `copyDesiredState`'s annotation merge only reaches `metadata.annotations`.

So the framework removes `configmap.restarter.kubedoop.dev/<name>` — the key commons-operator stamps into the pod template to deliver a `configOverrides` change to running pods. `AGENTS.md` documents that as the **only** mechanism that does so, because rewriting the role group ConfigMap leaves the pod template byte-identical and none of these products re-read config at runtime.

```
restarter stamps the annotation         → rollout 1
framework's next reconcile removes it   → rollout 2
that Update wakes the restarter …       → rollout 3 …
```

The restarter's predicate is `NewTypedPredicateFuncs` on the label, so it fires on **Update**, not only Create; and the framework's own `Owns(&appsv1.StatefulSet{})` closes the circle. **Neither side is failing**, so the workqueue `Forget`s each pass and nothing backs off. The pods roll for as long as the label is set, and the config change lands by accident rather than by contract — for exactly the users who followed the documentation.

## Verified from both sides, not from one

- commons-operator `internal/controller/restart/statefulset_controller.go` writes `Spec.Template.Annotations` (lines 210–215) and `Patch`es; `For(&appv1.StatefulSet{}, builder.WithPredicates(labelPredicate))`.
- A probe on this repo, before the fix:

```
object annotations   : map[foreign/obj:keep]     ← the metadata merge works
pod TEMPLATE annots  : map[]                     ← wiped
```

`grep -rn "Template.Annotations" pkg/` returned **nothing** — no test anywhere protected those keys.

## The fix

Pod-template annotations are merged with desired winning per key: the same rule the object's own annotations already followed, for the same reason (another controller writes there), so a product can still change an annotation it owns.

Two deliberate non-changes:
- **Pod-template labels stay replaced wholesale.** They must match the StatefulSet's immutable `.spec.selector`, so they are framework-owned exactly like the object's labels.
- **A template with no annotations keeps a `nil` map.** Materialising an empty one is a spec difference, so it would bump the resourceVersion and roll every pod once on upgrade.

## Verification

`make lint` (0 issues), `make test` (18 packages), `make verify-generate`, `go test -race ./pkg/reconciler/`, plus `examples/trino-operator` lint + test — all pass.

Four mutations, each kills its spec:

| mutation | spec that dies |
|---|---|
| drop the merge (restore the wholesale replace) | `KeepsRestarterPodTemplateAnnotation` — *"the restarter's pod-template annotation was removed; the pods roll on every reconcile"* |
| merge in the wrong order (live wins) | `DesiredPodTemplateAnnotationWins` |
| always materialise a map | `NoAnnotationsStaysNil` |
| give labels the same merge treatment | `PodTemplateLabelsStillReplaced` |

> The label mutation initially did **not** kill its spec — because I had captured the labels *after* `live.Spec = desired.Spec`, making the merge a no-op. Re-run with the capture in the right place, it fails as required. Worth noting since a mutation that does not exercise its branch is worse than none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)