### PR TITLE
feat(reconciler)!: derive the workload ServiceAccount, and own its permissions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -159,7 +159,9 @@ customizable extension points. It is built from a `GenericReconcilerConfig[CR]` 
    event; the status is left untouched
 3. ClusterOperation gate: `reconciliationPaused` returns immediately; `stopped` falls through so
    every resource is still reconciled with replicas forced to 0
-4. Ensure the ServiceAccount (when configured); warn about handler-configured role names the CR
+4. Ensure the workload ServiceAccount (always; name derived from the CR by
+   `ServiceAccountResourceName`) and, when `WorkloadRBACRules` is set, its Role/RoleBinding (§11c);
+   warn about handler-configured role names the CR
    does not declare
 5. PreReconcile Extensions (Hook)
 6. Validate declared dependencies (`GenericReconcilerConfig.Dependencies`)
@@ -351,9 +353,9 @@ reconciler iterates `spec.Roles` directly.
 `RoleGroupBuildContext` carries `ClusterName`, `ClusterNamespace`, `ClusterLabels`, `ClusterSpec`,
 `RoleName`, `RoleSpec`, `RoleGroupName`, `RoleGroupSpec`, `MergedConfig` (the folded
 product-config/role/role-group overrides), `ResourceName` (`{cluster}-{role}-{group}`, truncated
-with a hash suffix by `RoleGroupResourceName`), `ServiceAccountName` (the SA the reconciler
-resolved and ensured), `SidecarManager`, `VolumeProviders` (see §16) and
-`VectorAggregatorAddress`.
+with a hash suffix by `RoleGroupResourceName`), `ServiceAccountName` (the SA the reconciler derived
+and ensured — `ServiceAccountResourceName(kind, cluster)`, never configured and never empty),
+`SidecarManager`, `VolumeProviders` (see §16) and `VectorAggregatorAddress`.
 
 **It is also where a product puts its per-CR inputs.** `Image`, `ImagePullPolicy`, `ContainerPorts`
 and `ServicePorts` on the context outrank the handler's own, and the context is rebuilt per role
@@ -736,6 +738,81 @@ every *other* key too. Generators run only for absent keys, so the steady-state 
 them. Call it from a `common.ClusterExtension` `PreReconcile` hook, where a ctx and client exist and
 the workload has not been built yet; it is deliberately **not** created from the sidecar provider's
 `Validate`, a step whose job is to have no side effects.
+
+### 11c. Workload Identity and Workload RBAC
+
+Two halves of one thing, both settled per CR at the top of the reconcile (steps 0 and 0b), before
+any extension hook or role runs. **Neither is the operator's own RBAC** — that comes from the
+operator's ClusterRole and is a separate axis entirely.
+
+**The identity is derived and unconditional.** Every cluster gets a ServiceAccount named
+`ServiceAccountResourceName(kind, cluster)` — `"<lowercased kind>-<cluster>"`, e.g.
+`hdfscluster-prod` — in the CR's namespace, with the CR as controller owner. There is no config
+field for the name and no way to skip it. The reconciler propagates it through
+`RoleGroupBuildContext.ServiceAccountName`, which is therefore **never empty**, and
+`BaseRoleGroupHandler` binds it to the pod template.
+
+The Kind is in the name because a CR name alone is not unique in a namespace: an `HdfsCluster` and a
+`TrinoCluster` both called `prod` would otherwise select one ServiceAccount and the second
+controller could never own it. The name is derived rather than configured for the same reason every
+other framework-owned name is (§3): the framework creates the object, controller-owns it,
+garbage-collects it with the CR and binds the workload's Role to it, so nothing needs to address it
+by a product-chosen name. Configuring it is what produced the failure class this replaced — a static
+name was a *constant*, so every CR of a product in one namespace resolved to the SAME
+ServiceAccount: whichever cluster reconciled second failed with `AlreadyOwnedError` forever, and
+deleting the first garbage-collected the SA out from under the second's running pods.
+`ServiceAccountResourceName` is **exported** because anything outside the operator that must name the
+SA — a hand-written RoleBinding, an admission policy, an audit query — should derive it from the
+formula. An object squatting on the derived name is never adopted; the reconcile fails naming both
+owners.
+
+**The permissions are declared by the product.** `GenericReconcilerConfig.WorkloadRBACRules func(cr
+CR) []rbacv1.PolicyRule` says what this cluster's *pods* call; the framework maintains a namespaced
+`Role` + `RoleBinding` named after that same derived ServiceAccount, controller-owned by the CR:
+
+```go
+WorkloadRBACRules: func(cr *v1alpha1.NifiCluster) []rbacv1.PolicyRule {
+    return []rbacv1.PolicyRule{{
+        APIGroups: []string{"coordination.k8s.io"},
+        Resources: []string{"leases"},
+        Verbs:     []string{"get", "list", "watch", "create", "update"},
+    }}
+},
+```
+
+The framework passes the name it derived itself, so identity and permissions cannot drift apart —
+that is why this is a config field and not only the exported `reconciler.EnsureWorkloadRBAC` helper
+(which takes the name as a parameter, so a caller *can* pass one no pod uses: both objects exist, the
+pods start, and the first API call 403s). The helper stays exported for a product driving the
+reconciler's pieces itself; `WithWorkloadRBACProductName` and `WithWorkloadRBACExtraLabels` are its
+options, and canonical labels always win over extras.
+
+**There is no `ClusterRole` path.** A namespaced CR cannot controller-own a cluster-scoped object, so
+the framework would have no lifecycle for one — no GC with the cluster, no ownership gate on the
+reclaim. A product needing cluster-scoped permissions maintains those objects itself, cleanup
+included.
+
+**An empty rule set REVOKES**, deleting both objects when this CR controller-owns them — the same
+reading every optional slot gets (a nil `MetricsService` reclaims the Service), and the only one that
+makes a rule set shrinking to nothing actually stop granting. A **nil hook** is the different
+statement "this product never opted in", and touches no RBAC object at all: running a revoke every
+pass would cost two Gets per cluster and demand RBAC read permission from operators that never asked
+for the feature.
+
+**A pre-existing RoleBinding is never adopted.** `roleRef` is immutable, so one already at this name
+pointing elsewhere cannot be converged; the framework fails with a `*ValidationError` naming both
+refs and the fixing command, rather than rewriting only the subject — which would hand these pods
+whatever the old ref allows and report success.
+
+**Setting the hook obliges the operator twice over.** Kubernetes forbids granting permissions the
+granter lacks, so the operator's ClusterRole must be a superset of every rule passed — *and* it needs
+write access to the RBAC API itself. Both are kubebuilder markers, and a 403 has those two distinct
+causes needing opposite fixes, so the SDK re-explains the API server's message rather than
+pre-checking (that message already computed rule covering against the operator's real effective
+permissions and names the missing rule). The `Owns(&rbacv1.Role{})`/`Owns(&rbacv1.RoleBinding{})`
+watches are registered **only** when the hook is set: an unconditional one would force every operator
+on this SDK to grant itself cluster-wide `list;watch` on RBAC, and a forbidden informer fails
+`WaitForCacheSync` for *all* sources, so `manager.Start` returns and the process exits.
 
 ### 12. External Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,75 @@ builders, config/logging rendering and the CSI wiring, followed by three API red
 the contracts a product operator implements. **Downstream operators must migrate — the breaking
 changes are listed below.**
 
+### BREAKING (workload ServiceAccount)
+
+- **The workload ServiceAccount's name is now DERIVED from the CR, and the two config fields that
+  chose it are removed.** `GenericReconcilerConfig.ServiceAccountName` and
+  `ServiceAccountNameFunc` are gone; the name is
+  `reconciler.ServiceAccountResourceName(kind, cluster)` = `"<lowercased kind>-<cluster>"`
+  (`hdfscluster-prod`), exported because IAM trust policies and hand-written RoleBindings have to
+  name it. **Migration**: delete both fields from your `GenericReconcilerConfig`. If your operator
+  set them, its pods move to the derived ServiceAccount on the next reconcile — a rolling restart —
+  and the old SA is left behind for you to delete (it is controller-owned by the CR, so it also goes
+  on cluster deletion).
+
+  This follows the framework's own rule that it owns the name of every slot it owns the lifecycle of
+  (§3): it creates the SA, controller-owns it and GCs it with the CR, so nothing needed to address
+  it by a product-chosen name. Making it derived also makes a whole failure class unrepresentable
+  rather than merely diagnosed — a static name was a *constant*, so every CR of a product in one
+  namespace resolved to the SAME ServiceAccount: whichever cluster reconciled second failed with
+  `AlreadyOwnedError` forever, and deleting the first garbage-collected the SA out from under the
+  second's running pods. The Kind is in the derived name because a CR name alone is not unique in a
+  namespace — an `HdfsCluster` and a `TrinoCluster` both named `prod` would otherwise reintroduce the
+  same collision one level down.
+- **Every cluster now gets a ServiceAccount; there is no way to skip it.** Previously, leaving both
+  fields unset skipped SA management entirely and the pods ran as the namespace `default` — the
+  opposite of what `docs/security.md` §3.1 claims the framework guarantees ("audit logs reflect the
+  specific application identity rather than a generic default account"). A ServiceAccount is pure
+  metadata, so the switch bought nothing and mostly fired by accident.
+- **A 429 from the ServiceAccount step now backs off instead of degrading the cluster.**
+  `ensureServiceAccount` returned the raw API error rather than routing it through the same
+  translation `applyResource` uses, so throttling ran the product's error hooks, emitted a Warning
+  and flipped `Degraded` on a cluster nobody had managed to read yet. While the SA was opt-in this
+  branch was reachable only by the products that configured one; it is now on every cluster's
+  critical path.
+
+### features (workload RBAC)
+
+- **`GenericReconcilerConfig.WorkloadRBACRules func(cr CR) []rbacv1.PolicyRule`** declares the
+  Kubernetes API permissions a cluster's **pods** need — a separate axis from the operator's own
+  ClusterRole. The framework maintains a namespaced `Role` and `RoleBinding` named after the derived
+  workload ServiceAccount, in the CR's namespace, controller-owned by the CR (so both are
+  garbage-collected with the cluster). It is the other half of the identity above, settled at the
+  same point in the same way, from the same derived name — which is what keeps a workload's identity
+  and its permissions from drifting apart. Products previously hand-built these objects and shipped
+  them through `RoleGroupResources.ExtraResources`, which put a cluster-level concern on a
+  per-role-group path and left the SA-name/subject correspondence to the product to get right.
+- **`reconciler.EnsureWorkloadRBAC`** is the exported helper behind it (options:
+  `WithWorkloadRBACProductName`, `WithWorkloadRBACExtraLabels`), for a product driving the
+  reconciler's pieces itself. Prefer the config field: the helper takes the ServiceAccount name as a
+  parameter, so a caller can pass one that is not the workload's — producing a Role that grants to a
+  ServiceAccount no pod uses, with both objects present, the pods starting fine, and a 403 on the
+  first API call.
+- **An empty rule set revokes**, deleting both objects when this CR controller-owns them — the same
+  reading every optional slot gets, and the only one under which a rule set shrinking to nothing
+  actually stops granting. A **nil hook** is the distinct statement "this product never opted in" and
+  touches no RBAC object at all.
+- **A pre-existing `RoleBinding` with a different `roleRef` is never adopted.** `roleRef` is
+  immutable, so it cannot be converged; the framework fails with a `*ValidationError` naming both
+  refs and the fixing command, rather than rewriting only the subject — which would hand this
+  cluster's pods whatever the old ref allows, and return success.
+- **No `ClusterRole` path, deliberately**: a namespaced CR cannot controller-own a cluster-scoped
+  object, so the framework would have no lifecycle for one.
+- **The RBAC watches are registered only when the hook is set.** An unconditional
+  `Owns(&rbacv1.Role{})` would force every operator built on this SDK to grant itself cluster-wide
+  `list;watch` on roles and rolebindings, and a forbidden informer fails `WaitForCacheSync` for *all*
+  sources — `manager.Start` returns and the process exits.
+- Setting the hook requires the operator to hold those permissions itself (Kubernetes forbids
+  granting what the granter lacks) **plus** write access to the RBAC API. A 403 from either cause is
+  re-explained rather than pre-checked: the API server's message has already computed rule covering
+  against the operator's real effective permissions and names the missing rule.
+
 ### fixes (role group slot identity)
 
 - **A `RoleGroupResources` slot under a name the framework does not own is now a build failure**

--- a/docs/DOC_CHANGELOG.md
+++ b/docs/DOC_CHANGELOG.md
@@ -4,6 +4,52 @@ This document tracks all changes made to the SDK documentation.
 
 ---
 
+## [2026-08-08] (workload identity and workload RBAC become framework concerns)
+
+### Package guides
+
+- Root `AGENTS.md` gains **§11c Workload Identity and Workload RBAC**, documenting the two halves as
+  one thing: the derived ServiceAccount and the Role/RoleBinding built from
+  `WorkloadRBACRules`, both settled per CR at the top of the reconcile. Previously the SA was two
+  sentences inside the flow list and workload RBAC appeared only as "use the builders and ship them
+  as ExtraResources".
+- `pkg/builder/AGENTS.md`: the RBAC builders are no longer *the* route to workload RBAC; they are
+  for objects the framework does not maintain.
+
+### Security architecture
+
+- `docs/security.md` §3.1 rewritten. It described an **opt-in** ServiceAccount whose name came from
+  one of two config fields, then claimed in the next bullet that pods run under a specific
+  application identity rather than `default` — true only for products that opted in, and the default
+  was the opposite. Now states unconditional provisioning, the derived name
+  (`ServiceAccountResourceName(kind, cluster)`) and why the Kind is in it.
+- `docs/security.md` §3.2 rewritten from "Builders, not automation" to the
+  `WorkloadRBACRules` contract: what the framework owns, why an empty rule set revokes, why a
+  pre-existing `roleRef` is never adopted, the two distinct causes of a 403, and why the RBAC watches
+  are conditional.
+
+### Design rationale recorded
+
+- The name of an object the framework creates, owns, and garbage-collects is not a product decision.
+  §3's "the framework owns the NAME of every fixed slot" applied to ConfigMap/Service/StatefulSet/PDB
+  — enforced to the point of failing a build — and the ServiceAccount was the lone exception, for no
+  reason anyone could point at. Deriving it removes the shared-name failure mode by construction
+  instead of detecting it and printing a paragraph telling the author to use the other field.
+- An identity that can be switched off is an identity that will be off by accident. A ServiceAccount
+  costs nothing, so the switch was removed rather than defaulted.
+- Identity and permissions belong at the same level and in the same step. Workload RBAC as
+  `ExtraResources` put a **cluster-level** concern on a **per-role-group** path, and made every
+  product responsible for matching the RoleBinding's subject to the SA the framework had chosen. The
+  framework now passes the name it derived, so that correspondence is not something a product can get
+  wrong.
+- Cluster-scoped RBAC is out of scope, and that is a lifecycle statement rather than a limitation: a
+  namespaced CR cannot controller-own a cluster-scoped object, so there would be no garbage collection
+  with the cluster and no ownership gate on the reclaim.
+- The framework re-explains the API server's 403 rather than pre-checking it. A pre-check would have
+  to reimplement RBAC rule covering — wildcards, `resourceNames`, aggregated ClusterRoles,
+  non-resource URLs — and would then be wrong in both directions, while the server's own message has
+  already done that computation against the operator's real effective permissions.
+
 ## [2026-08-07] (the log tag stops being the container name)
 
 ### Package guides

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -753,8 +753,8 @@ Both design points are about not lying:
 The SDK adopts a layered security strategy, addressing both **Infrastructure Security** (K8s access control, Pod context) and **Application Security** (identity, encryption). The core philosophy relies on "Privilege Separation" and "Automated Provisioning."
 
 ### 4.9.2 Infrastructure Security (Operator & K8s Layer)
-- **ServiceAccount Provisioning**: The SDK can automatically manage ServiceAccounts for workloads, ensuring Pods run with appropriate identities distinct from the Operator's own identity.
-- **RBAC Integration**: Supports binding minimum required permissions (RoleBindings) to workload ServiceAccounts, adhering to the Principle of Least Privilege.
+- **ServiceAccount Provisioning**: The SDK gives every cluster a workload ServiceAccount, so Pods run with an identity distinct from the Operator's own. Its name is derived from the CR (`ServiceAccountResourceName(kind, cluster)`), not configured — see `docs/security.md` §3.1.
+- **RBAC Integration**: `GenericReconcilerConfig.WorkloadRBACRules` lets a product declare the API permissions its **pods** need; the SDK maintains the namespaced Role and RoleBinding against the derived workload ServiceAccount, adhering to the Principle of Least Privilege. Cluster-scoped RBAC is out of scope — a namespaced CR cannot controller-own it. See `docs/security.md` §3.2.
 - **Pod Security Context**: Enforces secure defaults for Pod execution (e.g., non-root users, fsGroup controls) to prevent container breakouts.
 
 ### 4.9.3 Application Security (Workload Layer)

