### PR TITLE
test(reconciler): pin the two Service apply rules that actually carry weight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ builders, config/logging rendering and the CSI wiring, followed by three API red
 the contracts a product operator implements. **Downstream operators must migrate — the breaking
 changes are listed below.**
 
+### tests (the Service apply rules were entirely unguarded)
+
+- **Two regression specs for `copyServiceState`, whose preserved-field block could be deleted whole
+  with the suite staying green.** Probing envtest 1.35 shows only two of its six carry-overs are
+  load-bearing, and neither had a spec:
+  - a port **RENAME** (same number) makes the API server **reallocate** the node port
+    (31965 → 32604), because its own `patchAllocatedValues` matches ports by name. `findServicePort`'s
+    port-number fallback is what keeps a pinned node port across a cosmetic rename;
+  - `loadBalancerClass` is not merely unrestored but **rejected** — `may not change once set` — so
+    dropping the carry-over wedges a role group's reconcile permanently the first time a user removes
+    the class from their CR.
+
+  The other four (`clusterIP`, `clusterIPs`, `ipFamilies`/`ipFamilyPolicy`, `healthCheckNodePort`,
+  and node ports across a port-NUMBER change) are restored by the API server anyway; they stay as
+  defence in depth, and the distinction is now recorded in the source so nobody deletes the two that
+  matter. Closes the outstanding half of #598.
+
+### docs (label-key scope)
+
+- `RoleGroupMarkerLabelKey`'s doc claimed the key "marks a resource as belonging to one specific role
+  group". It does not: the natural form is `<cluster>-<group>` with **no role in it**, so a product
+  whose roles all use the conventional group name `default` stamps the same key on all of them. The
+  role cannot be added — the key lands in the immutable `.spec.selector` — so the doc now states that
+  it is a *fingerprint*, never a selector on its own, and that the over-long substitute
+  (`RoleGroupResourceName`) IS role-scoped, i.e. the two forms deliberately identify different things.
+  No code change; the one consumer is reached only after a Get by the role group's derived name,
+  which already pins the role. A spec pins the collision so a later "fix" cannot silently change a
+  selector. Closes #605.
+
 ### features (ExtraResources are validated before anything is applied)
 
 - **A product's `RoleGroupResources.ExtraResources` entries are now checked in the same pre-apply

--- a/docs/DOC_CHANGELOG.md
+++ b/docs/DOC_CHANGELOG.md
@@ -4,6 +4,20 @@ This document tracks all changes made to the SDK documentation.
 
 ---
 
+## [2026-08-09c] (two claims corrected: what the apply path preserves, what a marker key identifies)
+
+### Package guides
+
+- `copyServiceState` gains a table recording which of its six carry-overs are load-bearing and which
+  are defensive. The code reads as six interchangeable lines and only an experiment against a real
+  API server tells them apart: four are restored by the API server anyway, while a port RENAME costs
+  the allocated node port and `loadBalancerClass` makes the API server reject the whole update.
+- `RoleGroupMarkerLabelKey`'s doc corrected. It said the key "marks a resource as belonging to one
+  specific role group"; the natural form omits the ROLE, so it is not unique across roles sharing a
+  group name. Now stated as a fingerprint that nothing may select on alone, with why the role cannot
+  be added (the key lands in the immutable `.spec.selector`) and why the over-long substitute is
+  role-scoped where the natural form is not.
+
 ## [2026-08-09] (the ExtraResources contract stops being documentation-only)
 
 ### Core architecture

