### PR TITLE
feat(commons): validate the image tag, and render the pull secret the CRDs promise

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -313,6 +313,28 @@ is read **every reconcile**, which is what a webhook cannot do: webhook defaults
 admission and never recomputed, freezing `kubedoopVersion` at whatever operator version first
 admitted the CR (§10 and `docs/architecture.md` §2.6).
 
+**The assembled tag is validated, and an unusable one fails the role group.** `productVersion` and
+`kubedoopVersion` both land in the image tag, whose grammar is `[A-Za-z0-9_][A-Za-z0-9._-]{0,127}`,
+and nothing downstream would have caught a value that breaks it: the API server does not validate
+`container.image` at all, so an unparsable reference is accepted, stored, and surfaces only as
+`InvalidImageName` on a pod, while the reconcile reports success. The case this exists for is
+`KubedoopVersion: version.BuildVersion` with the scaffold's dev default of `"N/A"` — the `/` makes
+`…:476-kubedoopN/A` unparsable, so **every development build on the structured image path produced
+pods that could never start**. The error names the offending field, and says the value may have come
+from the operator's own defaults rather than from the CR. `spec.image.custom` is deliberately **not**
+validated: it is the user's verbatim reference, so a wrong one is their own visible mistake.
+
+**`spec.image.pullSecretName` names a docker-registry Secret added to every pod's
+`imagePullSecrets`.** It folds over `ImageDefaults.PullSecretName` per field like the rest, and is
+resolved **independently of the image**: a pull secret is a property of where the image lives, so it
+applies on all three paths — the assembled reference, `custom`, and a product that resolves its own
+images with `ProductName` empty. Ten product CRDs already declared this field, and migrating to the
+commons `ImageSpec` used to delete the behaviour silently — the CRD still accepted the value and no
+pod ever carried the entry, so a private-registry install failed with `ImagePullBackOff` and nothing
+naming the cause. One name rather than a list, matching those CRDs; it is applied before
+`podOverrides`, and strategic merge patch keys `imagePullSecrets` by `name`, so an override **adds**
+a credential rather than replacing this one.
+
 An unresolvable `spec.image` **fails the role group**, naming the missing field, instead of silently
 falling back to the handler's static image and running a version nobody asked for. With
 `ProductName` empty the handler resolves nothing from the CR beyond `spec.image.custom` — the shape

--- a/config/crd/bases/test.zncdata.dev_altmockclusters.yaml
+++ b/config/crd/bases/test.zncdata.dev_altmockclusters.yaml
@@ -98,6 +98,20 @@ spec:
                     - Never
                     - IfNotPresent
                     type: string
+                  pullSecretName:
+                    description: |-
+                      PullSecretName names a docker-registry Secret in the cluster CR's namespace, added to
+                      .spec.imagePullSecrets of every pod the framework builds for this cluster.
+
+                      It applies to whichever image path is taken, Custom included: a private registry is a
+                      property of where the image lives, not of how its reference was assembled. It is also
+                      deliberately NOT part of image resolution — a pull secret is still needed when the product
+                      resolves its own images and the framework never builds a reference at all.
+
+                      One name rather than a list, matching the field the ten product CRDs already declare. A
+                      deployment needing several credentials merges them into one Secret, or adds the rest through
+                      podOverrides, which is applied after this and therefore wins.
+                    type: string
                   repo:
                     description: |-
                       Repo is the image repository (e.g. "quay.io/kubedoop").

--- a/config/crd/bases/test.zncdata.dev_mockclusters.yaml
+++ b/config/crd/bases/test.zncdata.dev_mockclusters.yaml
@@ -85,6 +85,20 @@ spec:
                     - Never
                     - IfNotPresent
                     type: string
+                  pullSecretName:
+                    description: |-
+                      PullSecretName names a docker-registry Secret in the cluster CR's namespace, added to
+                      .spec.imagePullSecrets of every pod the framework builds for this cluster.
+
+                      It applies to whichever image path is taken, Custom included: a private registry is a
+                      property of where the image lives, not of how its reference was assembled. It is also
+                      deliberately NOT part of image resolution — a pull secret is still needed when the product
+                      resolves its own images and the framework never builds a reference at all.
+
+                      One name rather than a list, matching the field the ten product CRDs already declare. A
+                      deployment needing several credentials merges them into one Secret, or adds the rest through
+                      podOverrides, which is applied after this and therefore wins.
+                    type: string
                   repo:
                     description: |-
                       Repo is the image repository (e.g. "quay.io/kubedoop").