--- a/docs/security.md
+++ b/docs/security.md
@@ -195,39 +195,114 @@ This layer focuses on how the Operator constructs the Kubernetes Pods and Resour
 
 A Product Cluster managed by the SDK can operate with its own distinct identity.
 
-- **Opt-in Provisioning**: ServiceAccount management is enabled by the operator author, not by
-  default. When `GenericReconcilerConfig.ServiceAccountNameFunc` or the static
-  `ServiceAccountName` resolves to a non-empty name, the reconciler creates (or updates) that
-  `ServiceAccount` in the CR's namespace with the CR as controller owner, and propagates the name
-  through `RoleGroupBuildContext.ServiceAccountName` into the Pod template. When both are empty, SA
-  management is skipped entirely and Pods run as the namespace `default`.
-- **Granularity is per CR, not per RoleGroup.** The name is resolved once per cluster CR; there is
-  no per-role or per-role-group ServiceAccount.
-- **Per-CR Naming (recommended)**: Products should configure `GenericReconcilerConfig.ServiceAccountNameFunc` to derive the SA name from the CR (e.g. `"<product>-<cluster name>"`). Resolution order is: per-CR func result > static `ServiceAccountName` > empty (SA management skipped). A static name shared by two clusters of the same product in one namespace breaks isolation and reconciliation: the second cluster can never take controller ownership of the shared SA (the SDK surfaces a clear error naming both owners), and deleting the first cluster garbage-collects the SA out from under the second cluster's running pods.
-- **Scope**: Pods run as this ServiceAccount, meaning any audit logs in Kubernetes will reflect the specific application identity rather than a generic "default" account.
-- **Customization**: the name is chosen by the operator author through the two config fields above —
-  the common CRD types (`GenericClusterSpec`) carry **no** `serviceAccountName` field, so there is no
-  SDK-level way for a user to override it in the CR. A product that needs external IAM integration
-  (AWS IRSA, Google Workload Identity) adds its own spec field and feeds it to
-  `ServiceAccountNameFunc`, and applies the IAM annotations to the SA itself.
+- **Unconditional Provisioning**: every cluster gets a workload `ServiceAccount`. The reconciler
+  creates (or updates) it in the CR's namespace with the CR as controller owner at step 0 of the
+  reconcile — before any extension hook or role is processed — and propagates the name through
+  `RoleGroupBuildContext.ServiceAccountName` into the Pod template. There is no switch to turn it
+  off: a ServiceAccount is pure metadata, and the opt-in it replaced mostly produced clusters
+  running as the namespace `default` by accident, which is the opposite of what this section
+  promises.
+- **The name is DERIVED, not configured**: `reconciler.ServiceAccountResourceName(kind, cluster)`
+  yields `"<lowercased kind>-<cluster>"` — an `HdfsCluster` named `prod` runs as
+  `hdfscluster-prod`. The Kind is part of it because a CR name alone is not unique in a namespace:
+  an `HdfsCluster` and a `TrinoCluster` both named `prod` would otherwise select one ServiceAccount
+  and the second controller could never take ownership of it.
 
-## 3.2 RBAC Integration (Principle of Least Privilege)
+  This follows the framework's general rule that it owns the name of every slot it owns the
+  lifecycle of (`docs/architecture.md` §3): the framework creates the object, controller-owns it and
+  garbage-collects it with the CR, so nothing needs to address it by a product-chosen name. It also
+  removes a whole failure class rather than detecting it — a configurable *static* name was a
+  constant, so every CR of a product in one namespace resolved to the SAME ServiceAccount: the
+  second cluster failed with `AlreadyOwnedError` forever, and deleting the first garbage-collected
+  the SA out from under the second's running pods.
+- **Granularity is per CR, not per RoleGroup.** One identity per cluster; there is no per-role or
+  per-role-group ServiceAccount.
+- **Scope**: Pods run as this ServiceAccount, so Kubernetes audit logs reflect the specific
+  application identity rather than a generic `default` account.
+- **Predictability is part of the contract**: `ServiceAccountResourceName` is exported so that
+  anything outside the operator that must name this ServiceAccount — a hand-written RoleBinding, an
+  admission policy, an audit query — derives it from the formula rather than from the operator's
+  source.
+- **Not user-overridable**: the common CRD types (`GenericClusterSpec`) carry **no**
+  `serviceAccountName` field, and there is no config field either. The identity is the framework's.
 
-Workloads often need to interact with the Kubernetes API (e.g., Flink JobManager creating generic Jobs, Spark driver creating executor pods).
+## 3.2 Workload RBAC (Principle of Least Privilege)
 
-- **Builders, not automation**: the SDK ships `builder.RoleBuilder`, `RoleBindingBuilder`,
-  `ClusterRoleBuilder` and `ClusterRoleBindingBuilder`, including
-  `AddServiceAccountSubject(name, namespace)` for binding the workload's SA. The
-  `GenericReconciler` itself creates **no** RBAC object: a product that needs workload RBAC builds
-  the objects and ships them through `reconciler.RoleGroupResources.ExtraResources` (or from a
-  cluster extension), which gives them the same controller owner reference and garbage-collection
-  as any other framework-applied resource.
-- **Benefit**: no manual `kubectl create rolebinding` is needed, yet the permissions are declared in
-  the product's own code and scoped strictly to what the application needs, preventing
-  over-privileged pods.
-- **Caveat**: because these are `ExtraResources`, register their GVKs with
-  `SetupWithManagerOpts(mgr, SetupWithManagerOptions{ExtraOwns: ...})`, otherwise out-of-band edits
-  to a Role or RoleBinding produce no reconcile event and are not repaired until the next resync.
+Workloads often need to interact with the Kubernetes API (e.g., a Flink JobManager creating Jobs, a
+Spark driver creating executor pods, a member electing a leader through a Lease).
+
+This is **the other half of §3.1**. That section gives the workload an *identity*; this one gives
+that identity its *permissions*. The framework maintains both at the same point in the same way —
+once per CR, at cluster level, before any role is built — and the role group merely consumes the
+result.
+
+- **The product declares rules; the framework owns everything else.** Set
+  `GenericReconcilerConfig.WorkloadRBACRules func(cr CR) []rbacv1.PolicyRule`. The framework
+  maintains a namespaced `Role` and `RoleBinding`, named after the derived ServiceAccount, in the
+  CR's namespace, with the CR as **controller** owner. The split is deliberate: only the product
+  knows what its pods call, and only the framework can guarantee the naming, the ownership, the
+  idempotent apply and the revocation.
+
+  ```go
+  WorkloadRBACRules: func(cr *v1alpha1.NifiCluster) []rbacv1.PolicyRule {
+      return []rbacv1.PolicyRule{{
+          APIGroups: []string{"coordination.k8s.io"},
+          Resources: []string{"leases"},
+          Verbs:     []string{"get", "list", "watch", "create", "update"},
+      }}
+  },
+  ```
+
+- **The framework passes the ServiceAccount name it derived itself**, so the identity and its
+  permissions cannot drift apart. That is why this is a config field rather than only the exported
+  `reconciler.EnsureWorkloadRBAC` helper: the helper takes the name as a parameter, so a caller can
+  pass one that is not the workload's, producing a Role that grants to a ServiceAccount no pod uses —
+  two objects that both exist, pods that start fine, and a 403 on the first API call. The helper
+  stays exported for a product driving the reconciler's pieces itself.
+
+- **Namespaced only, by construction.** There is no `ClusterRole` path: a namespaced CR cannot
+  controller-own a cluster-scoped object, so the framework would have no lifecycle for one — no
+  garbage collection with the cluster, and no ownership gate on the reclaim. A product that genuinely
+  needs cluster-scoped permissions maintains those objects itself, including their cleanup.
+
+- **An empty rule set REVOKES.** Returning `nil` or an empty slice deletes both objects (gated on
+  this CR controller-owning them). Like every other optional slot in the framework — a nil
+  `MetricsService` reclaims the Service — nil is an instruction, not "leave it alone". Without that
+  reading, narrowing a rule set to nothing would be the one change that silently did nothing while
+  the pods kept permissions the product had stopped granting. A **nil hook** is different from a hook
+  returning empty: nil means the product never opted in and no RBAC object is touched at all.
+
+- **A pre-existing RoleBinding is never adopted.** `roleRef` is immutable, so a RoleBinding already
+  at this name pointing elsewhere cannot be converged. The framework fails with a
+  `*reconciler.ValidationError` naming both refs and the command that fixes it, rather than rewriting
+  only the subject — which would hand this cluster's pods whatever the old ref allows, and report
+  success.
+
+- **The operator must hold what it grants.** Kubernetes refuses to let a subject grant permissions it
+  does not itself hold, so the operator's own ClusterRole must be a superset of every rule passed
+  here. This is invisible at compile time and invisible in any test running as cluster-admin (envtest
+  does), so it needs **two** kinds of marker:
+
+  ```go
+  // the rules being granted — Kubernetes forbids granting what the granter lacks
+  // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update
+  // write access to the RBAC API itself, without which nothing here can be created at all
+  // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
+  ```
+
+  A 403 has those two distinct causes needing opposite fixes, so the SDK re-explains the API server's
+  own message rather than pre-checking: that message has already computed rule covering against the
+  operator's real effective permissions (wildcards, `resourceNames`, aggregated ClusterRoles) and
+  names the missing rule.
+
+- **Watches are registered only when the hook is set.** An unconditional `Owns(&rbacv1.Role{})` would
+  force *every* operator built on this SDK to grant itself cluster-wide `list;watch` on roles and
+  rolebindings — and a forbidden informer fails `WaitForCacheSync` for **all** sources, so
+  `manager.Start` returns and the process exits. Operators that never use the feature pay nothing.
+
+- **The RBAC builders remain** (`builder.RoleBuilder`, `RoleBindingBuilder`, `ClusterRoleBuilder`,
+  `ClusterRoleBindingBuilder`) for products assembling RBAC objects the framework does not maintain.
+  They write nothing to the API server.
 
 ## 3.3 Pod Security Guidelines
 

--- a/examples/trino-operator/README.md
+++ b/examples/trino-operator/README.md
@@ -124,7 +124,8 @@ make test-e2e
 ├─────────────────────────────────────────────────────────────────┤
 │ 1. Fetch CR, record observedGeneration                          │
 │ 2. ClusterOperation gate (reconciliationPaused returns here)    │
-│ 3. Ensure ServiceAccount (when SA management is enabled)        │
+│ 3. Ensure workload ServiceAccount (always; name derived from CR)│
+│ 3b. Ensure workload RBAC (only when WorkloadRBACRules is set)   │
 │ 4. Execute Cluster PreReconcile extensions                      │
 │ 5. Validate dependencies                                        │
 │ 6. For each Role (sorted by name):                              │

--- a/pkg/builder/AGENTS.md
+++ b/pkg/builder/AGENTS.md
@@ -20,10 +20,11 @@ Every non-test file in this package:
 | `pod_override_merge.go` | The pod template strategic merge patch and `clearSupersededUnions`, which resolves the collisions the patch format cannot express |
 | `copy.go` | `cloneSlice` / `clonePtr` — the internal deep-copy helpers the builders use so `Build()` never hands out builder-owned slices or pointers |
 
-Nothing in this package writes to the API server. The RBAC builders in particular are helpers only:
-`GenericReconciler` creates no Role/RoleBinding, so a product that needs workload RBAC builds the
-objects here and ships them through `reconciler.RoleGroupResources.ExtraResources` (or its own
-extension).
+Nothing in this package writes to the API server. The RBAC builders are helpers for objects the
+framework does **not** maintain: a cluster's workload Role and RoleBinding are now owned by
+`GenericReconcilerConfig.WorkloadRBACRules` / `reconciler.EnsureWorkloadRBAC` (root `AGENTS.md`
+§11c), so reach for these builders only for RBAC outside that contract — and ship those objects
+through `reconciler.RoleGroupResources.ExtraResources` or a cluster extension.
 
 ## Builder Semantics
 

--- a/pkg/reconciler/AGENTS.md
+++ b/pkg/reconciler/AGENTS.md
@@ -10,7 +10,7 @@ Every non-test file in this package:
 
 | File | Purpose |
 |------|---------|
-| `generic_reconciler.go` | `GenericReconcilerConfig` / `GenericReconciler` — the reconcile loop, panic recovery, ServiceAccount provisioning, dependency checks, role/role-group iteration, sidecar validation, status write, `SetupWithManager*` |
+| `generic_reconciler.go` | `GenericReconcilerConfig` / `GenericReconciler` — the reconcile loop, panic recovery, workload identity + RBAC provisioning, dependency checks, role/role-group iteration, sidecar validation, status write, `SetupWithManager*` |
 | `role_group_handler.go` | `RoleGroupHandler` / `RoleGroupHandlerFuncs`, `RoleGroupBuildContext`, `RoleGroupResources`, `VolumeProvider`, `VectorAggregatorProvider`, `VectorConfigProvider`, `LoggingProducerProvider`, `MergeRoleGroupConfig`, logging-config rendering helpers |
 | `base_role_group_handler.go` | `BaseRoleGroupHandler` — the default resource builder products embed; `RoleNameProvider`, `BuildRolePodDisruptionBudget`, per-role setters |
 | `apply.go` | `copyDesiredState` — update semantics of the apply path (issue #526): labels replaced wholesale, annotations merged, per-kind spec assigned wholesale minus the API-server-owned/immutable fields that are restored from the live object (StatefulSet selector/serviceName/volumeClaimTemplates/podManagementPolicy; Service clusterIP(s)/ipFamilies/ipFamilyPolicy/healthCheckNodePort/loadBalancerClass/allocated NodePorts), unstructured top-level copy for arbitrary-GVK extras |
@@ -21,6 +21,7 @@ Every non-test file in this package:
 | `event.go` | `EventManager` — Normal/Warning event emission on the CR. `NewEventManager(recorder, scheme)`: the scheme resolves the Kind named in resource events, which the typed objects `pkg/builder` produces do not carry. The framework emits exactly `Created`/`Updated`/`Deleted` (Normal) and `ReconcileError`/`ReconcilePanic`/`PodOverrideIgnored`/`UnknownConfiguredRole`/`ImmutableFieldIgnored`/`VectorSidecarSkipped` (Warning) — **there are no reconcile start/completion events**. `LogAndEmitError`/`LogAndEmitInfo` exist for product code and the framework never calls them |
 | `discovery.go` | `EnsureDiscoveryConfigMap` — shared ensure-helper for product discovery ConfigMaps (CreateOrUpdate + controller owner ref + canonical labels; the product computes the data map) |
 | `generated_secret.go` | `EnsureGeneratedSecret` — the ensure-helper for an object whose content must NOT converge: values are generated once, a missing key is filled, an existing value is never rewritten. Controller owner ref + canonical labels, `IsAlreadyExists` tolerated |
+| `workload_rbac.go` | `EnsureWorkloadRBAC` — the namespaced `Role` + `RoleBinding` giving the cluster's PODS their API permissions, named after the derived ServiceAccount. Empty rules revoke; a foreign `roleRef` is never adopted; 403s are re-explained by cause (missing RBAC API access vs. escalation refusal) |
 | `metrics.go` | `OrphanCleanupPending` (GaugeVec) and `OrphanDrainTimeouts` (CounterVec), registered on controller-runtime's `metrics.Registry` at init, plus `forgetClusterMetrics`. The framework exports **only** the cleanup state machine — see below |
 
 There is no `reconciler.go`, `status.go` or `finalizer.go` in this package — status is written by
@@ -75,15 +76,24 @@ There is no `reconciler.go`, `status.go` or `finalizer.go` in this package — s
      `deletionTimestamp` from its own controller. The SDK's guard makes that safe — the framework
      stops re-creating resources as soon as the timestamp is set, instead of fighting the product's
      teardown for as long as the finalizer is held.
-4. **ServiceAccounts:** Prefer per-CR naming via `GenericReconcilerConfig.ServiceAccountNameFunc`
-   (e.g. `"<product>-" + cr.GetName()`). The reconciler resolves the SA name per CR (func result >
-   static `ServiceAccountName` > "" = skip), ensures the SA with the CR as controller owner
-   (`ensureServiceAccount`), and propagates the resolved name through
-   `RoleGroupBuildContext.ServiceAccountName` to the STS pod template. A static name shared by two
-   clusters in one namespace permanently fails the second cluster's reconcile (AlreadyOwnedError,
-   surfaced as a clear both-owners error) and GC-deletes the SA under the survivor when the owner
-   cluster is deleted. The SDK creates no Role/RoleBinding — see `pkg/builder` for the builders a
-   product uses to emit its own RBAC as `RoleGroupResources.ExtraResources`.
+4. **Workload identity:** nothing to configure. Every cluster gets a ServiceAccount named
+   `ServiceAccountResourceName(kind, cluster)` = `"<lowercased kind>-<cluster>"`
+   (`hdfscluster-prod`). The reconciler ensures it with the CR as controller owner
+   (`ensureServiceAccount`) at step 0 and propagates the same derived name through
+   `RoleGroupBuildContext.ServiceAccountName` — never empty — to the STS pod template. The Kind is
+   in the name because a CR name alone is not unique in a namespace; the name is derived rather
+   than configured because the framework owns the object's whole lifecycle. Exported because things
+   outside the operator have to name the SA.
+4b. **Workload RBAC:** `GenericReconcilerConfig.WorkloadRBACRules func(cr CR) []rbacv1.PolicyRule`
+   declares what the cluster's PODS call; the framework maintains a namespaced `Role` +
+   `RoleBinding` at the derived SA's name, controller-owned by the CR (`workload_rbac.go`,
+   `EnsureWorkloadRBAC`). Namespaced only — a namespaced CR cannot own a `ClusterRole`. An empty
+   rule set REVOKES (ownership-gated); a **nil hook** touches nothing. A pre-existing RoleBinding
+   with a different `roleRef` is never adopted (immutable field) and fails with a
+   `*ValidationError`. Setting the hook requires the operator to hold those permissions itself plus
+   write access to the RBAC API; the RBAC watches are registered only when the hook is set, because
+   a forbidden informer kills the whole manager. `pkg/builder`'s RBAC builders remain for objects
+   the framework does not maintain.
 5. **External dependencies:** Declare referenced ConfigMaps/Secrets with
    `GenericReconcilerConfig.Dependencies func(cr CR) []Dependency`. They are checked before any
    role is reconciled; a missing one aborts the cycle with a Degraded condition. Nil = no checks.