--- a/pkg/reconciler/apply.go
+++ b/pkg/reconciler/apply.go
@@ -408,6 +408,28 @@ func mergeAnnotations(live, desired map[string]string) map[string]string {
 // AllocateLoadBalancerNodePorts, TrafficDistribution, and any field a future Kubernetes version
 // adds — comes from desired. Assigning the spec wholesale (as copyStatefulSetState does) is what
 // makes new mutable fields converge by default instead of silently sticking at their live value.
+// Not all of the preserved set is load-bearing, and the difference is invisible from the code —
+// it took an experiment against a real API server (envtest 1.35) to establish. Recorded here
+// because the six carry-over lines below read as interchangeable and two of them are not:
+//
+//	field                    naive Update (no carry-over)          verdict
+//	clusterIP / clusterIPs   restored by the API server            defensive only
+//	ipFamilies / policy      restored by the API server            defensive only
+//	healthCheckNodePort      restored by the API server            defensive only
+//	nodePort, port UNCHANGED restored by the API server            defensive only
+//	nodePort, port RENAMED   REALLOCATED (31965 -> 32604)          LOAD-BEARING
+//	loadBalancerClass        update REJECTED with a 422            LOAD-BEARING
+//
+// The API server's own patchAllocatedValues matches ports by name, so renaming a port — a
+// cosmetic change — loses its allocated node port and breaks every client that had it pinned.
+// findServicePort's port-number fallback is what makes the framework strictly more preserving
+// than Kubernetes here.
+//
+// loadBalancerClass is worse than "not restored": it is immutable in the sense that the API
+// server rejects the whole update ("may not change once set"), so dropping the carry-over wedges
+// the role group's reconcile permanently the moment a user removes the class from their CR.
+//
+// Both are pinned by specs in generic_reconciler_test.go; deleting either line fails them.
 func copyServiceState(desired, live *corev1.Service) []string {
 	livePorts := live.Spec.Ports
 	clusterIP := live.Spec.ClusterIP

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -2730,6 +2730,22 @@ var _ = Describe("Role group marker label key", func() {
 		Expect(resources.StatefulSet.Spec.Selector.MatchLabels).To(HaveKeyWithValue("trino-default", "true"))
 	})
 
+	It("stamps the SAME marker on two roles sharing a role group name", func() {
+		// Documented property, not an oversight (issue #605): the natural key is "<cluster>-<group>"
+		// with no role in it, so every role using the conventional group name "default" carries the
+		// same marker. The role cannot be added — the key lands in the immutable .spec.selector, so
+		// changing it would break every running cluster on upgrade — which is exactly why nothing
+		// may select on this key alone. Its one consumer reaches it only after a Get by the role
+		// group's derived name, which does carry the role.
+		Expect(reconciler.RoleGroupMarkerLabelKey("trino", "worker", "default")).
+			To(Equal(reconciler.RoleGroupMarkerLabelKey("trino", "coordinator", "default")))
+
+		// The over-long substitute is RoleGroupResourceName, which IS role-scoped. The two forms
+		// deliberately identify different things; a caller may rely on neither.
+		Expect(reconciler.RoleGroupMarkerLabelKey(longCluster, "worker", longGroup)).
+			NotTo(Equal(reconciler.RoleGroupMarkerLabelKey(longCluster, "coordinator", longGroup)))
+	})
+
 	It("keeps two overrunning role groups of one role distinguishable", func() {
 		// The substitute must stay unique per role group: two groups sharing a marker would make
 		// each role group's Services select the other's pods as well.

--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -1010,8 +1010,23 @@ func ServiceAccountResourceName(kind, clusterName string) string {
 	return head + "-" + suffix
 }
 
-// RoleGroupMarkerLabelKey returns the label key that marks a resource as belonging to one specific
-// role group: "<cluster>-<group>", or a bounded substitute when that is not a legal label key.
+// RoleGroupMarkerLabelKey returns the label key that fingerprints a resource as one this framework
+// built for a role group: "<cluster>-<group>", or a bounded substitute when that is not a legal
+// label key.
+//
+// It is NOT unique per role group, and nothing may select on it alone. The natural form omits the
+// ROLE, so a product whose roles all use the conventional group name "default" — four roles in
+// DolphinScheduler, three in HDFS — stamps the identical key "<cluster>-default" on all of them.
+// The one consumer, isFrameworkRoleGroupPDB, is safe because it is reached only after a Get by the
+// role group's derived name, which already pins the role; the key merely answers "did we build
+// this?". Anything that starts from a List instead must key on the descriptive labels
+// (app.kubernetes.io/component + the role-group label), as orphan discovery does.
+//
+// The role is missing for a reason that cannot be undone: the key lands in the StatefulSet's
+// .spec.selector when LabelDomain is unset, and a selector is IMMUTABLE — adding the role would
+// break every running cluster on upgrade. The substitute below IS role-scoped, so the two forms
+// deliberately differ in what they identify. That asymmetry is safe for the same reason (see the
+// paragraph on legality), and is another reason not to treat the key as an identifier.
 //
 // A label key's name part is limited to 63 bytes and to a restricted character set, and this key is
 // derived from two free-form user strings. Entirely ordinary big-data names blow through it — a

--- a/pkg/reconciler/generic_reconciler_test.go
+++ b/pkg/reconciler/generic_reconciler_test.go
@@ -2259,6 +2259,79 @@ var _ = Describe("GenericReconciler update propagation (issue #526)", func() {
 		Expect(svc.Spec.ClusterIP).To(Equal(clusterIP), "allocated ClusterIP must never be touched")
 	})
 
+	It("keeps the allocated NodePort when the handler RENAMES a port", func() {
+		// The spec above changes the port NUMBER and keeps the name, which the API server's own
+		// patchAllocatedValues already handles — it survives with the framework's carry-over
+		// deleted. A RENAME is the case that does not: probed against envtest 1.35, a naive
+		// Update that renames a port (same number, nodePort left 0) makes the API server
+		// REALLOCATE the node port (31965 -> 32604). Every client that had the old port hard-coded
+		// — a firewall rule, an external load balancer's target, a documented connection string —
+		// breaks, silently, because a role's port was given a better name.
+		//
+		// findServicePort's port-NUMBER fallback is what prevents that, making the framework
+		// strictly more preserving than Kubernetes. Nothing pinned it before this spec.
+		portName := "client"
+		r := newReconciler(func(buildCtx *reconciler.RoleGroupBuildContext) *reconciler.RoleGroupResources {
+			svc := testutil.NewTestService(buildCtx.ResourceName, buildCtx.ClusterNamespace)
+			svc.Spec.Type = corev1.ServiceTypeNodePort
+			svc.Spec.Ports = []corev1.ServicePort{{
+				Name:       portName,
+				Port:       9092,
+				TargetPort: intstr.FromInt(9092),
+				Protocol:   corev1.ProtocolTCP,
+			}}
+			return &reconciler.RoleGroupResources{Service: svc}
+		})
+
+		reconcile(r)
+		svc := &corev1.Service{}
+		key := types.NamespacedName{Namespace: namespace, Name: resourceName}
+		Expect(k8sClient.Get(ctx, key, svc)).To(Succeed())
+		allocated := svc.Spec.Ports[0].NodePort
+		Expect(allocated).NotTo(BeZero())
+
+		portName = "kafka-client"
+		reconcile(r)
+
+		Expect(k8sClient.Get(ctx, key, svc)).To(Succeed())
+		Expect(svc.Spec.Ports).To(HaveLen(1))
+		Expect(svc.Spec.Ports[0].Name).To(Equal("kafka-client"), "the rename must reach the live Service")
+		Expect(svc.Spec.Ports[0].NodePort).To(Equal(allocated),
+			"a rename must not cost the allocated NodePort — the API server would reallocate it")
+	})
+
+	It("keeps a loadBalancerClass the handler no longer states", func() {
+		// loadBalancerClass is immutable in a stronger sense than the rest of the preserved set:
+		// the API server does not silently restore it, it REJECTS the whole update
+		// ("spec.loadBalancerClass: Invalid value: null: may not change once set", probed against
+		// envtest 1.35). Without the carry-over, a user who set the class once and later removed
+		// it from their CR would wedge that role group's reconcile permanently — a 422 on every
+		// pass, and no path back except deleting the Service by hand.
+		//
+		// No ImmutableFieldIgnored warning is expected here: the handler UNSET the field, which is
+		// declining to have an opinion rather than asking for a change.
+		class := ptr.To("example.com/internal-lb")
+		r := newReconciler(func(buildCtx *reconciler.RoleGroupBuildContext) *reconciler.RoleGroupResources {
+			svc := testutil.NewTestService(buildCtx.ResourceName, buildCtx.ClusterNamespace)
+			svc.Spec.Type = corev1.ServiceTypeLoadBalancer
+			svc.Spec.LoadBalancerClass = class
+			return &reconciler.RoleGroupResources{Service: svc}
+		})
+
+		reconcile(r)
+		svc := &corev1.Service{}
+		key := types.NamespacedName{Namespace: namespace, Name: resourceName}
+		Expect(k8sClient.Get(ctx, key, svc)).To(Succeed())
+		Expect(svc.Spec.LoadBalancerClass).To(HaveValue(Equal("example.com/internal-lb")))
+
+		class = nil
+		reconcile(r) // must not return the API server's 422
+
+		Expect(k8sClient.Get(ctx, key, svc)).To(Succeed())
+		Expect(svc.Spec.LoadBalancerClass).To(HaveValue(Equal("example.com/internal-lb")),
+			"the live class must survive an update that does not state it")
+	})
+
 	It("propagates Service fields outside the historical copy list", func() {
 		distribution := ""
 		r := newReconciler(func(buildCtx *reconciler.RoleGroupBuildContext) *reconciler.RoleGroupResources {


### PR DESCRIPTION
Closes #598, closes #605.

Rebased onto `main` after #619 merged. **The ExtraResources half of this branch is gone** — #619 shipped the same guard with a better design (identity by full GVK, plus the empty-name and duplicate-entry cases this branch never had), so keeping mine would have been a worse duplicate. What remains is the part nothing else covers.

## #598 — the part I owed

My comment on that issue said the entire `copyServiceState` preservation block could be deleted with the suite staying green, and that what is actually load-bearing is narrower than either the issue or the earlier narrowing claimed — then shipped no spec for it. Probing envtest 1.35 settles which of the six carry-overs matter:

| field | naive Update, no carry-over | verdict |
|---|---|---|
| `clusterIP` / `clusterIPs` | restored by the API server | defensive only |
| `ipFamilies` / `ipFamilyPolicy` | restored by the API server | defensive only |
| `healthCheckNodePort` | restored by the API server | defensive only |
| nodePort, port **number** changed | restored by the API server | defensive only |
| nodePort, port **RENAMED** | **reallocated** (31965 → 32604) | **load-bearing** |
| `loadBalancerClass` | **update rejected**, 422 | **load-bearing** |

The API server's own `patchAllocatedValues` matches ports by name, so renaming a port — a cosmetic change — costs its allocated node port and breaks every client that had it pinned. `findServicePort`'s port-number fallback is what makes the framework strictly more preserving than Kubernetes.

`loadBalancerClass` is worse than "not restored": the API server rejects the whole update (`may not change once set`), so dropping the carry-over wedges that role group's reconcile **permanently** the first time a user removes the class from their CR.

Two regression specs, both mutation-verified. The existing spec nearby is not redundant with these — it changes the port *number* and keeps the name, which the API server handles on its own, so it survives with the framework's carry-over deleted.

## #605 — the marker key is a fingerprint, not an identifier

`RoleGroupMarkerLabelKey`'s doc claimed the key "marks a resource as belonging to one specific role group". It does not: the natural form is `<cluster>-<group>` with **no role in it**, so a product whose roles all use the conventional group name `default` stamps the identical key on every one of them.

The role cannot be added — the key lands in the immutable `.spec.selector`, so changing it would break every running cluster on upgrade. The doc now states that it is a fingerprint, never a selector on its own, and that the over-long substitute (`RoleGroupResourceName`) IS role-scoped, i.e. the two forms deliberately identify different things. Verified the one consumer is safe: `isFrameworkRoleGroupPDB` is reached only after a Get by the role group's derived name, which already pins the role. A spec pins the collision, and adding the role to the key fails it.

## Scope

No behavior change. Two regression specs, one spec pinning a documented property, three doc corrections (`copyServiceState`'s evidence table, `RoleGroupMarkerLabelKey`, and the two changelogs).

Gates green in both modules (`0 issues.`, all packages `ok`), plus three mutations confirming the specs have teeth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)