--- a/docs/DOC_CHANGELOG.md
+++ b/docs/DOC_CHANGELOG.md
@@ -4,6 +4,23 @@ This document tracks all changes made to the SDK documentation.
 
 ---
 
+## [2026-08-09d] (the image spec gains a validated tag and a pull secret)
+
+### Core architecture
+
+- `docs/architecture.md` §2.6 gains two paragraphs: why the assembled TAG is validated (the API
+  server does not validate `container.image` at all, so an unparsable reference surfaces only as a
+  kubelet `InvalidImageName` on a pod while the reconcile reports success), and why a registry
+  credential is deliberately NOT part of image resolution — where an image lives is independent of
+  how its reference was built, so the credential has to survive the two paths that assemble no
+  reference at all.
+
+### Package guides
+
+- Root `AGENTS.md` §3 documents `spec.image.pullSecretName` and the tag validation, including what is
+  exempt (`custom`, the user's verbatim reference) and how an override interacts with it (strategic
+  merge patch keys `imagePullSecrets` by `name`, so a `podOverrides` entry adds rather than replaces).
+
 ## [2026-08-09c] (two claims corrected: what the apply path preserves, what a marker key identifies)
 
 ### Package guides

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -167,6 +167,23 @@ convention, and three migrated operators consequently hand-rolled image resoluti
 silent fall back to the handler's static image: running a version nobody asked for is not a safe
 default for a stateful product (the same call as `config.affinity` above).
 
+The assembled **tag** is validated for the same reason, and it is the only place a check can happen:
+`productVersion` and `kubedoopVersion` both land in it, its grammar is
+`[A-Za-z0-9_][A-Za-z0-9._-]{0,127}`, and the Kubernetes API server does not validate
+`container.image` at all — so a value that breaks the grammar is accepted, stored, and reported only
+by the kubelet, as `InvalidImageName` on a pod, while the reconcile returns success and the cluster's
+conditions stay green. The failure this closes is structural rather than hypothetical: the
+recommended wiring is `KubedoopVersion: version.BuildVersion`, and a build variable's unset value is
+whatever the scaffold chose — `"N/A"` in the current one, whose `/` makes the reference unparsable.
+`spec.image.custom` is exempt, because the framework assembles nothing there.
+
+**A registry credential is not part of image resolution.** `spec.image.pullSecretName` folds over
+`ImageDefaults.PullSecretName` per field like everything else, but is resolved by its own accessor
+and applied to the pod directly. Where the image *lives* is independent of how its reference was
+built, so the credential must survive the two paths that assemble no reference at all — `custom`, and
+a product resolving its own images with `ProductName` empty — which is precisely where a private
+registry is most likely to be in play.
+
 **The `ProductConfig` hook receives a `ctx` and a client, and may fail.** "Recomputed every reconcile, and may reflect the current state of the cluster" is only true if the hook can *read* the cluster; without those parameters it was a pure function of the CR, so the products that most needed a product-config layer — anything resolving an `S3Connection` reference or a ZooKeeper address — could not use it, and a failed lookup had nowhere to go but a swallowed error or a panic. Zero operators used the hook, which was the symptom rather than the disease.
 
 Products that already perform the lookup inside `BuildResources` use the imperative counterpart, `RoleGroupBuildContext.ApplyProductDefaults`, rather than repeating it: it folds an overrides layer **beneath** everything already merged, by the merge's own per-dimension rules. Two operators had hand-written that fold, identically, along with a second rule for environment variables that the framework can express directly because `MergedConfig.EnvVars` is a map rather than an ordered list.

--- a/examples/trino-operator/config/crd/bases/trino.kubedoop.dev_trinoclusters.yaml
+++ b/examples/trino-operator/config/crd/bases/trino.kubedoop.dev_trinoclusters.yaml
@@ -713,6 +713,20 @@ spec:
                     - Never
                     - IfNotPresent
                     type: string