@@ -306,7 +316,8 @@ recovery that turns a recovered panic into a returned error plus a `ReconcilePan
 
 0. `ClusterOperation` gate — `reconciliationPaused` returns immediately; `stopped` falls through
    (replicas are forced to 0 downstream so every resource is still reconciled).
-1. ServiceAccount ensure (when configured), unknown-configured-role warning.
+1. ServiceAccount ensure (always; name derived from the CR), workload RBAC ensure (only when
+   `WorkloadRBACRules` is set), unknown-configured-role warning.
 2. Cluster `PreReconcile` extensions.
 3. Declared dependency validation.
 4. Per role: role `PreReconcile` → per role group (`PreReconcile` → build context →

--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -156,9 +156,25 @@ type GenericReconcilerConfig[CR common.ClusterResource[CR]] struct {
 	// ClusterRole path: a namespaced CR cannot controller-own a cluster-scoped object, so the
 	// framework would have no lifecycle for one.
 	//
-	// Returning an empty slice REVOKES them. Like every other optional slot in this framework, nil
-	// is an instruction rather than "leave it alone" — a nil MetricsService reclaims the Service —
-	// and it is the only reading that makes a rule set shrinking to nothing actually stop granting.
+	// There are two distinct "nothing" cases, and they mean OPPOSITE things:
+	//
+	//	WorkloadRBACRules == nil            this product does not use workload RBAC. No Role or
+	//	                                    RoleBinding is read, written or deleted, and the
+	//	                                    operator needs no RBAC permissions at all.
+	//
+	//	WorkloadRBACRules returns nil       this cluster is granted nothing. The Role and
+	//	  (or an empty slice)               RoleBinding are DELETED if this CR controller-owns
+	//	                                    them, so the pods stop holding the permissions.
+	//
+	// The second is the same reading every other optional slot in this framework gets — a nil
+	// MetricsService reclaims the Service — and it is the only one under which a rule set that
+	// shrinks to nothing actually stops granting. The first exists so that operators which never
+	// opted in pay nothing: running a revoke every reconcile would cost two API reads per cluster
+	// and demand RBAC read permission from every operator built on this SDK.
+	//
+	// A hook that returns rules conditionally therefore revokes on the passes where its condition
+	// is false, which is usually what a product wants; leaving the hook unset is how a product says
+	// "not my concern" rather than "not right now".
 	//
 	// The framework passes the ServiceAccount name it derived itself, so the identity and the
 	// permissions cannot drift apart. That is why this is a config field and not only the exported

--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -39,6 +39,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -132,32 +133,44 @@ type GenericReconcilerConfig[CR common.ClusterResource[CR]] struct {
 	// +optional
 	DrainTimeout time.Duration
 
-	// ServiceAccountName is the static name of the ServiceAccount to create for the workload.
-	// When set (and ServiceAccountNameFunc is nil or returns ""), the GenericReconciler
-	// automatically creates (or updates) a ServiceAccount with this name in the CR's namespace
-	// at the start of each reconciliation and propagates it to the workload pod template via
-	// RoleGroupBuildContext.ServiceAccountName.
+	// WorkloadRBACRules, when set, declares the Kubernetes API permissions this cluster's WORKLOAD
+	// pods need — the product's own processes calling the API, not the operator's permissions,
+	// which come from its ClusterRole and are a separate axis entirely.
 	//
-	// WARNING: a static name is shared by every CR of the product in a namespace. With two
-	// clusters in one namespace, the second cluster can never take controller ownership of the
-	// shared SA (its reconcile fails permanently), and deleting the first cluster garbage-collects
-	// the SA out from under the second cluster's running pods. Prefer ServiceAccountNameFunc for
-	// per-CR naming; keep this field only as a fallback or for single-cluster-per-namespace use.
-	// +optional
-	ServiceAccountName string
-
-	// ServiceAccountNameFunc computes the ServiceAccount name per CR at reconcile time.
-	// When set and returning a non-empty string, its result takes precedence over the static
-	// ServiceAccountName. When it returns "", the static ServiceAccountName is used as fallback;
-	// if that is also empty, ServiceAccount management is skipped entirely.
+	// It is the other half of the workload's ServiceAccount. That gives the workload an IDENTITY;
+	// this gives that identity its PERMISSIONS, and the framework maintains both at the same point
+	// in the same way: once per CR, at cluster level, before any role is built. A role group merely
+	// consumes the result — the ServiceAccount name reaches the pod template through
+	// RoleGroupBuildContext.ServiceAccountName, and the Role is already bound to it.
 	//
-	// RECOMMENDED for multi-cluster namespaces: derive the name from the CR, e.g.
-	// "<product>-<cr name>" ("kafka-" + cr.GetName()), so each cluster owns its own SA. This
-	// avoids the shared-SA failure mode described on ServiceAccountName (permanent ownership
-	// conflict for the second cluster, and SA garbage collection when the first cluster is
-	// deleted).
+	//	WorkloadRBACRules: func(cr *v1alpha1.NifiCluster) []rbacv1.PolicyRule {
+	//	    return []rbacv1.PolicyRule{{
+	//	        APIGroups: []string{"coordination.k8s.io"},
+	//	        Resources: []string{"leases"},
+	//	        Verbs:     []string{"get", "list", "watch", "create", "update"},
+	//	    }}
+	//	},
+	//
+	// The Role and RoleBinding are namespaced, named after the derived ServiceAccount and
+	// controller-owned by the CR, so they are garbage-collected with it. There is deliberately no
+	// ClusterRole path: a namespaced CR cannot controller-own a cluster-scoped object, so the
+	// framework would have no lifecycle for one.
+	//
+	// Returning an empty slice REVOKES them. Like every other optional slot in this framework, nil
+	// is an instruction rather than "leave it alone" — a nil MetricsService reclaims the Service —
+	// and it is the only reading that makes a rule set shrinking to nothing actually stop granting.
+	//
+	// The framework passes the ServiceAccount name it derived itself, so the identity and the
+	// permissions cannot drift apart. That is why this is a config field and not only the exported
+	// EnsureWorkloadRBAC helper: the helper takes the name as a parameter, so a caller can pass one
+	// that is not the workload's, producing a Role that grants to a ServiceAccount no pod uses —
+	// two objects that both exist, pods that start fine, and a 403 on the first API call.
+	//
+	// Setting this REQUIRES the operator to hold these permissions itself — Kubernetes forbids
+	// granting what the granter lacks — plus write access to the RBAC API. Both are kubebuilder
+	// markers on the operator; see EnsureWorkloadRBAC for the exact failure messages.
 	// +optional
-	ServiceAccountNameFunc func(cr CR) string
+	WorkloadRBACRules func(cr CR) []rbacv1.PolicyRule
 
 	// ProductConfig, when set, computes the product's configuration contribution for a role
 	// group at reconcile time, returned as an *v1alpha1.OverridesSpec (the same shape users
@@ -261,12 +274,10 @@ type GenericReconciler[CR common.ClusterResource[CR]] struct {
 	// healthCheckInterval is the cadence at which a successful reconcile requeues itself; <= 0
 	// disables periodic requeue (see reconcile's wakeup aggregation).
 	healthCheckInterval time.Duration
-	serviceAccountName  string
-	// serviceAccountNameFunc, when set, resolves a per-CR SA name that takes precedence over
-	// the static serviceAccountName (see resolveServiceAccountName).
-	serviceAccountNameFunc func(cr CR) string
-	productConfig          func(ctx context.Context, c client.Client, cr CR, roleName, roleGroupName string) (*v1alpha1.OverridesSpec, error)
-	dependencies           func(cr CR) []Dependency
+	// workloadRBACRules, when set, declares the workload's API permissions (see the config field).
+	workloadRBACRules func(cr CR) []rbacv1.PolicyRule
+	productConfig     func(ctx context.Context, c client.Client, cr CR, roleName, roleGroupName string) (*v1alpha1.OverridesSpec, error)
+	dependencies      func(cr CR) []Dependency
 }
 
 // NewGenericReconciler creates a new GenericReconciler.
@@ -331,24 +342,23 @@ func NewGenericReconciler[CR common.ClusterResource[CR]](cfg *GenericReconcilerC
 	}
 
 	return &GenericReconciler[CR]{
-		client:                 cfg.Client,
-		apiReader:              cfg.APIReader,
-		scheme:                 cfg.Scheme,
-		k8sUtil:                util.NewK8sUtil(cfg.Client, cfg.Scheme),
-		healthManager:          healthManager,
-		dependencyResolver:     NewDependencyResolver(cfg.Client),
-		cleaner:                cleaner,
-		eventManager:           eventManager,
-		configMerger:           config.NewConfigMerger(),
-		roleGroupHandler:       cfg.RoleGroupHandler,
-		extensionRegistry:      extensionRegistry,
-		prototype:              cfg.Prototype,
-		rateLimitRetryAfter:    rateLimitRetryAfter,
-		healthCheckInterval:    healthCheckInterval,
-		serviceAccountName:     cfg.ServiceAccountName,
-		serviceAccountNameFunc: cfg.ServiceAccountNameFunc,
-		productConfig:          cfg.ProductConfig,
-		dependencies:           cfg.Dependencies,
+		client:              cfg.Client,
+		apiReader:           cfg.APIReader,
+		scheme:              cfg.Scheme,
+		k8sUtil:             util.NewK8sUtil(cfg.Client, cfg.Scheme),
+		healthManager:       healthManager,
+		dependencyResolver:  NewDependencyResolver(cfg.Client),
+		cleaner:             cleaner,
+		eventManager:        eventManager,
+		configMerger:        config.NewConfigMerger(),
+		roleGroupHandler:    cfg.RoleGroupHandler,
+		extensionRegistry:   extensionRegistry,
+		prototype:           cfg.Prototype,
+		rateLimitRetryAfter: rateLimitRetryAfter,
+		healthCheckInterval: healthCheckInterval,
+		workloadRBACRules:   cfg.WorkloadRBACRules,
+		productConfig:       cfg.ProductConfig,
+		dependencies:        cfg.Dependencies,
 	}, nil
 }
 
@@ -520,13 +530,25 @@ func (r *GenericReconciler[CR]) reconcile(ctx context.Context, cr CR, stored cli
 		}
 	}
 
-	// 0. Auto-create ServiceAccount if configured. The name is resolved per CR (per-CR func
-	// wins over the static name; empty means SA management is disabled) so that two clusters
-	// of the same product in one namespace each own their own SA.
-	if saName := r.resolveServiceAccountName(cr); saName != "" {
-		if err := r.ensureServiceAccount(ctx, cr, saName); err != nil {
-			return ctrl.Result{}, NewReconcileError("ServiceAccount", "failed to ensure service account", err)
-		}
+	// 0. The workload's identity. EVERY cluster gets one, with no way to turn it off, which is
+	// what makes docs/security.md's claim true for every product rather than only the ones that
+	// opted in: "audit logs reflect the specific application identity rather than a generic
+	// default account". A ServiceAccount is pure metadata, so the cost of always having one does
+	// not buy a switch whose main effect was clusters running as `default` by accident.
+	//
+	// The name is derived from the CR (kind + name), so there is nothing to configure here and
+	// nothing for two clusters in one namespace to collide over.
+	saName := r.resolveServiceAccountName(cr)
+	if err := r.ensureServiceAccount(ctx, cr, saName); err != nil {
+		return ctrl.Result{}, NewReconcileError("ServiceAccount", "failed to ensure service account", err)
+	}
+
+	// 0b. The workload's PERMISSIONS, immediately after its IDENTITY and from the same derived
+	// name, so the two cannot drift apart. Both are per-CR, both are settled before any role is
+	// built, and the role group only consumes the result (the SA name reaches the pod template
+	// through RoleGroupBuildContext.ServiceAccountName, already bound to the Role).
+	if err := r.ensureWorkloadRBAC(ctx, cr, saName); err != nil {
+		return ctrl.Result{}, NewReconcileError("WorkloadRBAC", "failed to ensure workload RBAC", err)
 	}
 
 	// 1. Execute PreReconcile extensions
@@ -931,6 +953,47 @@ func RoleResourceName(clusterName, roleName string) string {
 	return fmt.Sprintf("%s-%s", clusterName, roleName)
 }
 
+// maxServiceAccountNameLen bounds ServiceAccountResourceName. A ServiceAccount name is validated
+// as a DNS subdomain, so 253 is the real limit; the CR name feeding it is itself capped at 253,
+// which is why truncation here only ever guards the pathological case.
+const maxServiceAccountNameLen = 253
+
+// ServiceAccountResourceName returns the canonical name of the ServiceAccount a cluster's workload
+// pods run as: "<lowercased kind>-<cluster>", e.g. "hdfscluster-prod".
+//
+// There is deliberately no config field for this name, for the same reason every other
+// framework-owned name is derived (AGENTS.md §3, "the framework owns the NAME of every fixed
+// slot"): the framework creates the object, controller-owns it, garbage-collects it with the CR
+// and binds WorkloadRBACRules to it, so nothing needs to address it by a name the product chose.
+// Letting the product choose is what produced the failure class this replaced — a static name is a
+// constant, so every CR of a product in one namespace resolved to the SAME ServiceAccount:
+// whichever cluster reconciled second failed with AlreadyOwnedError forever, and deleting the
+// first garbage-collected the SA out from under the second's running pods.
+//
+// The Kind is part of it because the CR name alone is not unique within a namespace: an
+// HdfsCluster and a TrinoCluster both named "prod" would otherwise derive the same ServiceAccount,
+// and whichever controller reconciled second could never take ownership of it — reintroducing that
+// same collision one level down.
+//
+// It is exported because it is a CONTRACT, not an implementation detail: anything outside the
+// operator that has to name this ServiceAccount — a hand-written RoleBinding, an admission policy,
+// an audit query — should derive it from the formula rather than read it out of the operator's
+// source.
+//
+// Like RoleGroupResourceName it is bounded with a deterministic hash suffix, but against a much
+// looser limit: a ServiceAccount name is a DNS subdomain (253), not the 63-byte DNS label that
+// constrains a Service name.
+func ServiceAccountResourceName(kind, clusterName string) string {
+	name := strings.ToLower(kind) + "-" + clusterName
+	if len(name) <= maxServiceAccountNameLen {
+		return name
+	}
+	sum := sha256.Sum256([]byte(name))
+	suffix := hex.EncodeToString(sum[:])[:8]
+	head := strings.TrimRight(name[:maxServiceAccountNameLen-len(suffix)-1], "-")
+	return head + "-" + suffix
+}
+
 // RoleGroupMarkerLabelKey returns the label key that marks a resource as belonging to one specific
 // role group: "<cluster>-<group>", or a bounded substitute when that is not a legal label key.
 //
@@ -1001,8 +1064,8 @@ func (r *GenericReconciler[CR]) buildRoleGroupContext(ctx context.Context, cr CR
 		MergedConfig:     mergedConfig,
 		ResourceName:     resourceName,
 		// Propagate the reconciler-managed ServiceAccount so the workload pods actually run as
-		// the SA the reconciler creates. Resolved per CR (per-CR func over static name), and
-		// empty when no SA is configured (backward compatible).
+		// the SA the reconciler creates. Derived from the CR (kind + name), never configured and
+		// never empty — this is the consumption half of the identity settled at step 0.
 		ServiceAccountName: r.resolveServiceAccountName(cr),
 	}, nil
 }
@@ -1690,6 +1753,15 @@ func (r *GenericReconciler[CR]) ControllerBuilder(mgr ctrl.Manager, opts SetupWi
 		Owns(&policyv1.PodDisruptionBudget{}).
 		Owns(&corev1.ServiceAccount{})
 
+	// The RBAC watches are registered ONLY when the product declares workload rules. An
+	// unconditional Owns() would force every operator built on this SDK to grant itself cluster-wide
+	// list;watch on roles and rolebindings — and a forbidden informer fails WaitForCacheSync for ALL
+	// sources, so manager.Start returns and the process exits. Charging that to operators that never
+	// use the feature is a cost that has to stay at zero.
+	if r.workloadRBACRules != nil {
+		b = b.Owns(&rbacv1.Role{}).Owns(&rbacv1.RoleBinding{})
+	}
+
 	for _, obj := range opts.ExtraOwns {
 		if obj == nil {
 			continue
@@ -1705,26 +1777,26 @@ func (r *GenericReconciler[CR]) ControllerBuilder(mgr ctrl.Manager, opts SetupWi
 	return b
 }
 
-// resolveServiceAccountName resolves the ServiceAccount name for a CR.
-// Precedence: ServiceAccountNameFunc (when set and returning non-empty) > static
-// ServiceAccountName > "" (SA management skipped). Per-CR naming is what keeps two clusters
-// of the same product in one namespace from fighting over a single shared SA.
+// resolveServiceAccountName returns the name of the ServiceAccount this cluster's workload runs
+// as. It is DERIVED from the CR — never configured, never empty — so the identity a role group
+// consumes and the object step 0 ensured are the same string by construction rather than by two
+// call sites agreeing.
+//
+// The Kind comes from the scheme (resolveKind), which resolves it from the Go type, so it is
+// stable across a fetched CR and a prototype even though the typed client strips TypeMeta.
 func (r *GenericReconciler[CR]) resolveServiceAccountName(cr CR) string {
-	if r.serviceAccountNameFunc != nil {
-		if name := r.serviceAccountNameFunc(cr); name != "" {
-			return name
-		}
-	}
-	return r.serviceAccountName
+	return ServiceAccountResourceName(r.resourceKind(cr), cr.GetName())
 }
 
 // ensureServiceAccount creates or updates the ServiceAccount for the cluster workload and sets
 // the CR as its controller owner.
 //
 // Guard rail: if an SA with this name already exists but is controlled by a DIFFERENT owner,
-// SetControllerReference refuses to steal it; that raw AlreadyOwnedError is wrapped in an
-// explicit error naming both owners, because it almost always means two CRs were configured to
-// share one static ServiceAccountName — the fix is per-CR naming via ServiceAccountNameFunc.
+// SetControllerReference refuses to steal it and the raw AlreadyOwnedError is wrapped in an error
+// naming both owners. With a derived name this no longer means "two clusters were configured onto
+// one SA" — that is now unrepresentable — so it means something ELSE occupies the derived name,
+// which the framework must not adopt: adopting it would hand these pods whatever identity that
+// object already carries.
 func (r *GenericReconciler[CR]) ensureServiceAccount(ctx context.Context, cr CR, name string) error {
 	sa := &corev1.ServiceAccount{}
 	sa.Name = name
@@ -1747,13 +1819,15 @@ func (r *GenericReconciler[CR]) ensureServiceAccount(ctx context.Context, cr CR,
 		labels[constant.LabelKubernetesInstance] = cr.GetName()
 		labels[constant.LabelKubernetesManagedBy] = managedByValue
 		sa.Labels = labels
+
 		if err := controllerutil.SetControllerReference(cr, sa, r.scheme); err != nil {
 			var alreadyOwned *controllerutil.AlreadyOwnedError
 			if stderrors.As(err, &alreadyOwned) {
 				return fmt.Errorf(
-					"ServiceAccount %s/%s is already controlled by %s %q and cannot be adopted by %s %q: "+
-						"multiple clusters appear to share one ServiceAccount name; "+
-						"use per-CR naming (GenericReconcilerConfig.ServiceAccountNameFunc, e.g. \"<product>-<cluster>\"): %w",
+					"ServiceAccount %s/%s is already controlled by %s %q and cannot be adopted by %s %q. "+
+						"This name is derived from the CR (kind + name), so it is not a naming collision "+
+						"between two clusters: something else occupies it. Delete that object, or rename "+
+						"the cluster: %w",
 					sa.Namespace, sa.Name,
 					alreadyOwned.Owner.Kind, alreadyOwned.Owner.Name,
 					r.resourceKind(cr), cr.GetName(),
@@ -1764,5 +1838,30 @@ func (r *GenericReconciler[CR]) ensureServiceAccount(ctx context.Context, cr CR,
 		}
 		return nil
 	})
-	return err
+	// Route the API error through the same translation applyResource uses. A 429 here is the API
+	// server asking for a pause, not a broken cluster, and this step is now on EVERY cluster's
+	// critical path — returning the raw error would run the product's error hooks and flip Degraded
+	// on a cluster nobody was able to read yet. While the SA was opt-in this branch was reachable
+	// only by the products that configured one, which is why the gap survived.
+	return r.apiError(err)
+}
+
+// ensureWorkloadRBAC maintains the workload's namespaced Role and RoleBinding from the rules the
+// product declared, bound to the ServiceAccount name this cycle already derived and ensured.
+//
+// A nil WorkloadRBACRules hook means the product never opted in, and does NOT reach
+// EnsureWorkloadRBAC: an empty rule set there means REVOKE, and running a revoke every reconcile
+// for every operator that has no workload RBAC would issue two pointless Gets per cluster per pass
+// and, worse, require the RBAC read permission from operators that never asked for the feature.
+// A hook that is set and RETURNS empty is a different statement — that is the product revoking —
+// and does go through.
+func (r *GenericReconciler[CR]) ensureWorkloadRBAC(ctx context.Context, cr CR, serviceAccountName string) error {
+	if r.workloadRBACRules == nil {
+		return nil
+	}
+	if err := EnsureWorkloadRBAC(ctx, r.client, r.scheme, cr, serviceAccountName, r.workloadRBACRules(cr)); err != nil {
+		// Same reasoning as ensureServiceAccount: a 429 is a request to back off, not a fault.
+		return r.apiError(err)
+	}
+	return nil
 }

--- a/pkg/reconciler/generic_reconciler_test.go
+++ b/pkg/reconciler/generic_reconciler_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -28,6 +29,7 @@ import (
 	"github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
 	"github.com/zncdatadev/operator-go/pkg/common"
 	"github.com/zncdatadev/operator-go/pkg/config"
+	"github.com/zncdatadev/operator-go/pkg/constant"
 	"github.com/zncdatadev/operator-go/pkg/reconciler"
 	"github.com/zncdatadev/operator-go/pkg/testutil"
 	appsv1 "k8s.io/api/apps/v1"
@@ -887,24 +889,24 @@ var _ = Describe("GenericReconciler Integration Tests", func() {
 // Regression coverage for issue #511: the ClusterOperation pause/stop gate must be evaluated at
 // the very top of reconcile(), BEFORE any resource mutation. Previously the gate lived in
 // dependency validation (step 2), so a paused cluster still provisioned its ServiceAccount and ran
-// PreReconcile extensions before returning early. These tests wire a real GenericReconciler with a
-// configured ServiceAccountName and assert the SA is never created while paused (and still is when
-// the cluster proceeds normally).
+// PreReconcile extensions before returning early. These tests assert the SA is never created while
+// paused (and still is when the cluster proceeds normally).
+//
+// The SA name is derived from the CR, so each spec's unique CR name gives it a unique SA name and
+// parallel/ordered specs cannot observe each other's ServiceAccounts.
 var _ = Describe("GenericReconciler ClusterOperation gate ordering (issue #511)", func() {
 	var (
 		mockHandler *testutil.MockRoleGroupHandler
 		namespace   string
-		saName      string
 	)
 
 	newReconciler := func(prototype *testutil.MockCluster) *reconciler.GenericReconciler[*testutil.MockCluster] {
 		cfg := &reconciler.GenericReconcilerConfig[*testutil.MockCluster]{
-			Client:             k8sClient,
-			Scheme:             testScheme,
-			Recorder:           recorder,
-			RoleGroupHandler:   &handlerAdapter{handler: mockHandler},
-			Prototype:          prototype,
-			ServiceAccountName: saName,
+			Client:           k8sClient,
+			Scheme:           testScheme,
+			Recorder:         recorder,
+			RoleGroupHandler: &handlerAdapter{handler: mockHandler},
+			Prototype:        prototype,
 		}
 		r, err := reconciler.NewGenericReconciler(cfg)
 		Expect(err).NotTo(HaveOccurred())
@@ -912,15 +914,25 @@ var _ = Describe("GenericReconciler ClusterOperation gate ordering (issue #511)"
 		return r
 	}
 
-	saLookup := func() error {
-		return k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: saName}, &corev1.ServiceAccount{})
+	saNameFor := func(crName string) string {
+		return reconciler.ServiceAccountResourceName("MockCluster", crName)
+	}
+
+	saLookup := func(crName string) error {
+		return k8sClient.Get(ctx,
+			types.NamespacedName{Namespace: namespace, Name: saNameFor(crName)},
+			&corev1.ServiceAccount{})
+	}
+
+	deleteSAFor := func(crName string) {
+		_ = k8sClient.Delete(ctx, &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{Name: saNameFor(crName), Namespace: namespace},
+		})
 	}
 
 	BeforeEach(func() {
 		namespace = testNamespace
 		mockHandler = testutil.NewMockRoleGroupHandler()
-		// Unique SA name per spec run so parallel/ordered specs don't observe each other's SAs.
-		saName = fmt.Sprintf("gate-sa-%d", time.Now().UnixNano())
 	})
 
 	Context("when reconciliation is paused", func() {
@@ -944,14 +956,12 @@ var _ = Describe("GenericReconciler ClusterOperation gate ordering (issue #511)"
 		AfterEach(func() {
 			Expect(k8sClient.Delete(ctx, pausedCR)).To(Succeed())
 			// Best-effort cleanup in case a regression re-created the SA.
-			_ = k8sClient.Delete(ctx, &corev1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: namespace},
-			})
+			deleteSAFor(crName)
 		})
 
 		It("must NOT create the ServiceAccount (the pre-gate mutation the bug caused)", func() {
 			// Guard: SA must not pre-exist.
-			Expect(saLookup()).NotTo(Succeed())
+			Expect(saLookup(crName)).NotTo(Succeed())
 
 			r := newReconciler(pausedCR)
 			req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: crName}}
@@ -962,7 +972,7 @@ var _ = Describe("GenericReconciler ClusterOperation gate ordering (issue #511)"
 				"the pause still re-observes on the health cadence")
 
 			// The pause gate runs before ensureServiceAccount, so the SA must still be absent.
-			err = saLookup()
+			err = saLookup(crName)
 			Expect(err).To(HaveOccurred())
 			Expect(k8serrors.IsNotFound(err)).To(BeTrue(), "ServiceAccount should not have been created while paused")
 
@@ -995,9 +1005,7 @@ var _ = Describe("GenericReconciler ClusterOperation gate ordering (issue #511)"
 
 		AfterEach(func() {
 			Expect(k8sClient.Delete(ctx, runningCR)).To(Succeed())
-			_ = k8sClient.Delete(ctx, &corev1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: namespace},
-			})
+			deleteSAFor(crName)
 		})
 
 		It("proceeds normally and DOES create the ServiceAccount", func() {
@@ -1008,7 +1016,7 @@ var _ = Describe("GenericReconciler ClusterOperation gate ordering (issue #511)"
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(Equal(ctrl.Result{RequeueAfter: reconciler.DefaultHealthCheckInterval}))
 
-			Expect(saLookup()).To(Succeed(), "ServiceAccount should be created for an un-paused cluster")
+			Expect(saLookup(crName)).To(Succeed(), "ServiceAccount should be created for an un-paused cluster")
 		})
 	})
 
@@ -1032,9 +1040,7 @@ var _ = Describe("GenericReconciler ClusterOperation gate ordering (issue #511)"
 
 		AfterEach(func() {
 			Expect(k8sClient.Delete(ctx, stoppedCR)).To(Succeed())
-			_ = k8sClient.Delete(ctx, &corev1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{Name: saName, Namespace: namespace},
-			})
+			deleteSAFor(crName)
 			_ = k8sClient.Delete(ctx, &appsv1.StatefulSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      reconciler.RoleGroupResourceName(crName, "test-role", "default"),
@@ -1052,7 +1058,7 @@ var _ = Describe("GenericReconciler ClusterOperation gate ordering (issue #511)"
 			stsName := reconciler.RoleGroupResourceName(crName, "test-role", "default")
 
 			// Guards: neither the SA nor the StatefulSet pre-exists.
-			Expect(k8serrors.IsNotFound(saLookup())).To(BeTrue())
+			Expect(k8serrors.IsNotFound(saLookup(crName))).To(BeTrue())
 			Expect(k8serrors.IsNotFound(
 				k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: stsName}, &appsv1.StatefulSet{}),
 			)).To(BeTrue())
@@ -1065,7 +1071,7 @@ var _ = Describe("GenericReconciler ClusterOperation gate ordering (issue #511)"
 			Expect(result).To(Equal(ctrl.Result{RequeueAfter: reconciler.DefaultHealthCheckInterval}))
 
 			// The ServiceAccount IS provisioned (stopped runs the full reconcile).
-			Expect(saLookup()).To(Succeed(), "ServiceAccount should be created for a stopped cluster under the new design")
+			Expect(saLookup(crName)).To(Succeed(), "ServiceAccount should be created for a stopped cluster under the new design")
 
 			// The StatefulSet is CREATED with 0 replicas so the cluster can be resumed.
 			fetched := &appsv1.StatefulSet{}
@@ -1090,11 +1096,13 @@ func (h *saCapturingHandler) BuildResources(ctx context.Context, k8sClient clien
 	return h.inner.BuildResources(ctx, k8sClient, cr, buildCtx)
 }
 
-// Coverage for per-CR ServiceAccount naming: a static ServiceAccountName is shared by every CR
-// of a product in a namespace, so the second cluster hits AlreadyOwnedError forever and deleting
-// the first cluster garbage-collects the SA out from under the second. ServiceAccountNameFunc
-// resolves a per-CR name (precedence: func result > static name > "" = skip SA management).
-var _ = Describe("GenericReconciler per-CR ServiceAccount naming", func() {
+// Coverage for the DERIVED workload ServiceAccount name. The name is
+// ServiceAccountResourceName(kind, cluster) and there is no config field for it, which is what
+// makes the failure class it replaced unrepresentable: a configurable static name was a constant,
+// so every CR of a product in one namespace resolved to the SAME ServiceAccount — the second
+// cluster hit AlreadyOwnedError forever and deleting the first garbage-collected the SA out from
+// under the second's running pods.
+var _ = Describe("GenericReconciler derived workload ServiceAccount", func() {
 	var (
 		mockHandler *testutil.MockRoleGroupHandler
 		capturing   *saCapturingHandler
@@ -1102,19 +1110,22 @@ var _ = Describe("GenericReconciler per-CR ServiceAccount naming", func() {
 		testID      string
 	)
 
-	newReconciler := func(prototype *testutil.MockCluster, staticName string, nameFunc func(cr *testutil.MockCluster) string) *reconciler.GenericReconciler[*testutil.MockCluster] {
+	newReconciler := func(prototype *testutil.MockCluster) *reconciler.GenericReconciler[*testutil.MockCluster] {
 		cfg := &reconciler.GenericReconcilerConfig[*testutil.MockCluster]{
-			Client:                 k8sClient,
-			Scheme:                 testScheme,
-			Recorder:               recorder,
-			RoleGroupHandler:       capturing,
-			Prototype:              prototype,
-			ServiceAccountName:     staticName,
-			ServiceAccountNameFunc: nameFunc,
+			Client:           k8sClient,
+			Scheme:           testScheme,
+			Recorder:         recorder,
+			RoleGroupHandler: capturing,
+			Prototype:        prototype,
 		}
 		r, err := reconciler.NewGenericReconciler(cfg)
 		Expect(err).NotTo(HaveOccurred())
 		return r
+	}
+
+	// The name the framework will derive for a MockCluster CR.
+	saNameFor := func(crName string) string {
+		return reconciler.ServiceAccountResourceName("MockCluster", crName)
 	}
 
 	newCR := func(name string) *testutil.MockCluster {
@@ -1153,91 +1164,86 @@ var _ = Describe("GenericReconciler per-CR ServiceAccount naming", func() {
 		testID = fmt.Sprintf("%d", time.Now().UnixNano())
 	})
 
-	It("uses the per-CR func over the static name and wires it into the build context", func() {
-		crName := "sa-func-" + testID
-		staticName := "sa-static-" + testID
-		perCRName := "sa-per-cr-" + crName
+	It("derives the SA name from the CR and wires it into the build context", func() {
+		crName := "sa-derived-" + testID
+		derived := saNameFor(crName)
 		cr := newCR(crName)
 		defer func() {
 			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
-			deleteSA(perCRName)
-			deleteSA(staticName)
+			deleteSA(derived)
 		}()
 
-		r := newReconciler(cr, staticName, func(c *testutil.MockCluster) string {
-			return "sa-per-cr-" + c.GetName()
-		})
+		// Nothing is configured — the name comes from the CR alone.
+		r := newReconciler(cr)
 
 		_, err := reconcileReq(r, crName)
 		Expect(err).NotTo(HaveOccurred())
 
-		// The per-CR named SA exists and is controller-owned by this CR.
-		sa, err := getSA(perCRName)
+		// The derived SA exists, is controller-owned by this CR, and carries the canonical labels
+		// every other framework-built object carries.
+		sa, err := getSA(derived)
 		Expect(err).NotTo(HaveOccurred())
+		Expect(sa.Name).To(Equal("mockcluster-" + crName))
 		ownerRef := metav1.GetControllerOf(sa)
 		Expect(ownerRef).NotTo(BeNil())
 		Expect(ownerRef.Name).To(Equal(crName))
 		Expect(ownerRef.Kind).To(Equal("MockCluster"))
+		Expect(sa.Labels).To(HaveKeyWithValue(constant.LabelKubernetesInstance, crName))
+		Expect(sa.Labels).To(HaveKeyWithValue(constant.LabelKubernetesManagedBy, "operator-go"))
 
-		// The static-named SA is never created when the func resolves a name.
-		_, err = getSA(staticName)
-		Expect(k8serrors.IsNotFound(err)).To(BeTrue(), "static SA must not be created when the per-CR func resolves")
-
-		// The resolved name flows through RoleGroupBuildContext to resource building (the base
-		// handler binds it to the pod template; see base_role_group_handler_test.go).
+		// The same name flows through RoleGroupBuildContext to resource building (the base handler
+		// binds it to the pod template; see base_role_group_handler_test.go). Deriving it in both
+		// places from one function is what keeps the ensured object and the consumed identity from
+		// drifting apart.
 		Expect(capturing.seenSANames).NotTo(BeEmpty())
 		for _, seen := range capturing.seenSANames {
-			Expect(seen).To(Equal(perCRName))
+			Expect(seen).To(Equal(derived))
 		}
 	})
 
-	It("falls back to the static name when the func is nil", func() {
-		crName := "sa-nilfunc-" + testID
-		staticName := "sa-static-nil-" + testID
+	It("gives every cluster an SA with nothing configured", func() {
+		// The identity is not opt-in. Before this, a product that set neither config field got no
+		// ServiceAccount at all and its pods ran as the namespace `default` — the exact opposite of
+		// what docs/security.md claims the framework guarantees.
+		crName := "sa-always-" + testID
 		cr := newCR(crName)
 		defer func() {
 			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
-			deleteSA(staticName)
+			deleteSA(saNameFor(crName))
 		}()
 
-		r := newReconciler(cr, staticName, nil)
-
+		r := newReconciler(cr)
 		_, err := reconcileReq(r, crName)
 		Expect(err).NotTo(HaveOccurred())
 
-		sa, err := getSA(staticName)
-		Expect(err).NotTo(HaveOccurred())
-		ownerRef := metav1.GetControllerOf(sa)
-		Expect(ownerRef).NotTo(BeNil())
-		Expect(ownerRef.Name).To(Equal(crName))
+		_, err = getSA(saNameFor(crName))
+		Expect(err).NotTo(HaveOccurred(), "every cluster gets a workload ServiceAccount, with nothing to configure")
 	})
 
-	It("falls back to the static name when the func returns empty", func() {
-		crName := "sa-emptyfunc-" + testID
-		staticName := "sa-static-empty-" + testID
-		cr := newCR(crName)
-		defer func() {
-			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
-			deleteSA(staticName)
-		}()
+	It("keeps two CRs of different kinds but the same name on different SAs", func() {
+		// The Kind is in the derived name because a CR name alone is not unique in a namespace.
+		// Without it an HdfsCluster and a TrinoCluster both called "prod" would select one
+		// ServiceAccount and the second controller could never own it — the same collision the
+		// configurable name produced, one level down.
+		crName := "sa-samename-" + testID
+		Expect(reconciler.ServiceAccountResourceName("HdfsCluster", crName)).
+			NotTo(Equal(reconciler.ServiceAccountResourceName("TrinoCluster", crName)))
+		Expect(reconciler.ServiceAccountResourceName("HdfsCluster", crName)).
+			To(Equal("hdfscluster-" + crName))
+	})
 
-		r := newReconciler(cr, staticName, func(*testutil.MockCluster) string {
-			return ""
-		})
-
-		_, err := reconcileReq(r, crName)
-		Expect(err).NotTo(HaveOccurred())
-
-		sa, err := getSA(staticName)
-		Expect(err).NotTo(HaveOccurred())
-		ownerRef := metav1.GetControllerOf(sa)
-		Expect(ownerRef).NotTo(BeNil())
-		Expect(ownerRef.Name).To(Equal(crName))
+	It("bounds a pathologically long derived name and keeps it unique", func() {
+		long := strings.Repeat("a", 300)
+		name := reconciler.ServiceAccountResourceName("MockCluster", long)
+		Expect(len(name)).To(BeNumerically("<=", 253))
+		Expect(name).NotTo(Equal(reconciler.ServiceAccountResourceName("MockCluster", long+"b")),
+			"truncation must stay collision-free via the hash suffix")
 	})
 
 	It("lets two clusters in one namespace each reconcile and own their own SA", func() {
-		// This is the multi-cluster scenario a shared static name breaks: the second cluster's
-		// SetControllerReference on the shared SA fails with AlreadyOwnedError forever.
+		// The multi-cluster scenario a configurable static name broke: the second cluster's
+		// SetControllerReference on the shared SA failed with AlreadyOwnedError forever. Deriving
+		// the name from the CR removes the shared object rather than detecting the conflict.
 		crNameA := "sa-multi-a-" + testID
 		crNameB := "sa-multi-b-" + testID
 		crA := newCR(crNameA)
@@ -1245,18 +1251,17 @@ var _ = Describe("GenericReconciler per-CR ServiceAccount naming", func() {
 		defer func() {
 			Expect(k8sClient.Delete(ctx, crA)).To(Succeed())
 			Expect(k8sClient.Delete(ctx, crB)).To(Succeed())
-			deleteSA("sa-per-cr-" + crNameA)
-			deleteSA("sa-per-cr-" + crNameB)
+			deleteSA(saNameFor(crNameA))
+			deleteSA(saNameFor(crNameB))
 		}()
 
-		nameFunc := func(c *testutil.MockCluster) string { return "sa-per-cr-" + c.GetName() }
-		rA := newReconciler(crA, "", nameFunc)
-		rB := newReconciler(crB, "", nameFunc)
+		rA := newReconciler(crA)
+		rB := newReconciler(crB)
 
 		_, err := reconcileReq(rA, crNameA)
 		Expect(err).NotTo(HaveOccurred())
 		_, err = reconcileReq(rB, crNameB)
-		Expect(err).NotTo(HaveOccurred(), "second cluster in the namespace must reconcile cleanly with per-CR SA naming")
+		Expect(err).NotTo(HaveOccurred(), "a second cluster in the namespace must reconcile cleanly")
 
 		// Reconcile both again: steady state must stay clean (no AlreadyOwnedError on re-reconcile).
 		_, err = reconcileReq(rA, crNameA)
@@ -1264,10 +1269,11 @@ var _ = Describe("GenericReconciler per-CR ServiceAccount naming", func() {
 		_, err = reconcileReq(rB, crNameB)
 		Expect(err).NotTo(HaveOccurred())
 
-		saA, err := getSA("sa-per-cr-" + crNameA)
+		saA, err := getSA(saNameFor(crNameA))
 		Expect(err).NotTo(HaveOccurred())
-		saB, err := getSA("sa-per-cr-" + crNameB)
+		saB, err := getSA(saNameFor(crNameB))
 		Expect(err).NotTo(HaveOccurred())
+		Expect(saA.Name).NotTo(Equal(saB.Name))
 
 		refA := metav1.GetControllerOf(saA)
 		Expect(refA).NotTo(BeNil())
@@ -1277,40 +1283,44 @@ var _ = Describe("GenericReconciler per-CR ServiceAccount naming", func() {
 		Expect(refB.Name).To(Equal(crNameB))
 	})
 
-	It("reports a clear error naming both owners when the SA is owned by a different owner", func() {
+	It("refuses to adopt a foreign object squatting on the derived name", func() {
+		// A derived name cannot collide with another CLUSTER, but it can still be occupied by
+		// something else. Adopting it would hand these pods whatever identity that object carries,
+		// so the framework refuses and says what to do.
 		crName := "sa-victim-" + testID
 		otherName := "sa-squatter-" + testID
-		sharedSAName := "sa-shared-" + testID
+		derived := saNameFor(crName)
 
-		// The "other" cluster that already controller-owns the shared SA.
+		// A different CR controller-owns an object sitting at this cluster's derived SA name.
 		otherCR := newCR(otherName)
 		cr := newCR(crName)
 		defer func() {
 			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
 			Expect(k8sClient.Delete(ctx, otherCR)).To(Succeed())
-			deleteSA(sharedSAName)
+			deleteSA(derived)
 		}()
 
 		sa := &corev1.ServiceAccount{
-			ObjectMeta: metav1.ObjectMeta{Name: sharedSAName, Namespace: namespace},
+			ObjectMeta: metav1.ObjectMeta{Name: derived, Namespace: namespace},
 		}
 		Expect(controllerutil.SetControllerReference(otherCR, sa, testScheme)).To(Succeed())
 		Expect(k8sClient.Create(ctx, sa)).To(Succeed())
 
-		r := newReconciler(cr, sharedSAName, nil)
+		r := newReconciler(cr)
 
 		_, err := reconcileReq(r, crName)
 		Expect(err).To(HaveOccurred())
-		// The error must diagnose the shared-name misconfiguration, naming both owners and the
-		// per-CR naming fix, instead of surfacing the raw AlreadyOwnedError.
-		Expect(err.Error()).To(ContainSubstring(sharedSAName))
+		// The error names both owners and says the name is derived, so nobody goes looking for the
+		// config field that would have caused this before.
+		Expect(err.Error()).To(ContainSubstring(derived))
 		Expect(err.Error()).To(ContainSubstring("already controlled by"))
 		Expect(err.Error()).To(ContainSubstring(otherName), "error should name the existing owner")
 		Expect(err.Error()).To(ContainSubstring(crName), "error should name the owner that failed to adopt")
-		Expect(err.Error()).To(ContainSubstring("ServiceAccountNameFunc"), "error should point at the per-CR naming fix")
+		Expect(err.Error()).To(ContainSubstring("derived from the CR"),
+			"error should say the name is derived rather than blaming a naming collision")
 
 		// The squatter's ownership is untouched.
-		fetched, err := getSA(sharedSAName)
+		fetched, err := getSA(derived)
 		Expect(err).NotTo(HaveOccurred())
 		ref := metav1.GetControllerOf(fetched)
 		Expect(ref).NotTo(BeNil())
@@ -1845,8 +1855,10 @@ var _ = Describe("GenericReconciler ExtraResources", func() {
 		resourceName := reconciler.RoleGroupResourceName(crName, "broker", "default")
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: resourceName}, &corev1.ConfigMap{})).To(Succeed())
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: resourceName}, &appsv1.StatefulSet{})).To(Succeed())
-		// Only the ConfigMap and StatefulSet were created.
+		// Only the ConfigMap and StatefulSet came from the role group. The cluster-level workload
+		// ServiceAccount is created for every cluster (step 0) and is not an ExtraResource.
 		Expect(recClient.created).To(ConsistOf(
+			"*v1.ServiceAccount/"+reconciler.ServiceAccountResourceName("MockCluster", crName),
 			"*v1.ConfigMap/"+resourceName,
 			"*v1.StatefulSet/"+resourceName,
 		))

--- a/pkg/reconciler/role_group_handler.go
+++ b/pkg/reconciler/role_group_handler.go
@@ -184,12 +184,15 @@ type RoleGroupBuildContext struct {
 	// role segment prevents collisions between same-named groups of different roles.
 	ResourceName string
 
-	// ServiceAccountName is the name of the ServiceAccount the workload pods should run as.
-	// It is populated by GenericReconciler with the resolved SA name — the per-CR
-	// ServiceAccountNameFunc result when set, else the static ServiceAccountName (the SA the
-	// reconciler auto-creates). When non-empty, the base StatefulSet builder binds it to the
-	// pod template via WithServiceAccount, so the created SA is actually used. Empty means no
-	// binding — pods fall back to the namespace default SA (backward compatible).
+	// ServiceAccountName is the name of the ServiceAccount the workload pods run as. The
+	// GenericReconciler DERIVES it from the CR (ServiceAccountResourceName: "<lowercased
+	// kind>-<cluster>") and ensures that ServiceAccount before any role is built, so a handler
+	// can rely on it being both non-empty and already existing. The base StatefulSet builder
+	// binds it to the pod template via WithServiceAccount.
+	//
+	// It is not configurable: the framework owns this name the same way it owns ResourceName
+	// above. A handler constructing a RoleGroupBuildContext by hand (in a test, say) may leave it
+	// empty, and the base handler then binds nothing — pods fall back to the namespace default.
 	ServiceAccountName string
 
 	// SidecarManager is the sidecar manager for this role group, always set (non-nil) by

--- a/pkg/reconciler/workload_rbac.go
+++ b/pkg/reconciler/workload_rbac.go
@@ -1,0 +1,420 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"context"
+	stderrors "errors"
+	"fmt"
+	"maps"
+	"strings"
+
+	"github.com/zncdatadev/operator-go/pkg/constant"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// workloadRoleKind is the RoleBinding roleRef Kind this helper writes. It is deliberately not
+// ClusterRole: a namespaced CR cannot controller-own a cluster-scoped object, so the framework
+// would have no lifecycle for one — no garbage collection with the cluster, and no ownership gate
+// on the reclaim.
+const workloadRoleKind = "Role"
+
+// WorkloadRBACOption configures EnsureWorkloadRBAC.
+type WorkloadRBACOption func(*workloadRBACOptions)
+
+type workloadRBACOptions struct {
+	productName string
+	labels      map[string]string
+}
+
+// WithWorkloadRBACProductName sets app.kubernetes.io/name on the Role and RoleBinding.
+func WithWorkloadRBACProductName(name string) WorkloadRBACOption {
+	return func(o *workloadRBACOptions) { o.productName = name }
+}
+
+// WithWorkloadRBACExtraLabels merges extra labels onto the Role and RoleBinding. The canonical
+// labels always win, the same rule EnsureDiscoveryConfigMap follows.
+func WithWorkloadRBACExtraLabels(labels map[string]string) WorkloadRBACOption {
+	return func(o *workloadRBACOptions) { o.labels = labels }
+}
+
+// EnsureWorkloadRBAC maintains the namespaced Role and RoleBinding that give a cluster's WORKLOAD
+// pods the Kubernetes API permissions they need — not the operator's own permissions, which come
+// from the operator's ClusterRole and are a separate axis.
+//
+// Most products should NOT call this directly: set GenericReconcilerConfig.WorkloadRBACRules and
+// the framework calls it at cluster level, with the ServiceAccount name it DERIVED, right after
+// creating that ServiceAccount. That is what keeps the workload's identity and its permissions from
+// drifting apart — the failure this signature cannot prevent is a caller passing a name that is not
+// the workload's, leaving a Role that grants to a ServiceAccount no pod uses: both objects exist,
+// the pods start, and the first API call 403s.
+//
+// It stays exported for a product driving the reconciler's pieces itself rather than through
+// GenericReconciler. Call it from a common.ClusterExtension PreReconcile hook, where a ctx and
+// client exist and the workload has not been built yet.
+//
+//	err := reconciler.EnsureWorkloadRBAC(ctx, c, scheme, cr, saName, []rbacv1.PolicyRule{{
+//	    APIGroups: []string{"coordination.k8s.io"},
+//	    Resources: []string{"leases"},
+//	    Verbs:     []string{"get", "list", "watch", "create", "update"},
+//	}}, reconciler.WithWorkloadRBACProductName("nifi"))
+//
+// Either way the framework owns the ensure semantics — naming, canonical labels, the controller
+// owner reference, idempotent create-or-update, revocation — and the product owns the rules,
+// because only the product knows what its pods call.
+//
+// Both objects are named after the ServiceAccount they serve and live in the CR's namespace, so a
+// reader who sees the SA on a pod can find its permissions without knowing this API. Both carry a
+// CONTROLLER owner reference to the CR, which is what puts them inside the framework's lifecycle:
+// they are garbage-collected with the cluster, and — unlike a plain owner reference — a competing
+// controller cannot claim them.
+//
+// # Revocation
+//
+// An empty rule set DELETES the Role and RoleBinding, provided this CR controller-owns them. That
+// is the same reading the framework gives every other optional slot — a nil MetricsService reclaims
+// the Service — and it is what makes "the rules converge" true in both directions: narrowing to
+// zero is the largest narrowing there is.
+//
+// # A pre-existing RoleBinding is never adopted
+//
+// roleRef is immutable, so a RoleBinding already sitting at this name pointing somewhere else
+// cannot be converged. This fails with a *ValidationError naming both refs and the one command
+// that fixes it, rather than rebinding the existing object to the workload's ServiceAccount —
+// which would hand those pods whatever the old ref allows.
+//
+// # The escalation footgun
+//
+// Kubernetes refuses to let a subject grant permissions it does not itself hold, so the OPERATOR's
+// own ClusterRole must be a superset of every rule passed here. The failure is a 403 at Role
+// create/update time, it is invisible at compile time, and it is invisible in any test that runs as
+// cluster-admin (which envtest does). This re-explains that error rather than pre-checking it: the
+// API server's own message already names the exact rule that is missing, and a pre-check would have
+// to reimplement RBAC rule covering — wildcards, resourceNames, aggregated ClusterRoles,
+// non-resource URLs — and would then be wrong in both directions.
+//
+// The operator needs TWO kinds of marker, and only one of them is about the rules:
+//
+//	// the rules being granted — Kubernetes forbids granting what the granter lacks
+//	// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update
+//	// write access to the RBAC API itself, without which nothing here can be created at all
+//	// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;watch;create;update;patch;delete
+func EnsureWorkloadRBAC(
+	ctx context.Context,
+	c client.Client,
+	scheme *runtime.Scheme,
+	owner client.Object,
+	serviceAccountName string,
+	rules []rbacv1.PolicyRule,
+	opts ...WorkloadRBACOption,
+) error {
+	if serviceAccountName == "" {
+		return fmt.Errorf("workload RBAC needs the name of the ServiceAccount it grants to: got an empty string")
+	}
+	options := &workloadRBACOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	// An empty rule set is an instruction to REVOKE, not "leave it alone". Returning early here
+	// made it the one case that silently did nothing while the pods kept permissions the product
+	// had stopped granting.
+	if len(rules) == 0 {
+		return reclaimWorkloadRBAC(ctx, c, owner, serviceAccountName)
+	}
+
+	key := types.NamespacedName{Namespace: owner.GetNamespace(), Name: serviceAccountName}
+	want := rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: workloadRoleKind, Name: serviceAccountName}
+
+	// Check the one thing that can never be converged BEFORE writing anything. The same check runs
+	// again inside the mutate func below, and both are needed for different reasons: this one keeps
+	// a doomed pass from leaving a Role behind ("a slot that half-converged and then failed is worse
+	// than one that did not start" — the rule validateRoleGroupResources follows), while the one
+	// below closes the window between this read and the write.
+	if err := checkWorkloadRoleRef(ctx, c, key, want); err != nil {
+		return err
+	}
+
+	// Build the desired objects ONCE, as pure data, before any I/O. Keeping construction separate
+	// from the write is what makes the framework's own invariants checkable: buildWorkloadRBAC is a
+	// pure function, so a test can hold both objects at once and prove they share no map and alias
+	// none of the caller's data — which is impossible to observe once they have crossed the API
+	// boundary, since every client deep-copies on serialize. Same split pkg/builder exists for.
+	desiredRole, desiredBinding := buildWorkloadRBAC(owner, key, want, rules, options)
+
+	role := &rbacv1.Role{ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace}}
+	if _, err := controllerutil.CreateOrUpdate(ctx, c, role, func() error {
+		if err := controllerutil.SetControllerReference(owner, role, scheme); err != nil {
+			return err
+		}
+		role.Labels = desiredRole.Labels
+		role.Rules = desiredRole.Rules
+		return nil
+	}); err != nil {
+		return explainWorkloadRBACError(ctx, err, rules)
+	}
+
+	binding := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace}}
+	if _, err := controllerutil.CreateOrUpdate(ctx, c, binding, func() error {
+		if err := controllerutil.SetControllerReference(owner, binding, scheme); err != nil {
+			return err
+		}
+		binding.Labels = desiredBinding.Labels
+		binding.Subjects = desiredBinding.Subjects
+
+		// RoleRef is immutable, so it can only be SET on create — but it must still be CHECKED on
+		// update, and checking it is the whole point.
+		//
+		// controllerutil.CreateOrUpdate Gets the live object into `binding` before running this
+		// func, so on the update path RoleRef is never the zero value. Writing it only when empty
+		// would therefore silently ADOPT whatever a pre-existing object points at: a RoleBinding
+		// left at this name by an older operator, a Helm chart, or the ExtraResources route this
+		// replaces would keep its roleRef while its subject was rewritten to the workload's
+		// ServiceAccount — handing those pods permissions nobody granted them, and returning nil.
+		// Migration is exactly the situation this helper exists for, so that is the main path.
+		if binding.RoleRef == (rbacv1.RoleRef{}) {
+			binding.RoleRef = desiredBinding.RoleRef
+			return nil
+		}
+		if binding.RoleRef != want {
+			return workloadRoleRefConflict(key, binding.RoleRef, want)
+		}
+		return nil
+	}); err != nil {
+		return explainWorkloadRBACError(ctx, err, rules)
+	}
+
+	return nil
+}
+
+// buildWorkloadRBAC renders the desired Role and RoleBinding as pure data — no client, no I/O, no
+// live state — so that everything about WHAT the framework wants to write is decided in one place
+// and is checkable without a cluster.
+//
+// The two objects deliberately share nothing: each gets its own label map, and the Role's rules are
+// a deep copy of the caller's. Neither property is observable downstream of this function (an API
+// round-trip re-materialises both objects independently), which is exactly why the construction is
+// separated out rather than inlined into the two mutate funcs — that inlining is what let one
+// hoisted `labels := …` put a single map on both objects.
+func buildWorkloadRBAC(
+	owner client.Object,
+	key types.NamespacedName,
+	roleRef rbacv1.RoleRef,
+	rules []rbacv1.PolicyRule,
+	options *workloadRBACOptions,
+) (*rbacv1.Role, *rbacv1.RoleBinding) {
+	role := &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+			Labels:    workloadRBACLabels(owner, options),
+		},
+		// Copied, not aliased: a product's rules are typically a package-level literal, and the
+		// framework must not store its caller's backing array in an object it hands to a client.
+		// Same rule pkg/builder's Build() follows for every map and slice it returns.
+		Rules: cloneWorkloadRules(rules),
+	}
+
+	binding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      key.Name,
+			Namespace: key.Namespace,
+			// A second call, not the Role's map: two API objects must never share one Go map, or a
+			// future edit to either silently rewrites the other.
+			Labels: workloadRBACLabels(owner, options),
+		},
+		RoleRef: roleRef,
+		Subjects: []rbacv1.Subject{{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      key.Name,
+			Namespace: key.Namespace,
+		}},
+	}
+
+	return role, binding
+}
+
+// checkWorkloadRoleRef fails when a RoleBinding already sits at this name pointing somewhere the
+// framework cannot converge to. A NotFound (nothing there yet) and any other read error are both
+// "carry on": a read failure will surface again from the write path, with the API server's own
+// message, rather than being reported here as a validation problem it is not.
+func checkWorkloadRoleRef(ctx context.Context, c client.Client, key types.NamespacedName, want rbacv1.RoleRef) error {
+	live := &rbacv1.RoleBinding{}
+	if err := c.Get(ctx, key, live); err != nil {
+		return nil //nolint:nilerr // deliberate: the write path reports read failures with better context
+	}
+	if live.RoleRef == want {
+		return nil
+	}
+	return workloadRoleRefConflict(key, live.RoleRef, want)
+}
+
+// workloadRoleRefConflict builds the error both roleRef checks return, so the two cannot drift.
+func workloadRoleRefConflict(key types.NamespacedName, have, want rbacv1.RoleRef) error {
+	return NewValidationError("WorkloadRBAC", "", "", fmt.Errorf(
+		"the RoleBinding %s/%s already exists and points at %s/%s, but this cluster's workload RBAC "+
+			"requires %s/%s. roleRef is immutable, so the framework cannot converge it and will not "+
+			"rebind the existing one — that would grant this cluster's pods whatever the old ref "+
+			"allows. Delete it and let the framework recreate it: kubectl -n %s delete rolebinding %s",
+		key.Namespace, key.Name, have.Kind, have.Name,
+		want.Kind, want.Name, key.Namespace, key.Name))
+}
+
+// cloneWorkloadRules deep-copies the product's rules, including the string slices inside each rule,
+// so nothing the framework hands to the API client aliases the caller's data.
+func cloneWorkloadRules(rules []rbacv1.PolicyRule) []rbacv1.PolicyRule {
+	cloned := make([]rbacv1.PolicyRule, len(rules))
+	for i, rule := range rules {
+		cloned[i] = *rule.DeepCopy()
+	}
+	return cloned
+}
+
+// reclaimWorkloadRBAC deletes the Role and RoleBinding this cluster's workload RBAC consists of,
+// but only when they are controller-owned by this CR — the same ownership gate every other reclaim
+// in this package applies, so a same-named object belonging to something else is never touched.
+//
+// Order mirrors the grant: the binding first, so the permission stops applying before the Role that
+// spells it out disappears. A NotFound at either step is success.
+func reclaimWorkloadRBAC(ctx context.Context, c client.Client, owner client.Object, name string) error {
+	key := types.NamespacedName{Namespace: owner.GetNamespace(), Name: name}
+
+	if err := deleteWorkloadRBACIfOwned(ctx, c, key, &rbacv1.RoleBinding{}, owner); err != nil {
+		return err
+	}
+	return deleteWorkloadRBACIfOwned(ctx, c, key, &rbacv1.Role{}, owner)
+}
+
+// deleteWorkloadRBACIfOwned deletes obj at key when it exists and this CR is its controller owner.
+func deleteWorkloadRBACIfOwned(ctx context.Context, c client.Client, key types.NamespacedName, obj client.Object, owner client.Object) error {
+	// An owner with no UID cannot prove it owns anything, so it deletes nothing — the same rule the
+	// cleaner's live orphan discovery and role-PDB reclaim follow. Without it, an owner built in
+	// memory (which the exported helper permits) would match any object whose controller ref also
+	// carries an empty UID.
+	if owner.GetUID() == "" {
+		return nil
+	}
+	if err := c.Get(ctx, key, obj); err != nil {
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	ref := metav1.GetControllerOf(obj)
+	if ref == nil || ref.UID != owner.GetUID() {
+		// Not ours. Leaving it is the safe answer: the alternative is deleting an object another
+		// controller maintains because it happens to share a name.
+		return nil
+	}
+	if err := c.Delete(ctx, obj); err != nil && !errors.IsNotFound(err) {
+		return err
+	}
+	log.FromContext(ctx).Info("Revoked workload RBAC: the product supplied no rules",
+		"name", key.Name, "namespace", key.Namespace)
+	return nil
+}
+
+// workloadRBACLabels builds the canonical label set. Extra labels are merged underneath, so the
+// canonical ones always win — the same rule EnsureDiscoveryConfigMap follows.
+func workloadRBACLabels(owner client.Object, options *workloadRBACOptions) map[string]string {
+	labels := maps.Clone(options.labels)
+	if labels == nil {
+		labels = map[string]string{}
+	}
+	labels[constant.LabelKubernetesInstance] = owner.GetName()
+	labels[constant.LabelKubernetesManagedBy] = managedByValue
+	if options.productName != "" {
+		labels[constant.LabelKubernetesName] = options.productName
+	}
+	return labels
+}
+
+// explainWorkloadRBACError re-explains the failures a product author cannot diagnose from the raw
+// message, and passes everything else through untouched.
+//
+// A 403 here has TWO possible causes needing opposite fixes, which is why the attribution has to be
+// narrow rather than blanket:
+//
+//   - The operator lacks write access to roles/rolebindings themselves. Its own ClusterRole needs
+//     `+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,...`.
+//   - The operator holds that, but not the permissions it is trying to grant. Kubernetes refuses to
+//     let a subject grant what it does not itself hold (absent the `escalate` verb), so the
+//     operator's ClusterRole must cover every rule passed here.
+//
+// Blanket-attributing every 403 to the second sends an author auditing rules they just added while
+// the real gap is the first, so the escalation wording is used only when the API server's own
+// message says so. That message has already done the exact rule-covering computation, against the
+// operator's real effective permissions including aggregated ClusterRoles, and names the missing
+// rule — which is why this re-explains rather than pre-checks.
+func explainWorkloadRBACError(ctx context.Context, err error, rules []rbacv1.PolicyRule) error {
+	var alreadyOwned *controllerutil.AlreadyOwnedError
+	if stderrors.As(err, &alreadyOwned) {
+		// The ServiceAccount name is derived from the CR, so two clusters can no longer be
+		// configured onto one Role. What remains is an unrelated object squatting on the derived
+		// name — which the framework must not adopt, since rebinding it would grant this cluster's
+		// pods whatever it already allows.
+		return fmt.Errorf(
+			"the workload RBAC object %q is already controlled by %s %q, so this cluster cannot own it. "+
+				"Workload RBAC is named after this cluster's ServiceAccount, whose name is derived from "+
+				"the CR, so something else is occupying that name: delete it, or rename the cluster: %w",
+			alreadyOwned.Object.GetName(), alreadyOwned.Owner.Kind, alreadyOwned.Owner.Name, err)
+	}
+
+	if !errors.IsForbidden(err) {
+		return err
+	}
+	if !isRBACEscalation(err) {
+		return fmt.Errorf(
+			"the API server refused to write this cluster's workload RBAC. If the operator lacks access to "+
+				"the RBAC API itself, add "+
+				"`+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,"+
+				"verbs=get;list;watch;create;update;patch;delete` and regenerate its ClusterRole: %w", err)
+	}
+	log.FromContext(ctx).Error(err, "Workload RBAC was refused: the operator cannot grant permissions it does not hold itself",
+		"rules", rules)
+	return fmt.Errorf(
+		"the API server refused these workload RBAC rules because this operator does not hold them itself — "+
+			"Kubernetes forbids granting permissions the granter lacks. Add the matching "+
+			"+kubebuilder:rbac markers to the operator and regenerate its ClusterRole: %w", err)
+}
+
+// isRBACEscalation reports whether a 403 is the RBAC escalation refusal rather than a plain
+// missing-verb denial. The API server phrases the former distinctly; matching on it keeps the two
+// causes apart without the framework guessing.
+//
+// The first phrase is what a current API server actually emits, verified against a real refusal
+// rather than assumed — see the "REAL API server" spec, which mints an under-privileged user and
+// asserts this function recognises the result. That spec exists because the obvious guesses (the
+// two fallbacks below, taken from the escalation check's own error text and from the `escalate`
+// verb) do NOT appear in the message the server returns, so an implementation written from memory
+// silently attributes every escalation refusal to the wrong cause.
+//
+// The fallbacks are kept for older servers and for the paths that phrase it differently; the first
+// is the one under test.
+func isRBACEscalation(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "attempting to grant RBAC permissions not currently held") ||
+		strings.Contains(msg, "attempt to grant extra privileges") ||
+		strings.Contains(msg, "escalate")
+}

--- a/pkg/reconciler/workload_rbac_internal_test.go
+++ b/pkg/reconciler/workload_rbac_internal_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// These live in the INTERNAL test package because the properties they guard vanish the moment an
+// object crosses the API boundary: every client — real, cached or fake — deep-copies on serialize,
+// so two objects that shared one map in memory come back as two independent maps. An assertion
+// written against what EnsureWorkloadRBAC wrote therefore passes with or without the copies.
+//
+// buildWorkloadRBAC exists so that is not the end of the story. It renders both objects as pure
+// data, with no client and no live state, so a spec CAN hold them at once and prove they share
+// nothing — the call-site discipline that was previously unreachable, and that the first draft of
+// this file got wrong with both helpers already in place.
+var _ = Describe("workload RBAC object construction", func() {
+	owner := &metav1.PartialObjectMetadata{
+		ObjectMeta: metav1.ObjectMeta{Name: "cluster", Namespace: "ns"},
+	}
+	key := types.NamespacedName{Namespace: "ns", Name: "mockcluster-cluster"}
+	roleRef := rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: workloadRoleKind, Name: key.Name}
+
+	It("gives the Role and the RoleBinding independent label maps", func() {
+		// The exact defect this file's first draft shipped: one `labels := workloadRBACLabels(…)`
+		// hoisted above both mutate funcs, so a single map was assigned to two API objects.
+		role, binding := buildWorkloadRBAC(owner, key, roleRef,
+			[]rbacv1.PolicyRule{{Verbs: []string{"get"}}}, &workloadRBACOptions{})
+
+		Expect(role.Labels).To(Equal(binding.Labels))
+		role.Labels["only-on-the-role"] = "x"
+		Expect(binding.Labels).NotTo(HaveKey("only-on-the-role"),
+			"the two objects must not be able to rewrite each other's labels")
+	})
+
+	It("does not store the caller's rule slice in the Role", func() {
+		rules := []rbacv1.PolicyRule{{
+			APIGroups: []string{"coordination.k8s.io"},
+			Resources: []string{"leases"},
+			Verbs:     []string{"get"},
+		}}
+		role, _ := buildWorkloadRBAC(owner, key, roleRef, rules, &workloadRBACOptions{})
+
+		rules[0].Verbs[0] = "delete"
+		Expect(role.Rules[0].Verbs).To(Equal([]string{"get"}),
+			"the product keeps a reference to its rules; the built object must not alias them")
+	})
+
+	It("names both objects after the ServiceAccount and binds that ServiceAccount", func() {
+		role, binding := buildWorkloadRBAC(owner, key, roleRef,
+			[]rbacv1.PolicyRule{{Verbs: []string{"get"}}}, &workloadRBACOptions{})
+
+		Expect(role.Name).To(Equal(key.Name))
+		Expect(role.Namespace).To(Equal(key.Namespace))
+		Expect(binding.Name).To(Equal(key.Name))
+		Expect(binding.RoleRef).To(Equal(roleRef))
+		Expect(binding.Subjects).To(Equal([]rbacv1.Subject{{
+			Kind: rbacv1.ServiceAccountKind, Name: key.Name, Namespace: key.Namespace,
+		}}), "the binding's subject IS the workload's ServiceAccount, by construction")
+	})
+
+	It("returns an independent label map on every call", func() {
+		options := &workloadRBACOptions{productName: "nifi", labels: map[string]string{"extra": "v"}}
+
+		first := workloadRBACLabels(owner, options)
+		second := workloadRBACLabels(owner, options)
+		Expect(first).To(Equal(second))
+
+		first["only-on-first"] = "x"
+		Expect(second).NotTo(HaveKey("only-on-first"),
+			"two objects assigned these maps must not be able to rewrite each other's labels")
+	})
+
+	It("does not alias the caller's extra-label map", func() {
+		extras := map[string]string{"extra": "v"}
+		labels := workloadRBACLabels(owner, &workloadRBACOptions{labels: extras})
+
+		labels["added-by-framework"] = "x"
+		Expect(extras).NotTo(HaveKey("added-by-framework"),
+			"the caller's map must not gain the canonical labels")
+	})
+
+	It("deep-copies the caller's rules, including the string slices inside them", func() {
+		in := []rbacv1.PolicyRule{{
+			APIGroups: []string{"coordination.k8s.io"},
+			Resources: []string{"leases"},
+			Verbs:     []string{"get"},
+		}}
+		out := cloneWorkloadRules(in)
+		Expect(out).To(Equal(in))
+
+		// A shallow copy would share the Verbs backing array, so this is what separates
+		// cloneWorkloadRules from `copy()` or `return rules`.
+		in[0].Verbs[0] = "delete"
+		in[0].Resources[0] = "secrets"
+		Expect(out[0].Verbs).To(Equal([]string{"get"}))
+		Expect(out[0].Resources).To(Equal([]string{"leases"}))
+	})
+
+	It("survives an empty rule set", func() {
+		Expect(cloneWorkloadRules(nil)).To(BeEmpty())
+	})
+})