+                  pullSecretName:
+                    description: |-
+                      PullSecretName names a docker-registry Secret in the cluster CR's namespace, added to
+                      .spec.imagePullSecrets of every pod the framework builds for this cluster.
+
+                      It applies to whichever image path is taken, Custom included: a private registry is a
+                      property of where the image lives, not of how its reference was assembled. It is also
+                      deliberately NOT part of image resolution — a pull secret is still needed when the product
+                      resolves its own images and the framework never builds a reference at all.
+
+                      One name rather than a list, matching the field the ten product CRDs already declare. A
+                      deployment needing several credentials merges them into one Secret, or adds the rest through
+                      podOverrides, which is applied after this and therefore wins.
+                    type: string
                   repo:
                     description: |-
                       Repo is the image repository (e.g. "quay.io/kubedoop").

--- a/pkg/apis/commons/v1alpha1/image_types.go
+++ b/pkg/apis/commons/v1alpha1/image_types.go
@@ -278,8 +278,6 @@ func (i *ImageSpec) GetPullPolicy() corev1.PullPolicy {
 	return i.PullPolicy
 }
 
-// ResolvedPullPolicy is GetPullPolicy with a defaults layer, matching ResolveImage: the user's
-// choice when they made one, the product's otherwise, IfNotPresent if neither.
 // ResolvedPullSecretName folds the spec's pull secret over the defaults', user first — the same
 // per-field rule ResolveImage applies to the rest of the spec.
 //
@@ -294,6 +292,8 @@ func (i *ImageSpec) ResolvedPullSecretName(defaults ImageSpec) string {
 	return defaults.PullSecretName
 }
 
+// ResolvedPullPolicy is GetPullPolicy with a defaults layer, matching ResolveImage: the user's
+// choice when they made one, the product's otherwise, IfNotPresent if neither.
 func (i *ImageSpec) ResolvedPullPolicy(defaults ImageSpec) corev1.PullPolicy {
 	if i != nil && i.PullPolicy != "" {
 		return i.PullPolicy

--- a/pkg/apis/commons/v1alpha1/image_types.go
+++ b/pkg/apis/commons/v1alpha1/image_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -57,6 +58,20 @@ type ImageSpec struct {
 	// +kubebuilder:default=IfNotPresent
 	// +kubebuilder:validation:Enum=Always;Never;IfNotPresent
 	PullPolicy corev1.PullPolicy `json:"pullPolicy,omitempty"`
+
+	// PullSecretName names a docker-registry Secret in the cluster CR's namespace, added to
+	// .spec.imagePullSecrets of every pod the framework builds for this cluster.
+	//
+	// It applies to whichever image path is taken, Custom included: a private registry is a
+	// property of where the image lives, not of how its reference was assembled. It is also
+	// deliberately NOT part of image resolution — a pull secret is still needed when the product
+	// resolves its own images and the framework never builds a reference at all.
+	//
+	// One name rather than a list, matching the field the ten product CRDs already declare. A
+	// deployment needing several credentials merges them into one Secret, or adds the rest through
+	// podOverrides, which is applied after this and therefore wins.
+	// +kubebuilder:validation:Optional
+	PullSecretName string `json:"pullSecretName,omitempty"`
 }
 
 // ResolveImage builds the container image reference from this spec, filling every field the user
@@ -132,11 +147,63 @@ func (i *ImageSpec) ResolveImage(productName string, defaults ImageSpec) (string
 			productName, missingImageFields(repo, productVersion))
 	}
 
-	image := repo + "/" + productName + ":" + productVersion
+	tag := productVersion
 	if kubedoopVersion != "" {
-		image += "-kubedoop" + kubedoopVersion
+		tag += "-kubedoop" + kubedoopVersion
 	}
-	return image, nil
+	if err := validateImageTag(tag, productVersion, kubedoopVersion); err != nil {
+		return "", fmt.Errorf("cannot resolve spec.image for product %q: %w", productName, err)
+	}
+
+	return repo + "/" + productName + ":" + tag, nil
+}
+
+// Tag grammar, from the OCI/docker reference spec: a tag is `[A-Za-z0-9_][A-Za-z0-9._-]{0,127}`.
+// Split in two here so the error can name the field that broke it — productVersion opens the tag
+// and so must also satisfy the first-character rule, while kubedoopVersion only lands inside it.
+var (
+	imageTagHeadRE = regexp.MustCompile(`^[A-Za-z0-9_][A-Za-z0-9._-]*$`)
+	imageTagRestRE = regexp.MustCompile(`^[A-Za-z0-9._-]+$`)
+)
+
+// maxImageTagLen is the tag length the reference grammar allows: one leading character plus 127.
+const maxImageTagLen = 128
+
+// validateImageTag rejects a productVersion/kubedoopVersion pair that cannot appear in an image
+// tag, BEFORE the reference is handed to a pod.
+//
+// Nothing downstream catches this. The API server does not validate `container.image` at all, so an
+// unparsable reference is accepted, stored, and reported by the kubelet as `InvalidImageName` on a
+// pod nobody was looking at — while the reconcile reports success and the cluster's conditions stay
+// green. The failure is not hypothetical: the documented wiring for KubedoopVersion is the
+// operator's own `version.BuildVersion`, and the scaffold's dev default for that variable is "N/A",
+// which assembles into `…:3.2.2-kubedoopN/A` — the "/" makes the tag unparsable, so a development
+// build of any operator on the structured image path silently produced pods that could never start.
+//
+// The message is worded for a `kubectl apply` reader, like its sibling above: a product's
+// validating webhook forwards it verbatim, and the value may equally have come from the operator's
+// own defaults, which is worth saying out loud because the CR may not contain it anywhere.
+func validateImageTag(tag, productVersion, kubedoopVersion string) error {
+	if !imageTagHeadRE.MatchString(productVersion) {
+		return fmt.Errorf(
+			"spec.image.productVersion %q cannot appear in an image tag (allowed: letters, digits, "+
+				"'.', '_' and '-', starting with a letter, digit or '_'). The value may come from "+
+				"the operator's own defaults rather than from this resource",
+			productVersion)
+	}
+	if kubedoopVersion != "" && !imageTagRestRE.MatchString(kubedoopVersion) {
+		return fmt.Errorf(
+			"spec.image.kubedoopVersion %q cannot appear in an image tag (allowed: letters, digits, "+
+				"'.', '_' and '-'). It usually comes from the operator's own build version rather "+
+				"than from this resource — an unset or placeholder build version is the usual cause",
+			kubedoopVersion)
+	}
+	if len(tag) > maxImageTagLen {
+		return fmt.Errorf(
+			"the resulting image tag %q is %d characters, over the %d an image tag allows",
+			tag, len(tag), maxImageTagLen)
+	}
+	return nil
 }
 
 // ResolvedProductVersion returns the product version to publish as app.kubernetes.io/version for
@@ -213,6 +280,20 @@ func (i *ImageSpec) GetPullPolicy() corev1.PullPolicy {
 
 // ResolvedPullPolicy is GetPullPolicy with a defaults layer, matching ResolveImage: the user's
 // choice when they made one, the product's otherwise, IfNotPresent if neither.
+// ResolvedPullSecretName folds the spec's pull secret over the defaults', user first — the same
+// per-field rule ResolveImage applies to the rest of the spec.
+//
+// It is a separate accessor rather than part of ResolveImage on purpose. A pull secret is needed
+// wherever the image lives, including the two paths where the framework assembles no reference at
+// all: `custom`, and a product that resolves its own images and leaves ProductName empty. Folding it
+// into resolution would silently drop it for exactly the private-registry cases it exists for.
+func (i *ImageSpec) ResolvedPullSecretName(defaults ImageSpec) string {
+	if i != nil && i.PullSecretName != "" {
+		return i.PullSecretName
+	}
+	return defaults.PullSecretName
+}
+
 func (i *ImageSpec) ResolvedPullPolicy(defaults ImageSpec) corev1.PullPolicy {
 	if i != nil && i.PullPolicy != "" {
 		return i.PullPolicy

--- a/pkg/apis/commons/v1alpha1/image_types_test.go
+++ b/pkg/apis/commons/v1alpha1/image_types_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package v1alpha1_test
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -230,6 +232,56 @@ var _ = Describe("ResolveImage", func() {
 		Expect(image).To(BeEmpty())
 
 		Expect((&v1alpha1.ImageSpec{Custom: "pinned:1"}).ResolveImage("", defaults)).To(Equal("pinned:1"))
+	})
+
+	It("rejects a kubedoopVersion that cannot appear in an image tag", func() {
+		// The shipped failure: the documented wiring is ImageDefaults.KubedoopVersion =
+		// version.BuildVersion, and the scaffold's dev default for that variable is "N/A". The "/"
+		// makes the tag unparsable, so every pod of a development build was InvalidImageName while
+		// the reconcile reported success — the API server does not validate container.image at all,
+		// so nothing between here and the kubelet would have caught it.
+		broken := defaults
+		broken.KubedoopVersion = "N/A"
+		image, err := (&v1alpha1.ImageSpec{}).ResolveImage("hive", broken)
+		Expect(err).To(HaveOccurred())
+		Expect(image).To(BeEmpty(), "an unusable reference must never be returned")
+		Expect(err).To(MatchError(ContainSubstring("kubedoopVersion")))
+		Expect(err).To(MatchError(ContainSubstring("N/A")))
+		// The value is the operator's, not the CR's, so the message says where to look.
+		Expect(err).To(MatchError(ContainSubstring("build version")))
+	})
+
+	It("rejects a productVersion that cannot open an image tag", func() {
+		// A tag may not start with '.' or '-', though both are legal inside one. Naming the field
+		// matters: the two halves of the tag come from different places (a CR and the operator's
+		// own defaults), so "bad tag" alone would not say whose value to fix.
+		_, err := (&v1alpha1.ImageSpec{ProductVersion: ".4.1.0"}).ResolveImage("hive", defaults)
+		Expect(err).To(MatchError(ContainSubstring("productVersion")))
+		Expect(err).To(MatchError(ContainSubstring(".4.1.0")))
+	})
+
+	It("rejects an assembled tag longer than a tag may be", func() {
+		long := defaults
+		long.KubedoopVersion = strings.Repeat("v", 200)
+		_, err := (&v1alpha1.ImageSpec{}).ResolveImage("hive", long)
+		Expect(err).To(MatchError(ContainSubstring("128")))
+	})
+
+	It("leaves a custom reference alone", func() {
+		// custom is the user's verbatim reference, whole. The framework assembles nothing there, so
+		// it validates nothing: a wrong value is the user's own visible mistake, while a tag built
+		// from two layers is a mistake the CR may not even contain.
+		image, err := (&v1alpha1.ImageSpec{Custom: "my-registry/hive:N/A"}).ResolveImage("hive", defaults)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(image).To(Equal("my-registry/hive:N/A"))
+	})
+
+	It("accepts the tag characters real product versions use", func() {
+		// Control: '.', '-' and '_' are all legal inside a tag, and pre-release versions use them.
+		ok := defaults
+		ok.KubedoopVersion = "0.0.0-dev_1.2"
+		Expect((&v1alpha1.ImageSpec{ProductVersion: "4.1.0-rc.1"}).ResolveImage("hive", ok)).
+			To(Equal("quay.io/zncdatadev/hive:4.1.0-rc.1-kubedoop0.0.0-dev_1.2"))
 	})
 
 	It("keeps GetImage in step by delegating to it", func() {

--- a/pkg/builder/statefulset_builder.go
+++ b/pkg/builder/statefulset_builder.go
@@ -81,6 +81,10 @@ type StatefulSetBuilder struct {
 	// Service account
 	ServiceAccountName string
 
+	// ImagePullSecretName names a docker-registry Secret added to the pod's imagePullSecrets.
+	// Empty leaves the field unset, so a pod built without one is byte-identical to before.
+	ImagePullSecretName string
+
 	// Storage configuration
 	StorageConfig *StorageConfig
 
@@ -329,6 +333,17 @@ func (b *StatefulSetBuilder) WithInitContainers(containers []corev1.Container) *
 }
 
 // WithServiceAccount sets the service account name.
+// WithImagePullSecretName sets the docker-registry Secret added to the pod's imagePullSecrets.
+// An empty name is a no-op, leaving the field unset.
+//
+// It is applied before podOverrides, so a user override still wins: strategic merge patch keys
+// imagePullSecrets by `name`, which means an override adds a second credential rather than
+// replacing this one.
+func (b *StatefulSetBuilder) WithImagePullSecretName(name string) *StatefulSetBuilder {
+	b.ImagePullSecretName = name
+	return b
+}
+
 func (b *StatefulSetBuilder) WithServiceAccount(name string) *StatefulSetBuilder {
 	b.ServiceAccountName = name
 	return b
@@ -687,6 +702,12 @@ func (b *StatefulSetBuilder) buildPodSpec() corev1.PodSpec {
 	// call WithEnableServiceLinks are unaffected (k8s applies its own default of true).
 	if b.EnableServiceLinks != nil {
 		spec.EnableServiceLinks = clonePtr(b.EnableServiceLinks)
+	}
+
+	// Same rule: an empty name leaves imagePullSecrets nil rather than writing an entry with an
+	// empty reference, which the kubelet would try to look up and log a warning for on every pod.
+	if b.ImagePullSecretName != "" {
+		spec.ImagePullSecrets = []corev1.LocalObjectReference{{Name: b.ImagePullSecretName}}
 	}
 
 	return spec

--- a/pkg/builder/statefulset_builder.go
+++ b/pkg/builder/statefulset_builder.go
@@ -332,7 +332,6 @@ func (b *StatefulSetBuilder) WithInitContainers(containers []corev1.Container) *
 	return b
 }
 
-// WithServiceAccount sets the service account name.
 // WithImagePullSecretName sets the docker-registry Secret added to the pod's imagePullSecrets.
 // An empty name is a no-op, leaving the field unset.
 //
@@ -344,6 +343,7 @@ func (b *StatefulSetBuilder) WithImagePullSecretName(name string) *StatefulSetBu
 	return b
 }
 
+// WithServiceAccount sets the service account name.
 func (b *StatefulSetBuilder) WithServiceAccount(name string) *StatefulSetBuilder {
 	b.ServiceAccountName = name
 	return b

--- a/pkg/builder/statefulset_builder_test.go
+++ b/pkg/builder/statefulset_builder_test.go
@@ -193,6 +193,23 @@ var _ = Describe("StatefulSetBuilder", func() {
 		})
 	})
 
+	Describe("WithImagePullSecretName", func() {
+		It("puts the named Secret on the pod's imagePullSecrets", func() {
+			sts := stsBuilder.WithImagePullSecretName("registry-creds").Build()
+
+			Expect(sts.Spec.Template.Spec.ImagePullSecrets).To(Equal(
+				[]corev1.LocalObjectReference{{Name: "registry-creds"}}))
+		})
+
+		It("leaves the field unset for an empty name", func() {
+			// Writing an entry with an empty reference would make the kubelet look one up and warn
+			// on every pod — and every cluster that needs no registry credential is this case.
+			sts := stsBuilder.WithImagePullSecretName("").Build()
+
+			Expect(sts.Spec.Template.Spec.ImagePullSecrets).To(BeNil())
+		})
+	})
+
 	Describe("WithAffinity", func() {
 		It("should set the affinity", func() {
 			affinity := &corev1.Affinity{

--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -531,6 +531,16 @@ func (h *BaseRoleGroupHandler[CR]) containerImage(
 	return h.Image, h.pullPolicy(buildCtx), nil
 }
 
+// pullSecretName resolves the cluster's image pull secret from spec.image folded over
+// ImageDefaults. Empty means the deployment needs no registry credential, which is the common case.
+func (h *BaseRoleGroupHandler[CR]) pullSecretName(buildCtx *RoleGroupBuildContext) string {
+	var spec *v1alpha1.ImageSpec
+	if buildCtx != nil && buildCtx.ClusterSpec != nil {
+		spec = buildCtx.ClusterSpec.Image
+	}
+	return spec.ResolvedPullSecretName(h.ImageDefaults)
+}
+
 // pullPolicy resolves the pull policy for a handler-supplied image: the per-call value when the
 // product set one, the handler's otherwise.
 func (h *BaseRoleGroupHandler[CR]) pullPolicy(buildCtx *RoleGroupBuildContext) corev1.PullPolicy {
@@ -909,6 +919,17 @@ func (h *BaseRoleGroupHandler[CR]) buildStatefulSet(
 	// default SA), preserving backward compatibility.
 	if buildCtx.ServiceAccountName != "" {
 		stsBuilder.WithServiceAccount(buildCtx.ServiceAccountName)
+	}
+
+	// The pull secret is resolved from spec.image over ImageDefaults, independently of the image
+	// itself: it is needed on every path the image can come from — `custom`, the assembled
+	// reference, and a product that resolves its own images and leaves ProductName empty. Ten
+	// product CRDs already declare this field, and before it existed here every one of them
+	// silently dropped it on migration: the CRD still accepted `pullSecretName` and no pod ever
+	// carried an imagePullSecrets entry, so a private-registry install failed with ImagePullBackOff
+	// and no indication of why.
+	if secretName := h.pullSecretName(buildCtx); secretName != "" {
+		stsBuilder.WithImagePullSecretName(secretName)
 	}
 
 	// Wire the role group's declared runtime config (commons RoleGroupConfigSpec) into the

--- a/pkg/reconciler/base_role_group_handler_test.go
+++ b/pkg/reconciler/base_role_group_handler_test.go
@@ -2386,6 +2386,84 @@ var _ = Describe("Container image resolution", func() {
 			To(Equal("quay.io/zncdatadev/trino:476-kubedoop0.2.0"))
 	})
 
+	It("puts spec.image.pullSecretName on the pod", func() {
+		// Ten product CRDs declare this field. Before it existed here, migrating to the commons
+		// ImageSpec silently deleted the behaviour: the CRD still accepted the value, no pod
+		// carried an imagePullSecrets entry, and a private-registry install failed with
+		// ImagePullBackOff and nothing pointing at the cause.
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("fallback:1", testScheme)
+		handler.ProductName = "trino"
+		handler.ImageDefaults = v1alpha1.ImageSpec{
+			Repo: "quay.io/zncdatadev", ProductVersion: "476", KubedoopVersion: "0.2.0",
+		}
+
+		resources, err := handler.BuildResources(context.Background(), k8sClient, mockCR,
+			newBuildCtx(&v1alpha1.ImageSpec{PullSecretName: "registry-creds"}))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.StatefulSet.Spec.Template.Spec.ImagePullSecrets).To(Equal(
+			[]corev1.LocalObjectReference{{Name: "registry-creds"}}))
+	})
+
+	It("carries the pull secret on the custom-image path too", func() {
+		// A pull secret is a property of WHERE the image lives, not of how its reference was
+		// assembled — so folding it into ResolveImage would have dropped it for `custom`, which is
+		// exactly how a user points at their own registry.
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("fallback:1", testScheme)
+		handler.ProductName = "trino"
+
+		resources, err := handler.BuildResources(context.Background(), k8sClient, mockCR,
+			newBuildCtx(&v1alpha1.ImageSpec{Custom: "private.example.com/trino:476", PullSecretName: "creds"}))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.StatefulSet.Spec.Template.Spec.Containers[0].Image).
+			To(Equal("private.example.com/trino:476"))
+		Expect(resources.StatefulSet.Spec.Template.Spec.ImagePullSecrets).To(Equal(
+			[]corev1.LocalObjectReference{{Name: "creds"}}))
+	})
+
+	It("carries the pull secret when the handler resolves its own images", func() {
+		// ProductName empty is the shape hive and zookeeper use. The framework assembles no
+		// reference at all there, and the deployment still needs its registry credential.
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("private.example.com/hive:1", testScheme)
+
+		resources, err := handler.BuildResources(context.Background(), k8sClient, mockCR,
+			newBuildCtx(&v1alpha1.ImageSpec{PullSecretName: "creds"}))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.StatefulSet.Spec.Template.Spec.ImagePullSecrets).To(Equal(
+			[]corev1.LocalObjectReference{{Name: "creds"}}))
+	})
+
+	It("falls back to ImageDefaults for the pull secret, and to nothing when neither states one", func() {
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("fallback:1", testScheme)
+		handler.ImageDefaults = v1alpha1.ImageSpec{PullSecretName: "operator-wide-creds"}
+
+		resources, err := handler.BuildResources(context.Background(), k8sClient, mockCR, newBuildCtx(nil))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.StatefulSet.Spec.Template.Spec.ImagePullSecrets).To(Equal(
+			[]corev1.LocalObjectReference{{Name: "operator-wide-creds"}}))
+
+		// The common case: no credential anywhere leaves the field unset rather than writing an
+		// entry naming nothing.
+		plain := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("fallback:1", testScheme)
+		resources, err = plain.BuildResources(context.Background(), k8sClient, mockCR, newBuildCtx(nil))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.StatefulSet.Spec.Template.Spec.ImagePullSecrets).To(BeNil())
+	})
+
+	It("fails the role group when the resolved tag cannot be an image tag", func() {
+		// The dev-build case from #604: ImageDefaults.KubedoopVersion = version.BuildVersion, whose
+		// scaffold default is "N/A". Before this, the handler produced
+		// "quay.io/zncdatadev/trino:476-kubedoopN/A" and reported success.
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("fallback:1", testScheme)
+		handler.ProductName = "trino"
+		handler.ImageDefaults = v1alpha1.ImageSpec{
+			Repo: "quay.io/zncdatadev", ProductVersion: "476", KubedoopVersion: "N/A",
+		}
+
+		_, err := handler.BuildResources(context.Background(), k8sClient, mockCR, newBuildCtx(nil))
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ContainSubstring("kubedoopVersion")))
+	})
+
 	It("keeps a ProductName-less handler on its static image, and never errors", func() {
 		// The shape hive and zookeeper use today: they resolve images themselves and leave
 		// ProductName empty. Their CRs DO carry a webhook-filled spec.image, so treating an


### PR DESCRIPTION
Closes #604, closes #607.

Two gaps in the same type, and both have the same shape: a correct-looking CR produces pods that cannot start, while the reconcile reports success.

## #607 — the CRDs promised a pull secret nothing rendered

Ten product CRDs (airflow, dolphinscheduler, hbase, hdfs, hive, kafka, nifi, superset, trino, zookeeper) declare `pullSecretName`. The commons `ImageSpec` had no such field and **nothing under `pkg/` ever wrote `imagePullSecrets`** — so migrating to the commons spec silently deleted a user-visible behaviour: the CRD still accepted the value, no pod carried the entry, and a private-registry install failed with `ImagePullBackOff` and nothing naming the cause. Two adapters dropped it on the floor; the one operator that noticed hand-rendered it in two places.

`ImageSpec.PullSecretName` folds over `ImageDefaults.PullSecretName` per field like the rest of the spec, but is resolved by **its own accessor rather than inside `ResolveImage`**. That is the load-bearing design decision here: where an image *lives* is independent of how its reference was assembled, so the credential has to survive the two paths that assemble no reference at all —

- `spec.image.custom`, which is how a user points at their own registry in the first place;
- a product that resolves its own images and leaves `ProductName` empty (hive, zookeeper).

Folding it into resolution would have dropped it for exactly the private-registry cases it exists for. Specs cover both.

It is applied before `podOverrides`, and strategic merge patch keys `imagePullSecrets` by `name`, so a user override **adds** a credential rather than replacing this one.

## #604 — an image tag nothing validated

`productVersion` and `kubedoopVersion` both land in the image tag, whose grammar is `[A-Za-z0-9_][A-Za-z0-9._-]{0,127}`. Nothing downstream catches a value that breaks it: **the Kubernetes API server does not validate `container.image` at all**, so an unparsable reference is accepted, stored, and surfaces only as `InvalidImageName` on a pod, while the reconcile returns nil and the cluster's conditions stay green.

This is structural rather than hypothetical. The documented wiring is `ImageDefaults.KubedoopVersion = version.BuildVersion`, and a build variable's unset value is whatever the scaffold chose — `"N/A"` in the current one. The `/` makes `…:476-kubedoopN/A` unparsable, so **every development build on the structured image path produced pods that could never start**, and `ResolveImage`'s own carefully worded error path never fired.

The error names the offending field, and says the value may have come from the operator's own defaults rather than from the CR — because it usually has, and the CR being edited may not contain it anywhere.

`spec.image.custom` is deliberately exempt: it is the user's verbatim reference, so the framework assembles nothing there to check, and a wrong value is the user's own visible mistake rather than a mix of two layers.

## Migration

- An operator whose dev build version is a placeholder now **fails loudly at reconcile** with a readable message instead of producing broken pods. Set it to something tag-legal (`0.0.0-dev`). dolphinscheduler is the known case; nifi already fixed its own.
- Downstream adapters map their existing `pullSecretName` into the commons field (one line each); nifi's two hand-rendered call sites can be deleted.
- Correctly built operators are otherwise unaffected — no rendered-YAML change for a cluster that sets neither field.

## Verification

Gates green in both modules (`0 issues.`, all packages `ok`, `Generated files are up to date.`), plus six mutations confirming the new specs have teeth:

| mutation | result |
|---|---|
| no tag validation at all | ✗ |
| validate `productVersion` only, not `kubedoopVersion` | ✗ |
| drop the tag length bound | ✗ |
| builder ignores the pull secret | ✗ |
| handler never wires the pull secret | ✗ |
| pull secret read from the spec only, never the defaults | ✗ |

Per #621, no `CHANGELOG.md` entry — the user-visible description is in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)