--- a/pkg/reconciler/workload_rbac_test.go
+++ b/pkg/reconciler/workload_rbac_test.go
@@ -1,0 +1,542 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
+	"github.com/zncdatadev/operator-go/pkg/constant"
+	"github.com/zncdatadev/operator-go/pkg/reconciler"
+	"github.com/zncdatadev/operator-go/pkg/testutil"
+	rbacv1 "k8s.io/api/rbac/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+// Coverage for the workload RBAC layer: the namespaced Role and RoleBinding that give a cluster's
+// PODS their Kubernetes API permissions. This is a separate axis from the operator's own
+// ClusterRole, and it is deliberately namespaced-only — a namespaced CR cannot controller-own a
+// cluster-scoped object, so the framework would have no lifecycle for a ClusterRole.
+var _ = Describe("GenericReconciler workload RBAC", func() {
+	var (
+		mockHandler *testutil.MockRoleGroupHandler
+		namespace   string
+		testID      string
+	)
+
+	leaseRules := []rbacv1.PolicyRule{{
+		APIGroups: []string{"coordination.k8s.io"},
+		Resources: []string{"leases"},
+		Verbs:     []string{"get", "list", "watch", "create", "update"},
+	}}
+
+	newReconciler := func(prototype *testutil.MockCluster, rules func(cr *testutil.MockCluster) []rbacv1.PolicyRule) *reconciler.GenericReconciler[*testutil.MockCluster] {
+		cfg := &reconciler.GenericReconcilerConfig[*testutil.MockCluster]{
+			Client:            k8sClient,
+			Scheme:            testScheme,
+			Recorder:          recorder,
+			RoleGroupHandler:  &handlerAdapter{handler: mockHandler},
+			Prototype:         prototype,
+			WorkloadRBACRules: rules,
+		}
+		r, err := reconciler.NewGenericReconciler(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		return r
+	}
+
+	newCR := func(name string) *testutil.MockCluster {
+		cr := testutil.NewMockCluster(name, namespace).
+			WithRoles(map[string]v1alpha1.RoleSpec{
+				"test-role": {
+					RoleGroups: map[string]v1alpha1.RoleGroupSpec{
+						"default": {Replicas: ptr.To(int32(1))},
+					},
+				},
+			})
+		Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+		return cr
+	}
+
+	reconcileReq := func(r *reconciler.GenericReconciler[*testutil.MockCluster], crName string) error {
+		_, err := r.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{Namespace: namespace, Name: crName},
+		})
+		return err
+	}
+
+	// Workload RBAC is named after the workload's ServiceAccount, so a reader who sees the SA on a
+	// pod can find its permissions without knowing this API.
+	rbacNameFor := func(crName string) string {
+		return reconciler.ServiceAccountResourceName("MockCluster", crName)
+	}
+
+	getRole := func(name string) (*rbacv1.Role, error) {
+		role := &rbacv1.Role{}
+		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, role)
+		return role, err
+	}
+
+	getBinding := func(name string) (*rbacv1.RoleBinding, error) {
+		binding := &rbacv1.RoleBinding{}
+		err := k8sClient.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, binding)
+		return binding, err
+	}
+
+	cleanupRBAC := func(name string) {
+		_ = k8sClient.Delete(ctx, &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		})
+		_ = k8sClient.Delete(ctx, &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		})
+	}
+
+	BeforeEach(func() {
+		namespace = testNamespace
+		mockHandler = testutil.NewMockRoleGroupHandler()
+		testID = fmt.Sprintf("%d", time.Now().UnixNano())
+	})
+
+	It("creates a Role and a RoleBinding bound to the derived ServiceAccount", func() {
+		crName := "wl-rbac-" + testID
+		name := rbacNameFor(crName)
+		cr := newCR(crName)
+		defer func() {
+			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+			cleanupRBAC(name)
+		}()
+
+		Expect(reconcileReq(newReconciler(cr, func(*testutil.MockCluster) []rbacv1.PolicyRule {
+			return leaseRules
+		}), crName)).To(Succeed())
+
+		role, err := getRole(name)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(role.Rules).To(Equal(leaseRules))
+		Expect(role.Labels).To(HaveKeyWithValue(constant.LabelKubernetesInstance, crName))
+		Expect(role.Labels).To(HaveKeyWithValue(constant.LabelKubernetesManagedBy, "operator-go"))
+		roleOwner := metav1.GetControllerOf(role)
+		Expect(roleOwner).NotTo(BeNil())
+		Expect(roleOwner.Name).To(Equal(crName))
+
+		binding, err := getBinding(name)
+		Expect(err).NotTo(HaveOccurred())
+		// The binding points at the Role of the same name and grants to the workload's own
+		// ServiceAccount — the identity settled one step earlier in the same reconcile.
+		Expect(binding.RoleRef).To(Equal(rbacv1.RoleRef{
+			APIGroup: rbacv1.GroupName, Kind: "Role", Name: name,
+		}))
+		Expect(binding.Subjects).To(Equal([]rbacv1.Subject{{
+			Kind:      rbacv1.ServiceAccountKind,
+			Name:      name,
+			Namespace: namespace,
+		}}))
+		bindingOwner := metav1.GetControllerOf(binding)
+		Expect(bindingOwner).NotTo(BeNil())
+		Expect(bindingOwner.Name).To(Equal(crName))
+	})
+
+	It("converges a changed rule set", func() {
+		crName := "wl-converge-" + testID
+		name := rbacNameFor(crName)
+		cr := newCR(crName)
+		defer func() {
+			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+			cleanupRBAC(name)
+		}()
+
+		rules := leaseRules
+		r := newReconciler(cr, func(*testutil.MockCluster) []rbacv1.PolicyRule { return rules })
+		Expect(reconcileReq(r, crName)).To(Succeed())
+
+		// Narrowing the verbs must reach the live Role, not just the newly created one.
+		rules = []rbacv1.PolicyRule{{
+			APIGroups: []string{"coordination.k8s.io"},
+			Resources: []string{"leases"},
+			Verbs:     []string{"get"},
+		}}
+		Expect(reconcileReq(r, crName)).To(Succeed())
+
+		role, err := getRole(name)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(role.Rules).To(Equal(rules))
+	})
+
+	It("revokes both objects when the rule set becomes empty", func() {
+		// An empty rule set is an instruction, not "leave it alone" — the same reading a nil
+		// MetricsService gets. Without it, narrowing to zero was the one change that silently did
+		// nothing while the pods kept permissions the product had stopped granting.
+		crName := "wl-revoke-" + testID
+		name := rbacNameFor(crName)
+		cr := newCR(crName)
+		defer func() {
+			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+			cleanupRBAC(name)
+		}()
+
+		rules := leaseRules
+		r := newReconciler(cr, func(*testutil.MockCluster) []rbacv1.PolicyRule { return rules })
+		Expect(reconcileReq(r, crName)).To(Succeed())
+		_, err := getRole(name)
+		Expect(err).NotTo(HaveOccurred())
+
+		rules = nil
+		Expect(reconcileReq(r, crName)).To(Succeed())
+
+		_, err = getRole(name)
+		Expect(k8serrors.IsNotFound(err)).To(BeTrue(), "the Role must be deleted when the rules go empty")
+		_, err = getBinding(name)
+		Expect(k8serrors.IsNotFound(err)).To(BeTrue(), "the RoleBinding must be deleted when the rules go empty")
+	})
+
+	It("creates nothing when the product declares no rules hook", func() {
+		// A nil hook is "this product never opted in", which must not run a revoke every pass —
+		// that would need RBAC read permission from operators that never asked for the feature.
+		crName := "wl-optout-" + testID
+		name := rbacNameFor(crName)
+		cr := newCR(crName)
+		defer func() {
+			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+			cleanupRBAC(name)
+		}()
+
+		Expect(reconcileReq(newReconciler(cr, nil), crName)).To(Succeed())
+
+		_, err := getRole(name)
+		Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+		_, err = getBinding(name)
+		Expect(k8serrors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("refuses to rebind a pre-existing RoleBinding pointing somewhere else", func() {
+		// roleRef is immutable, so this cannot be converged. Rewriting only the subject would hand
+		// this cluster's pods whatever the old ref allows, and return success.
+		crName := "wl-squat-" + testID
+		name := rbacNameFor(crName)
+		cr := newCR(crName)
+		defer func() {
+			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+			cleanupRBAC(name)
+		}()
+
+		foreign := &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName, Kind: "Role", Name: "some-other-role",
+			},
+			Subjects: []rbacv1.Subject{{
+				Kind: rbacv1.ServiceAccountKind, Name: "someone-else", Namespace: namespace,
+			}},
+		}
+		Expect(k8sClient.Create(ctx, foreign)).To(Succeed())
+
+		err := reconcileReq(newReconciler(cr, func(*testutil.MockCluster) []rbacv1.PolicyRule {
+			return leaseRules
+		}), crName)
+		Expect(err).To(HaveOccurred())
+		Expect(reconciler.IsValidationError(err)).To(BeTrue(), "a non-convergeable roleRef is a validation failure")
+		Expect(err.Error()).To(ContainSubstring("some-other-role"), "the error names the existing ref")
+		Expect(err.Error()).To(ContainSubstring("roleRef is immutable"))
+		Expect(err.Error()).To(ContainSubstring("delete rolebinding " + name))
+
+		// The foreign binding is left exactly as it was.
+		live, getErr := getBinding(name)
+		Expect(getErr).NotTo(HaveOccurred())
+		Expect(live.RoleRef.Name).To(Equal("some-other-role"))
+		Expect(live.Subjects[0].Name).To(Equal("someone-else"))
+
+		// And NOTHING was applied: the roleRef conflict is detected before the Role is written, so a
+		// doomed pass leaves no half-converged state behind (the rule validateRoleGroupResources
+		// follows for role group slots).
+		_, roleErr := getRole(name)
+		Expect(k8serrors.IsNotFound(roleErr)).To(BeTrue(),
+			"the Role must not be created when the RoleBinding cannot be converged")
+	})
+
+	// NOTE: the deep-copy of the caller's rules and the per-object label maps are covered in
+	// workload_rbac_internal_test.go, not here. Both are in-process aliasing properties, and every
+	// path out of this package deep-copies on serialize, so a spec written at THIS level passes
+	// identically with and without the copies. The helpers can be pinned down one level down; the
+	// call-site discipline above them — calling workloadRBACLabels once per object rather than
+	// hoisting one map — is what no test reaches.
+
+	It("leaves a same-named object it does not control alone on revoke", func() {
+		// The reclaim is gated on controller ownership, so a Role another controller maintains is
+		// never deleted just because it shares the derived name.
+		crName := "wl-notours-" + testID
+		otherName := "wl-owner-" + testID
+		name := rbacNameFor(crName)
+		otherCR := newCR(otherName)
+		cr := newCR(crName)
+		defer func() {
+			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, otherCR)).To(Succeed())
+			cleanupRBAC(name)
+		}()
+
+		foreignRole := &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Rules:      leaseRules,
+		}
+		Expect(controllerutil.SetControllerReference(otherCR, foreignRole, testScheme)).To(Succeed())
+		Expect(k8sClient.Create(ctx, foreignRole)).To(Succeed())
+
+		// This cluster declares no rules, so its reconcile runs the revoke path.
+		Expect(reconcileReq(newReconciler(cr, func(*testutil.MockCluster) []rbacv1.PolicyRule {
+			return nil
+		}), crName)).To(Succeed())
+
+		live, err := getRole(name)
+		Expect(err).NotTo(HaveOccurred(), "a Role owned by something else must survive the reclaim")
+		Expect(metav1.GetControllerOf(live).Name).To(Equal(otherName))
+	})
+
+	It("rejects an empty ServiceAccount name from the exported helper", func() {
+		// The helper takes the name as a parameter, so it can be called with one that is not the
+		// workload's. An empty one is the case it can actually detect: a Role granting to nothing.
+		crName := "wl-noname-" + testID
+		cr := newCR(crName)
+		defer func() { Expect(k8sClient.Delete(ctx, cr)).To(Succeed()) }()
+
+		err := reconciler.EnsureWorkloadRBAC(ctx, k8sClient, testScheme, cr, "", leaseRules)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("empty string"))
+	})
+
+	It("applies the product name label through the helper option", func() {
+		crName := "wl-label-" + testID
+		name := rbacNameFor(crName)
+		cr := newCR(crName)
+		defer func() {
+			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+			cleanupRBAC(name)
+		}()
+
+		Expect(reconciler.EnsureWorkloadRBAC(ctx, k8sClient, testScheme, cr, name, leaseRules,
+			reconciler.WithWorkloadRBACProductName("nifi"),
+			reconciler.WithWorkloadRBACExtraLabels(map[string]string{
+				"custom": "value",
+				// A canonical key must not be overridable by an extra label.
+				constant.LabelKubernetesInstance: "forged",
+			}),
+		)).To(Succeed())
+
+		role, err := getRole(name)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(role.Labels).To(HaveKeyWithValue(constant.LabelKubernetesName, "nifi"))
+		Expect(role.Labels).To(HaveKeyWithValue("custom", "value"))
+		Expect(role.Labels).To(HaveKeyWithValue(constant.LabelKubernetesInstance, crName),
+			"canonical labels always win over extras")
+	})
+
+	It("refuses to adopt a foreign-owned object squatting on the derived name", func() {
+		// A derived name cannot collide with another cluster, but something else can still occupy
+		// it. Adopting it would give this cluster's pods whatever that object already grants.
+		crName := "wl-adopt-" + testID
+		otherName := "wl-adopt-owner-" + testID
+		name := rbacNameFor(crName)
+		otherCR := newCR(otherName)
+		cr := newCR(crName)
+		defer func() {
+			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+			Expect(k8sClient.Delete(ctx, otherCR)).To(Succeed())
+			cleanupRBAC(name)
+		}()
+
+		foreignRole := &rbacv1.Role{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Rules:      leaseRules,
+		}
+		Expect(controllerutil.SetControllerReference(otherCR, foreignRole, testScheme)).To(Succeed())
+		Expect(k8sClient.Create(ctx, foreignRole)).To(Succeed())
+
+		err := reconciler.EnsureWorkloadRBAC(ctx, k8sClient, testScheme, cr, name, leaseRules)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("already controlled by"))
+		Expect(err.Error()).To(ContainSubstring(otherName), "the error names the current owner")
+		Expect(err.Error()).To(ContainSubstring("derived from"),
+			"the error should say the name is derived, not blame a naming collision")
+
+		// The squatter is untouched.
+		live, getErr := getRole(name)
+		Expect(getErr).NotTo(HaveOccurred())
+		Expect(metav1.GetControllerOf(live).Name).To(Equal(otherName))
+	})
+
+	It("is refused by a REAL API server when the operator does not hold the rules it grants", func() {
+		// The escalation footgun, exercised against the actual API server rather than a stub. The
+		// suite's own client is cluster-admin, so this mints a restricted user — one that may write
+		// RBAC objects but holds none of the permissions being granted — which is exactly the shape
+		// of an under-privileged operator.
+		//
+		// This is the spec that keeps isRBACEscalation honest: it matches on the API server's own
+		// wording, so if that wording ever changes, the framework silently starts attributing an
+		// escalation refusal to the WRONG cause (a missing RBAC-API marker) and sends the author to
+		// audit the wrong thing. Only a real refusal can catch that.
+		restricted := restrictedRBACClient()
+
+		crName := "wl-real403-" + testID
+		cr := newCR(crName)
+		name := rbacNameFor(crName)
+		defer func() {
+			Expect(k8sClient.Delete(ctx, cr)).To(Succeed())
+			cleanupRBAC(name)
+		}()
+
+		err := reconciler.EnsureWorkloadRBAC(ctx, restricted, testScheme, cr, name, leaseRules)
+		Expect(err).To(HaveOccurred())
+		Expect(k8serrors.IsForbidden(err)).To(BeTrue(), "the API server must refuse the escalation")
+		Expect(err.Error()).To(ContainSubstring("does not hold them itself"),
+			"the framework must recognise the API server's escalation wording; if this fails, "+
+				"isRBACEscalation has drifted from what Kubernetes actually says")
+
+		// Nothing was granted.
+		_, getErr := getRole(name)
+		Expect(k8serrors.IsNotFound(getErr)).To(BeTrue())
+	})
+
+	// The 403 branches below use a stub because they pin the exact MESSAGE each cause produces,
+	// which is about the framework's attribution rather than the API server's behaviour. The spec
+	// above covers the half only a real refusal can.
+	It("attributes a plain 403 to missing access to the RBAC API itself", func() {
+		crName := "wl-403-plain-" + testID
+		cr := newCR(crName)
+		defer func() { Expect(k8sClient.Delete(ctx, cr)).To(Succeed()) }()
+
+		c := &forbiddenRBACClient{Client: k8sClient, message: "roles.rbac.authorization.k8s.io is forbidden"}
+		err := reconciler.EnsureWorkloadRBAC(ctx, c, testScheme, cr, rbacNameFor(crName), leaseRules)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("rbac.authorization.k8s.io,resources=roles;rolebindings"),
+			"the fix for this cause is the RBAC-API marker")
+		Expect(err.Error()).NotTo(ContainSubstring("does not hold them itself"),
+			"a plain denial must not be blamed on escalation — the two fixes are opposite")
+	})
+
+	It("attributes an escalation 403 to the operator not holding the rules itself", func() {
+		crName := "wl-403-esc-" + testID
+		cr := newCR(crName)
+		defer func() { Expect(k8sClient.Delete(ctx, cr)).To(Succeed()) }()
+
+		// The phrasing the API server uses when it refuses to let a subject grant what it lacks.
+		c := &forbiddenRBACClient{Client: k8sClient, message: "attempt to grant extra privileges"}
+		err := reconciler.EnsureWorkloadRBAC(ctx, c, testScheme, cr, rbacNameFor(crName), leaseRules)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("does not hold them itself"))
+		Expect(err.Error()).To(ContainSubstring("+kubebuilder:rbac"))
+	})
+
+	It("passes a non-403 write error through untouched", func() {
+		crName := "wl-othererr-" + testID
+		cr := newCR(crName)
+		defer func() { Expect(k8sClient.Delete(ctx, cr)).To(Succeed()) }()
+
+		c := &erroringRBACClient{Client: k8sClient, err: k8serrors.NewServiceUnavailable("etcd is down")}
+		err := reconciler.EnsureWorkloadRBAC(ctx, c, testScheme, cr, rbacNameFor(crName), leaseRules)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("etcd is down"))
+		Expect(err.Error()).NotTo(ContainSubstring("+kubebuilder:rbac"),
+			"only a 403 gets the RBAC explanation; anything else must not be reframed")
+	})
+})
+
+// restrictedRBACClient builds a client authenticated as a user that may create Roles and
+// RoleBindings but holds none of the permissions those Roles grant — an under-privileged operator.
+// Writing such a Role makes the API server apply its escalation prevention, which is the one thing
+// the suite's cluster-admin client can never trigger.
+func restrictedRBACClient() client.Client {
+	user, err := testEnv.Env.AddUser(envtest.User{
+		Name:   "under-privileged-operator",
+		Groups: []string{"kubedoop-test"},
+	}, nil)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Write access to the RBAC API itself, and nothing else. In particular NOT the
+	// coordination.k8s.io/leases rules the specs try to grant.
+	role := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{Name: "kubedoop-test-rbac-writer"},
+		Rules: []rbacv1.PolicyRule{{
+			APIGroups: []string{rbacv1.GroupName},
+			Resources: []string{"roles", "rolebindings"},
+			Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+		}},
+	}
+	if err := k8sClient.Create(ctx, role); err != nil && !k8serrors.IsAlreadyExists(err) {
+		Expect(err).NotTo(HaveOccurred())
+	}
+	binding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{Name: "kubedoop-test-rbac-writer"},
+		RoleRef:    rbacv1.RoleRef{APIGroup: rbacv1.GroupName, Kind: "ClusterRole", Name: role.Name},
+		Subjects: []rbacv1.Subject{{
+			Kind: rbacv1.GroupKind, APIGroup: rbacv1.GroupName, Name: "kubedoop-test",
+		}},
+	}
+	if err := k8sClient.Create(ctx, binding); err != nil && !k8serrors.IsAlreadyExists(err) {
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	restricted, err := client.New(user.Config(), client.Options{Scheme: testScheme})
+	Expect(err).NotTo(HaveOccurred())
+	return restricted
+}
+
+// forbiddenRBACClient answers writes with a 403 carrying a caller-chosen message, so each cause of
+// an RBAC refusal maps to a checkable message. The real-refusal half is covered by
+// restrictedRBACClient above.
+type forbiddenRBACClient struct {
+	client.Client
+	message string
+}
+
+func (c *forbiddenRBACClient) forbidden() error {
+	return k8serrors.NewForbidden(
+		schema.GroupResource{Group: rbacv1.GroupName, Resource: "roles"}, "", errors.New(c.message))
+}
+
+func (c *forbiddenRBACClient) Create(_ context.Context, _ client.Object, _ ...client.CreateOption) error {
+	return c.forbidden()
+}
+
+func (c *forbiddenRBACClient) Update(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+	return c.forbidden()
+}
+
+// erroringRBACClient answers writes with an arbitrary non-403 error.
+type erroringRBACClient struct {
+	client.Client
+	err error
+}
+
+func (c *erroringRBACClient) Create(_ context.Context, _ client.Object, _ ...client.CreateOption) error {
+	return c.err
+}
+
+func (c *erroringRBACClient) Update(_ context.Context, _ client.Object, _ ...client.UpdateOption) error {
+	return c.err
+}

--- a/pkg/testutil/envtest.go
+++ b/pkg/testutil/envtest.go
@@ -28,6 +28,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
@@ -145,6 +146,13 @@ func (e *TestEnv) Start() error {
 	if err := policyv1.AddToScheme(e.Scheme); err != nil {
 		_ = e.Env.Stop()
 		return fmt.Errorf("failed to add policyv1 to scheme: %w", err)
+	}
+
+	// rbacv1 is needed by GenericReconcilerConfig.WorkloadRBACRules, which makes the reconciler
+	// write a Role and RoleBinding.
+	if err := rbacv1.AddToScheme(e.Scheme); err != nil {
+		_ = e.Env.Stop()
+		return fmt.Errorf("failed to add rbacv1 to scheme: %w", err)
 	}
 
 	// Add project-specific types to scheme


### PR DESCRIPTION
Closes #597. Supersedes #615.

## What

Workload **identity** and workload **RBAC** are two halves of one thing, and the SDK owned neither properly. This settles both per CR, at the top of the reconcile, from one derived name.

```
step 0    identity     ServiceAccount  <lowercased kind>-<cluster>   ┐
step 0b   permissions  Role            same name                    │ one derived name,
                       RoleBinding     same name                    ┘ passed by the framework
                         roleRef  -> that Role
                         subject  -> that ServiceAccount
```

## Breaking change

`GenericReconcilerConfig.ServiceAccountName` and `ServiceAccountNameFunc` are **removed**.

**Migration:** delete both fields. The name is now `reconciler.ServiceAccountResourceName(kind, cluster)` — e.g. `hdfscluster-prod`. An operator that set them moves its pods to the derived ServiceAccount on the next reconcile (one rolling restart); the old SA is left in place for you to delete, and is GC'd with the CR anyway.

> ⚠️ If a downstream operator has **hand-written RoleBindings** pointing at the old SA name, those stop applying after the migration — and nothing errors. The pods start fine and 403 on their first API call. This has **not** been verified against downstream operators; that check is still open.

### Why derive rather than configure

The framework creates the ServiceAccount, controller-owns it, GCs it with the CR and binds the workload's Role to it — so nothing needs to address it by a product-chosen name. This is the rule every other framework-owned name already follows (`AGENTS.md` §3).

Configuring it is what produced the failure class this replaces. A static name was a *constant*, so every CR of a product in one namespace resolved to the **same** ServiceAccount:

- whichever cluster reconciled second failed with `AlreadyOwnedError` **forever**;
- deleting the first garbage-collected the SA out from under the second's **running pods**.

The Kind is part of the derived name because a CR name alone is not unique in a namespace — an `HdfsCluster` and a `TrinoCluster` both called `prod` would otherwise reintroduce that collision one level down.

Every cluster now gets a ServiceAccount with no way to skip it. Leaving both fields unset previously skipped SA management entirely and ran the pods as the namespace `default` — the opposite of what `docs/security.md` §3.1 claims the framework guarantees.

## New: `WorkloadRBACRules`

```go
WorkloadRBACRules: func(cr *v1alpha1.NifiCluster) []rbacv1.PolicyRule {
    return []rbacv1.PolicyRule{{
        APIGroups: []string{"coordination.k8s.io"},
        Resources: []string{"leases"},
        Verbs:     []string{"get", "list", "watch", "create", "update"},
    }}
},
```

The product declares what its **pods** call; the framework maintains a namespaced `Role` + `RoleBinding` named after the derived ServiceAccount, controller-owned by the CR. Products previously hand-built these and shipped them through `RoleGroupResources.ExtraResources`, which put a cluster-level concern on a per-role-group path and left the SA-name/subject correspondence to the product to get right.

| Behaviour | Rationale |
|---|---|
| Empty rule set **revokes** both objects (ownership-gated) | Same reading every optional slot gets; the only one under which a rule set shrinking to nothing actually stops granting |
| A **nil hook** touches nothing | "Never opted in" — operators without the feature need no RBAC permissions at all |
| A pre-existing RoleBinding with a different `roleRef` is **never adopted** | `roleRef` is immutable; rewriting only the subject would hand these pods whatever the old ref allows — **and the API server accepts that write** |
| The conflict is detected **before anything is applied** | A doomed pass leaves no Role behind |
| **No ClusterRole path** | A namespaced CR cannot controller-own a cluster-scoped object, so the framework would have no lifecycle for one |
| RBAC watches registered **only when the hook is set** | An unconditional `Owns()` forces every operator on this SDK to grant itself cluster-wide `list;watch` on RBAC — and a forbidden informer fails `WaitForCacheSync` for *all* sources, so `manager.Start` returns and the process exits |

`reconciler.EnsureWorkloadRBAC` is exported for products driving the reconciler's pieces themselves. Prefer the config field: the helper takes the SA name as a parameter, so a caller can pass one that is not the workload's — producing a Role that grants to a ServiceAccount no pod uses, with both objects present, pods starting fine, and a 403 on the first API call.

## Two defects found while building this

**1. A 429 from the ServiceAccount step degraded the cluster.** `ensureServiceAccount` returned the raw API error instead of routing it through the same translation `applyResource` uses, so throttling ran the product's error hooks, emitted a Warning and flipped `Degraded` on a cluster nobody had managed to read yet. While the SA was opt-in that branch was reachable only by products that configured one; it is now on every cluster's critical path. Caught by the existing rate-limiting spec.

**2. `isRBACEscalation` did not match what the API server actually says.** It matched `"attempt to grant extra privileges"` / `"escalate"`; a real server emits:

```
user "..." (groups=[...]) is attempting to grant RBAC permissions not currently held:
{APIGroups:["coordination.k8s.io"], Resources:["leases"], ...}
```

So a **real** escalation refusal was attributed to the wrong cause, sending the author to add the wrong kubebuilder marker. The three stub-based specs had all passed — because they fed the implementation its own assumed string, testing "my assumption equals my implementation" rather than "my implementation equals Kubernetes".

Fixed, and now guarded by a spec that mints an under-privileged user via `envtest.AddUser` and asserts against an **actual** refusal. If Kubernetes ever rewords it, that spec goes red instead of the framework silently degrading to the wrong attribution.

## Testing

20 workload-RBAC specs across three levels, each covering what the level below cannot:

| Level | What it pins down | How |
|---|---|---|
| Construction | The Role and RoleBinding share no map and alias none of the caller's data | `buildWorkloadRBAC` pure function + internal specs |
| Attribution | Which message each failure cause produces | Stub client |
| Behaviour | The API server really refuses this way, and the framework recognises it | `envtest.AddUser` restricted user |

Two assertions were **deliberately** verified to fail without their fix (the roleRef pre-check, and the shared-label-map defect reintroduced on purpose), so they are regression tests rather than decoration.

`make lint` 0 issues · full suite green · `make verify-generate` up to date · `pkg/reconciler` coverage 89.8%.

## Known gaps

- **Downstream migration is unverified** — see the warning above. Blocking for a release, not for review.
- Removing the `WorkloadRBACRules` hook entirely (set → nil) does not reclaim existing objects; that follows from "nil = never opted in" and needs a manual step.
- Permission granularity is **per CR, not per role**: a role needing higher privileges raises them for every pod in the cluster.
- RBAC changes emit no Kubernetes event, matching the ServiceAccount precedent.
- The example operator does **not** demonstrate `WorkloadRBACRules` — Trino's pods do not call the Kubernetes API, and adding a rule purely to demo the field would ship an over-privileged example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

