### PR TITLE
feat(reconciler): let a product default the role config, and pick storage per role

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -372,6 +372,50 @@ treats `PodSpec.Affinity` the same way — Helm values and Kustomize patches rep
 inheritance was tried and reverted: it invented a semantic users would have to learn, and it removed
 the only way to say "this group has no affinity", which a single-node development group needs.
 
+**A product's own config defaults fold BENEATH the CR's two levels.**
+`SetRoleConfigDefaults(roleName, *RoleGroupConfigSpec)` declares what a role's `resources`,
+`affinity` and `gracefulShutdownTimeout` should be when the CR says nothing, and the framework folds
+it through the **same `MergeRoleGroupConfig`** the role and role group use — not a separate "fill the
+nil fields" pass. That is what makes it inherit their rules rather than inventing new ones:
+`resources` folds per **leaf** (a default `cpu.min` survives a user who set only `cpu.max`, which a
+struct-level nil check would have discarded), `affinity` is replaced **wholesale** (so `affinity: {}`
+still clears the default rather than inheriting it — how a single-node development group opts out),
+and anything the user states anywhere still wins.
+
+`RoleGroupBuildContext.ConfigDefaults` is the per-CR channel and outranks the handler's map. It has
+to exist: `DefaultAntiAffinity`'s selector names the **cluster**, and one handler instance serves
+every cluster the operator reconciles (§4), so a default containing one cannot live on the handler at
+all.
+
+```go
+aff, err := reconciler.EncodeAffinity(reconciler.DefaultAntiAffinity(
+    buildCtx.ClusterName, buildCtx.RoleName, reconciler.TopologyKeyHostname, 70))
+if err != nil { return nil, err }
+buildCtx.ConfigDefaults = &commonsv1alpha1.RoleGroupConfigSpec{Affinity: aff}
+```
+
+`DefaultAntiAffinity(cluster, role, topologyKey, weight)` builds the **preferred** pod anti-affinity
+that spreads one role's pods, selecting on the framework's own identity labels
+(`app.kubernetes.io/instance` + `app.kubernetes.io/component`) — the part worth centralising, since a
+downstream operator re-typing those keys as string literals gets a selector matching nothing the
+moment they change, and a preferred term matching no pod is not an error. It selects on the **role**,
+not the role group: three of five ZooKeeper servers on one node is an outage whether or not they
+share a group. `weight` and `topologyKey` are parameters with no defaults, because the operators that
+hand-wrote this already disagree on the weight. `EncodeAffinity` is `DecodeAffinity`'s inverse.
+
+**`logging` may not appear in a config default.** The framework merges logging in the *reconciler*,
+from the CR's two levels only, and has already decided Vector enablement and rendered the config file
+before a default is read — so one set here would apply to neither. It is a `*ValidationError` rather
+than a half-honoured field.
+
+`SetRoleStorageMountPath(roleName, path)` is the per-role `StorageMountPath`, symmetric with the
+other five per-role setters. A role SET to `""` means **no data PVC for this role** even though the
+handler-global default is set, which is distinct from having no entry (inherit it) — and is the case
+this exists for: a product with a stateful and a stateless role could otherwise only choose between
+"every role" and "no role", so one migration deleted a `volumeClaimTemplate` its Gen 2 predecessor
+rendered. Both new maps feed `ConfiguredRoleNames()`, so a typo in either setter still produces the
+`UnknownConfiguredRole` warning.
+
 `RoleGroupHandlerFuncs` is a function adapter for simple handlers that don't need a full struct.
 
 **The framework owns the NAME of every fixed slot; the handler owns its content.** `ConfigMap`,

--- a/docs/DOC_CHANGELOG.md
+++ b/docs/DOC_CHANGELOG.md
@@ -4,6 +4,22 @@ This document tracks all changes made to the SDK documentation.
 
 ---
 
+## [2026-08-10] (product config defaults reuse the CR's own merge)
+
+### Core architecture
+
+- `docs/architecture.md` §2.5 records why a product's role-config defaults fold through
+  `MergeRoleGroupConfig` rather than a separate nil-fill pass: reusing the merge inherits its rules
+  (resources per leaf, affinity wholesale) instead of inventing a second precedence users would have
+  to learn, and it is what keeps `affinity: {}` meaning "no affinity" rather than "inherit".
+
+### Package guides
+
+- Root `AGENTS.md` §3 documents `SetRoleConfigDefaults`, `RoleGroupBuildContext.ConfigDefaults`,
+  `DefaultAntiAffinity`, `EncodeAffinity`, `TopologyKeyHostname` and `SetRoleStorageMountPath` —
+  including why the per-CR channel has to exist (an anti-affinity selector names the cluster, and the
+  handler is shared) and why `logging` is rejected in a default.
+
 ## [2026-08-09d] (the image spec gains a validated tag and a pull secret)
 
 ### Core architecture

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -107,6 +107,10 @@ Each field type folds with a defined strategy:
 
 This works only because these fields carry **no CRD-level default**: structural defaulting fills a field as soon as its enclosing object exists, so a `+kubebuilder:default` on a leaf makes "unset here" indistinguishable from "explicitly the default" and the Role's value can never win. Defaults therefore live at consumption time (`StorageResource.GetCapacity`, `RoleGroupConfigSpec.GetGracefulShutdownTimeout`, the renderers' root-level INFO).
 
+**A product's own defaults for this block are a third layer beneath the two, folded by the same rule.** `BaseRoleGroupHandler.SetRoleConfigDefaults` (and its per-CR counterpart `RoleGroupBuildContext.ConfigDefaults`) supply what a role's `resources`, `affinity` and `gracefulShutdownTimeout` should be when the CR says nothing. Reusing `MergeRoleGroupConfig` rather than adding a "fill the nil fields" pass is the whole design: a struct-level nil check would discard a product's `cpu.min` the moment a user set `cpu.max`, reintroducing the silent partial loss this table exists to prevent, and it would make `affinity: {}` inherit the product's policy instead of clearing it — removing the only way to say "this group has no affinity" one level further down than the case that already settled it. One rule, three layers, no new precedence for a user to learn.
+
+`logging` is excluded, and rejected rather than ignored: it is merged in the reconciler from the CR's two levels, and Vector enablement and the rendered config file are both decided before a handler default is read, so a default there would apply to neither.
+
 **This rule binds product operators too, and it is checkable.** It is not an explanation of why the
 SDK's own fields are shaped the way they are — it is a constraint on any CRD whose `config` block
 this framework folds, including every field a product adds of its own. Documentation alone was not

--- a/pkg/reconciler/affinity.go
+++ b/pkg/reconciler/affinity.go
@@ -21,7 +21,9 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/zncdatadev/operator-go/pkg/constant"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -68,4 +70,68 @@ func DecodeAffinity(raw *k8sruntime.RawExtension) (*corev1.Affinity, error) {
 		return nil, err
 	}
 	return affinity, nil
+}
+
+// EncodeAffinity is the inverse of DecodeAffinity: it renders an affinity into the schema-free
+// RawExtension the CRD field holds, so a product can supply one as a role config default
+// (BaseRoleGroupHandler.SetRoleConfigDefaults) using the typed Kubernetes API rather than a JSON
+// literal. A nil affinity encodes to nil, which the merge reads as "no opinion".
+//
+// Three Gen 3 migrations wrote this by hand, each with its own comment explaining that the marshal
+// cannot realistically fail. It can, in exactly one way — a value the Kubernetes API itself cannot
+// serialize — so the error is returned rather than dropped, and the caller decides.
+func EncodeAffinity(affinity *corev1.Affinity) (*k8sruntime.RawExtension, error) {
+	if affinity == nil {
+		return nil, nil
+	}
+	raw, err := json.Marshal(affinity)
+	if err != nil {
+		return nil, fmt.Errorf("encoding affinity: %w", err)
+	}
+	return &k8sruntime.RawExtension{Raw: raw}, nil
+}
+
+// TopologyKeyHostname spreads across nodes. It is the topology key every one of these products
+// wants by default, and is named here so a product does not re-type the string.
+const TopologyKeyHostname = "kubernetes.io/hostname"
+
+// DefaultAntiAffinity builds the preferred pod anti-affinity that spreads one ROLE's pods across a
+// topology domain — the rule every product in this family wants and each has hand-written.
+//
+// The label selector is the framework's own role identity (`app.kubernetes.io/instance` +
+// `app.kubernetes.io/component`), which is the part worth centralising: those keys are framework-
+// owned and stamped by BaseRoleGroupHandler, and a downstream operator that re-types them as string
+// literals gets a selector matching nothing the moment the framework changes them — a silent
+// scheduling failure, since a preferred term that matches no pod is not an error.
+//
+// It selects on the ROLE, not the role group: two groups of the same role are the same failure
+// domain problem (three of five ZooKeeper servers on one node is an outage whether or not they share
+// a group), and the role group's own marker key is not unique across roles anyway (see
+// RoleGroupMarkerLabelKey).
+//
+// `weight` and `topologyKey` are parameters with no defaults on purpose. The three operators that
+// wrote this already disagree on the weight (20 and 70 both appear), so a helper that fixed it would
+// change their rendered pods; and the topology key is a cluster-topology decision — spreading across
+// zones is a different guarantee from spreading across nodes.
+//
+// PREFERRED rather than required, because required turns a too-small cluster into pods that never
+// schedule at all: with three nodes and five replicas, two stay Pending forever with no way to
+// express "spread as far as you can". A product that genuinely requires the spread builds its own.
+func DefaultAntiAffinity(clusterName, roleName, topologyKey string, weight int32) *corev1.Affinity {
+	return &corev1.Affinity{
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{
+				Weight: weight,
+				PodAffinityTerm: corev1.PodAffinityTerm{
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							constant.LabelKubernetesInstance:  clusterName,
+							constant.LabelKubernetesComponent: roleName,
+						},
+					},
+					TopologyKey: topologyKey,
+				},
+			}},
+		},
+	}
 }

--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -144,6 +144,19 @@ type BaseRoleGroupHandler[CR common.ClusterInterface] struct {
 	// backward compatibility (no data PVC unless a product opts in).
 	StorageMountPath string
 
+	// RoleStorageMountPaths maps role names to a role-specific data PVC mount path, overriding
+	// StorageMountPath for that role. Symmetric with RoleContainerPorts and its siblings, and the
+	// one per-role override the handler was missing: a product either gave a data PVC to every
+	// StatefulSet role or to none.
+	//
+	// An entry set to "" means "no data PVC for this role", which is distinct from having no entry
+	// (inherit StorageMountPath). Set it through SetRoleStorageMountPath.
+	RoleStorageMountPaths map[string]string
+
+	// RoleConfigDefaults maps role names to the product's own defaults for the role group config
+	// block. See SetRoleConfigDefaults.
+	RoleConfigDefaults map[string]*v1alpha1.RoleGroupConfigSpec
+
 	// ConfigMountPath is where the generated config ConfigMap is mounted in the primary
 	// container. Products whose application reads config from a specific directory (e.g.
 	// "/etc/trino") set this. Defaults to the kubedoop-canonical config mount path
@@ -260,6 +273,8 @@ func NewBaseRoleGroupHandler[CR common.ClusterInterface](image string, scheme *r
 		RoleServicePorts:      make(map[string][]corev1.ServicePort),
 		RoleMainContainerName: make(map[string]string),
 		RoleLoggingContainers: make(map[string][]productlogging.ContainerLogging),
+		RoleStorageMountPaths: make(map[string]string),
+		RoleConfigDefaults:    make(map[string]*v1alpha1.RoleGroupConfigSpec),
 		Scheme:                scheme,
 	}
 }
@@ -456,6 +471,49 @@ func (h *BaseRoleGroupHandler[CR]) mainContainerNameFor(roleName string) string 
 	return h.MainContainerName
 }
 
+// SetRoleStorageMountPath sets the data PVC mount path for a specific role, overriding
+// StorageMountPath for that role. Symmetric with SetRoleContainerPorts.
+//
+// Pass "" to say this role has NO data PVC even though the handler-global default is set — the
+// case this exists for, since a product with a stateful and a stateless role could otherwise only
+// choose between "every role" and "no role".
+func (h *BaseRoleGroupHandler[CR]) SetRoleStorageMountPath(roleName, path string) {
+	if h.RoleStorageMountPaths == nil {
+		h.RoleStorageMountPaths = make(map[string]string)
+	}
+	h.RoleStorageMountPaths[roleName] = path
+}
+
+// SetRoleConfigDefaults declares the product's own defaults for a role's config block — the
+// `resources`, `affinity`, `gracefulShutdownTimeout` and `logging` a role should have when the CR
+// says nothing.
+//
+// The value is folded BENEATH the role and role group config, through the same
+// MergeRoleGroupConfig the CR's own two levels use, so it inherits their rules exactly rather than
+// inventing a second "fill the nil fields" semantic:
+//
+//   - `resources` folds per LEAF, so a product default for cpu.min survives a user who set only
+//     cpu.max — a struct-level nil check would have dropped it;
+//   - `affinity` is REPLACED wholesale, so `affinity: {}` in the CR still clears the default rather
+//     than inheriting it, which is how a single-node development group opts out;
+//   - anything the user states anywhere wins, at every level.
+//
+// Build the affinity with DefaultAntiAffinity and EncodeAffinity rather than a JSON literal:
+//
+//	aff, err := reconciler.EncodeAffinity(
+//	    reconciler.DefaultAntiAffinity(clusterName, "worker", reconciler.TopologyKeyHostname, 70))
+//
+// Note what that example implies: the anti-affinity selector names the CLUSTER, so a default that
+// includes one is per-cluster data and cannot live on the handler, which is shared by every cluster
+// the operator serves (§4). Supply it through RoleGroupBuildContext.ConfigDefaults instead; this
+// setter is for the reconcile-invariant part.
+func (h *BaseRoleGroupHandler[CR]) SetRoleConfigDefaults(roleName string, defaults *v1alpha1.RoleGroupConfigSpec) {
+	if h.RoleConfigDefaults == nil {
+		h.RoleConfigDefaults = make(map[string]*v1alpha1.RoleGroupConfigSpec)
+	}
+	h.RoleConfigDefaults[roleName] = defaults
+}
+
 // SetRoleLoggingContainers sets the logging-producer list for a specific role, overriding the
 // global LoggingContainers for that role. Symmetric with SetRoleContainerPorts.
 func (h *BaseRoleGroupHandler[CR]) SetRoleLoggingContainers(roleName string, containers []productlogging.ContainerLogging) {
@@ -529,6 +587,57 @@ func (h *BaseRoleGroupHandler[CR]) containerImage(
 		return image, h.pullPolicy(buildCtx), nil
 	}
 	return h.Image, h.pullPolicy(buildCtx), nil
+}
+
+// mergedRoleGroupConfig folds the product's own defaults BENEATH the CR's role and role group
+// levels, through the same MergeRoleGroupConfig those two use — so `resources` folds per leaf (a
+// default cpu.min survives a user who set only cpu.max), `affinity` is replaced wholesale
+// (`affinity: {}` still clears the default rather than inheriting it), and anything the user states
+// anywhere still wins. Reusing the merge is the point: a "fill the nil fields" pass would discard a
+// product's sibling leaves and make an empty affinity inherit rather than clear.
+//
+// It runs here rather than in the reconciler because the per-call channel has to outrank the
+// handler's map: an anti-affinity selector names the cluster, and one handler serves them all.
+func (h *BaseRoleGroupHandler[CR]) mergedRoleGroupConfig(
+	buildCtx *RoleGroupBuildContext,
+) (*v1alpha1.RoleGroupConfigSpec, error) {
+	defaults := h.configDefaults(buildCtx)
+	if defaults != nil && defaults.Logging != nil {
+		return nil, NewValidationError("RoleGroupBuildContext.ConfigDefaults", buildCtx.RoleName, buildCtx.RoleGroupName,
+			fmt.Errorf("config defaults may not set logging: the framework merges logging at the "+
+				"reconciler level from the CR's role and role group only, and has already decided Vector "+
+				"enablement and rendered the logging config file by the time defaults are read — a "+
+				"default here would apply to neither. Put product logging defaults in the CR's own "+
+				"defaulting webhook instead"))
+	}
+	return MergeRoleGroupConfig(defaults, buildCtx.RoleGroupSpec.GetConfig()), nil
+}
+
+// configDefaults resolves the product's role-config defaults: the per-call value when the product
+// set one (it depends on WHICH cluster is being built), the handler's per-role map otherwise.
+func (h *BaseRoleGroupHandler[CR]) configDefaults(buildCtx *RoleGroupBuildContext) *v1alpha1.RoleGroupConfigSpec {
+	if buildCtx == nil {
+		return nil
+	}
+	if buildCtx.ConfigDefaults != nil {
+		return buildCtx.ConfigDefaults
+	}
+	return h.RoleConfigDefaults[buildCtx.RoleName]
+}
+
+// storageMountPath resolves the data PVC mount path for a role: the per-role value when the product
+// set one, the handler's global default otherwise. Empty means this role gets no data PVC.
+//
+// A role SET to "" is not the same as a role with no entry: it means "no data PVC for this role even
+// though the global default is set", which is the case that made this per-role at all. DolphinScheduler
+// needs the volume on `worker` and must not have it on `master`, and with only a handler-global field
+// the migration had to choose "none" — deleting the `worker-data` volumeClaimTemplate that Gen 2
+// rendered, since Gen 2 already modelled storage per role.
+func (h *BaseRoleGroupHandler[CR]) storageMountPath(roleName string) string {
+	if path, ok := h.RoleStorageMountPaths[roleName]; ok {
+		return path
+	}
+	return h.StorageMountPath
 }
 
 // pullSecretName resolves the cluster's image pull secret from spec.image folded over
@@ -936,15 +1045,18 @@ func (h *BaseRoleGroupHandler[CR]) buildStatefulSet(
 	// StatefulSet. All of these land on the builder BEFORE pod overrides take effect: the
 	// builder applies PodOverrides last in Build(), so a user-supplied pod override (e.g. an
 	// affinity in podOverrides) always keeps precedence over the config-declared value.
-	roleGroupConfig := buildCtx.RoleGroupSpec.GetConfig()
+	roleGroupConfig, err := h.mergedRoleGroupConfig(buildCtx)
+	if err != nil {
+		return nil, err
+	}
 	if roleGroupConfig != nil {
 		if roleGroupConfig.Resources != nil {
 			stsBuilder.WithResources(roleGroupConfig.Resources)
 			// Opt-in data PVC: when a product sets StorageMountPath, build a VolumeClaimTemplate
 			// from the configured storage and mount it, so the volume/mount contract is enforced
 			// by the builder instead of being hand-assembled by each product.
-			if h.StorageMountPath != "" && roleGroupConfig.Resources.Storage != nil {
-				stsBuilder.WithStorage(roleGroupConfig.Resources.Storage, h.StorageMountPath)
+			if mountPath := h.storageMountPath(buildCtx.RoleName); mountPath != "" && roleGroupConfig.Resources.Storage != nil {
+				stsBuilder.WithStorage(roleGroupConfig.Resources.Storage, mountPath)
 			}
 		}
 
@@ -1227,6 +1339,12 @@ func (h *BaseRoleGroupHandler[CR]) ConfiguredRoleNames() []string {
 		names[name] = struct{}{}
 	}
 	for name := range h.RoleLoggingContainers {
+		names[name] = struct{}{}
+	}
+	for name := range h.RoleStorageMountPaths {
+		names[name] = struct{}{}
+	}
+	for name := range h.RoleConfigDefaults {
 		names[name] = struct{}{}
 	}
 	return slices.Sorted(maps.Keys(names))

--- a/pkg/reconciler/base_role_group_handler.go
+++ b/pkg/reconciler/base_role_group_handler.go
@@ -601,9 +601,9 @@ func (h *BaseRoleGroupHandler[CR]) containerImage(
 func (h *BaseRoleGroupHandler[CR]) mergedRoleGroupConfig(
 	buildCtx *RoleGroupBuildContext,
 ) (*v1alpha1.RoleGroupConfigSpec, error) {
-	defaults := h.configDefaults(buildCtx)
+	defaults, source := h.configDefaults(buildCtx)
 	if defaults != nil && defaults.Logging != nil {
-		return nil, NewValidationError("RoleGroupBuildContext.ConfigDefaults", buildCtx.RoleName, buildCtx.RoleGroupName,
+		return nil, NewValidationError(source, buildCtx.RoleName, buildCtx.RoleGroupName,
 			fmt.Errorf("config defaults may not set logging: the framework merges logging at the "+
 				"reconciler level from the CR's role and role group only, and has already decided Vector "+
 				"enablement and rendered the logging config file by the time defaults are read — a "+
@@ -615,14 +615,23 @@ func (h *BaseRoleGroupHandler[CR]) mergedRoleGroupConfig(
 
 // configDefaults resolves the product's role-config defaults: the per-call value when the product
 // set one (it depends on WHICH cluster is being built), the handler's per-role map otherwise.
-func (h *BaseRoleGroupHandler[CR]) configDefaults(buildCtx *RoleGroupBuildContext) *v1alpha1.RoleGroupConfigSpec {
+//
+// It also returns WHICH of the two supplied the value, so an error about a bad default names the
+// place the product has to edit. The two are set through different APIs in different files, and a
+// message naming the wrong one sends the reader to code that does not contain the problem.
+func (h *BaseRoleGroupHandler[CR]) configDefaults(
+	buildCtx *RoleGroupBuildContext,
+) (*v1alpha1.RoleGroupConfigSpec, string) {
 	if buildCtx == nil {
-		return nil
+		return nil, ""
 	}
 	if buildCtx.ConfigDefaults != nil {
-		return buildCtx.ConfigDefaults
+		return buildCtx.ConfigDefaults, "RoleGroupBuildContext.ConfigDefaults"
 	}
-	return h.RoleConfigDefaults[buildCtx.RoleName]
+	if defaults, ok := h.RoleConfigDefaults[buildCtx.RoleName]; ok {
+		return defaults, fmt.Sprintf("BaseRoleGroupHandler.SetRoleConfigDefaults(%q)", buildCtx.RoleName)
+	}
+	return nil, ""
 }
 
 // storageMountPath resolves the data PVC mount path for a role: the per-role value when the product

--- a/pkg/reconciler/role_config_defaults_test.go
+++ b/pkg/reconciler/role_config_defaults_test.go
@@ -1,0 +1,307 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
+	"github.com/zncdatadev/operator-go/pkg/common"
+	"github.com/zncdatadev/operator-go/pkg/config"
+	"github.com/zncdatadev/operator-go/pkg/reconciler"
+	"github.com/zncdatadev/operator-go/pkg/testutil"
+	"k8s.io/apimachinery/pkg/api/resource"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+)
+
+// defaultsBuildCtx builds a context for the "worker" role with whatever config the CR states.
+func defaultsBuildCtx(cfg *v1alpha1.RoleGroupConfigSpec) *reconciler.RoleGroupBuildContext {
+	return &reconciler.RoleGroupBuildContext{
+		ClusterName:      "test-cluster",
+		ClusterNamespace: "default",
+		RoleName:         "worker",
+		RoleSpec:         &v1alpha1.RoleSpec{},
+		RoleGroupName:    "default",
+		RoleGroupSpec:    v1alpha1.RoleGroupSpec{Replicas: ptr.To(int32(3)), Config: cfg},
+		MergedConfig:     &config.MergedConfig{},
+		ResourceName:     reconciler.RoleGroupResourceName("test-cluster", "worker", "default"),
+	}
+}
+
+func quantityPtr(s string) *resource.Quantity { q := resource.MustParse(s); return &q }
+
+var _ = Describe("Role config defaults", func() {
+	var (
+		ctx    context.Context
+		mockCR *testutil.MockCluster
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		mockCR = testutil.NewMockCluster("test-cluster", testNamespace)
+	})
+
+	newHandler := func() *reconciler.BaseRoleGroupHandler[common.ClusterInterface] {
+		return reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("product:1", testScheme)
+	}
+
+	It("applies a product default when the CR states nothing", func() {
+		// Three Gen 3 migrations wrote this pass by hand — "if nil, fill the product default" over
+		// resources / affinity / gracefulShutdownTimeout — down to the same function names.
+		handler := newHandler()
+		handler.SetRoleConfigDefaults("worker", &v1alpha1.RoleGroupConfigSpec{
+			GracefulShutdownTimeout: ptr.To("5m"),
+		})
+
+		resources, err := handler.BuildResources(ctx, k8sClient, mockCR, defaultsBuildCtx(nil))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.StatefulSet.Spec.Template.Spec.TerminationGracePeriodSeconds).
+			To(HaveValue(Equal(int64(300))))
+	})
+
+	It("lets the CR win over the default", func() {
+		handler := newHandler()
+		handler.SetRoleConfigDefaults("worker", &v1alpha1.RoleGroupConfigSpec{
+			GracefulShutdownTimeout: ptr.To("5m"),
+		})
+
+		resources, err := handler.BuildResources(ctx, k8sClient, mockCR, defaultsBuildCtx(
+			&v1alpha1.RoleGroupConfigSpec{GracefulShutdownTimeout: ptr.To("90s")}))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.StatefulSet.Spec.Template.Spec.TerminationGracePeriodSeconds).
+			To(HaveValue(Equal(int64(90))))
+	})
+
+	It("folds resources per LEAF, so a default survives a user who set one sibling", func() {
+		// The reason this reuses MergeRoleGroupConfig rather than a struct-level nil check: a
+		// user setting cpu.max would otherwise discard the product's cpu.min and memory entirely,
+		// which is the same defect the role/role-group merge was fixed for.
+		handler := newHandler()
+		handler.SetRoleConfigDefaults("worker", &v1alpha1.RoleGroupConfigSpec{
+			Resources: &v1alpha1.ResourcesSpec{
+				CPU:    &v1alpha1.CPUResource{Min: quantityPtr("100m"), Max: quantityPtr("1")},
+				Memory: &v1alpha1.MemoryResource{Limit: quantityPtr("1Gi")},
+			},
+		})
+
+		resources, err := handler.BuildResources(ctx, k8sClient, mockCR, defaultsBuildCtx(
+			&v1alpha1.RoleGroupConfigSpec{Resources: &v1alpha1.ResourcesSpec{
+				CPU: &v1alpha1.CPUResource{Max: quantityPtr("4")},
+			}}))
+		Expect(err).NotTo(HaveOccurred())
+
+		container := resources.StatefulSet.Spec.Template.Spec.Containers[0]
+		Expect(container.Resources.Limits.Cpu().String()).To(Equal("4"), "the user's value wins")
+		Expect(container.Resources.Requests.Cpu().String()).To(Equal("100m"), "the default's sibling leaf survives")
+		Expect(container.Resources.Limits.Memory().String()).To(Equal("1Gi"), "so does an untouched member")
+	})
+
+	It("lets `affinity: {}` clear a default rather than inherit it", func() {
+		// Affinity is the one field that does not fold per leaf — it is a scheduling POLICY, and
+		// an empty one is how a single-node development group says "no anti-affinity". Folding the
+		// default beneath the CR keeps that: non-nil means the user has an opinion, even an empty one.
+		handler := newHandler()
+		aff, err := reconciler.EncodeAffinity(reconciler.DefaultAntiAffinity(
+			"test-cluster", "worker", reconciler.TopologyKeyHostname, 70))
+		Expect(err).NotTo(HaveOccurred())
+		handler.SetRoleConfigDefaults("worker", &v1alpha1.RoleGroupConfigSpec{Affinity: aff})
+
+		withDefault, err := handler.BuildResources(ctx, k8sClient, mockCR, defaultsBuildCtx(nil))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(withDefault.StatefulSet.Spec.Template.Spec.Affinity).NotTo(BeNil())
+		Expect(withDefault.StatefulSet.Spec.Template.Spec.Affinity.PodAntiAffinity.
+			PreferredDuringSchedulingIgnoredDuringExecution).To(HaveLen(1))
+
+		cleared, err := handler.BuildResources(ctx, k8sClient, mockCR, defaultsBuildCtx(
+			&v1alpha1.RoleGroupConfigSpec{Affinity: &k8sruntime.RawExtension{Raw: []byte(`{}`)}}))
+		Expect(err).NotTo(HaveOccurred())
+		// `{}` decodes to an empty corev1.Affinity, which the builder sets as-is — non-nil but
+		// carrying no rule, which is what "this group has no anti-affinity" looks like in a pod spec.
+		Expect(cleared.StatefulSet.Spec.Template.Spec.Affinity.PodAntiAffinity).To(BeNil(),
+			"an explicitly empty affinity must not inherit the product default")
+	})
+
+	It("lets the per-call channel outrank the handler's map", func() {
+		// DefaultAntiAffinity's selector names the CLUSTER, and one handler instance serves every
+		// cluster the operator reconciles — so a default containing one cannot live on the handler
+		// at all. This is the same hazard as Image and ContainerPorts (§4).
+		handler := newHandler()
+		handler.SetRoleConfigDefaults("worker", &v1alpha1.RoleGroupConfigSpec{
+			GracefulShutdownTimeout: ptr.To("5m"),
+		})
+
+		buildCtx := defaultsBuildCtx(nil)
+		buildCtx.ConfigDefaults = &v1alpha1.RoleGroupConfigSpec{GracefulShutdownTimeout: ptr.To("2m")}
+
+		resources, err := handler.BuildResources(ctx, k8sClient, mockCR, buildCtx)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.StatefulSet.Spec.Template.Spec.TerminationGracePeriodSeconds).
+			To(HaveValue(Equal(int64(120))))
+	})
+
+	It("rejects a default that sets logging", func() {
+		// The framework merges logging in the RECONCILER, from the CR's two levels, and has already
+		// decided Vector enablement and rendered the config file before a handler default is read.
+		// Honouring it here would apply to neither, so it fails instead of half-working.
+		handler := newHandler()
+		buildCtx := defaultsBuildCtx(nil)
+		buildCtx.ConfigDefaults = &v1alpha1.RoleGroupConfigSpec{
+			Logging: &v1alpha1.LoggingSpec{EnableVectorAgent: ptr.To(true)},
+		}
+
+		_, err := handler.BuildResources(ctx, k8sClient, mockCR, buildCtx)
+		Expect(err).To(HaveOccurred())
+		Expect(reconciler.IsValidationError(err)).To(BeTrue(), "want a *ValidationError, got %T", err)
+		Expect(err.Error()).To(ContainSubstring("logging"))
+	})
+
+	It("reports a config-defaults role name the CR does not declare", func() {
+		// A typo in SetRoleConfigDefaults("wroker", ...) would otherwise silently produce a role
+		// group with none of the product's defaults, which is what ConfiguredRoleNames exists for.
+		handler := newHandler()
+		handler.SetRoleConfigDefaults("wroker", &v1alpha1.RoleGroupConfigSpec{})
+		handler.SetRoleStorageMountPath("mstaer", "/data")
+
+		Expect(handler.ConfiguredRoleNames()).To(ContainElements("wroker", "mstaer"))
+	})
+})
+
+var _ = Describe("DefaultAntiAffinity", func() {
+	It("selects on the framework's own role identity", func() {
+		// The value of centralising this: those keys are framework-owned and stamped by
+		// BaseRoleGroupHandler. An operator that re-types them as string literals — zookeeper's
+		// Gen 3 branch does — gets a selector matching nothing the moment they change, and a
+		// PREFERRED term that matches no pod is not an error, so the spread silently disappears.
+		aff := reconciler.DefaultAntiAffinity("kafka-prod", "broker", reconciler.TopologyKeyHostname, 70)
+
+		terms := aff.PodAntiAffinity.PreferredDuringSchedulingIgnoredDuringExecution
+		Expect(terms).To(HaveLen(1))
+		Expect(terms[0].Weight).To(Equal(int32(70)))
+		Expect(terms[0].PodAffinityTerm.TopologyKey).To(Equal("kubernetes.io/hostname"))
+		Expect(terms[0].PodAffinityTerm.LabelSelector.MatchLabels).To(Equal(map[string]string{
+			"app.kubernetes.io/instance":  "kafka-prod",
+			"app.kubernetes.io/component": "broker",
+		}))
+		Expect(aff.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution).To(BeEmpty(),
+			"required would leave replicas Pending forever on a cluster with fewer nodes than replicas")
+	})
+
+	It("round-trips through EncodeAffinity and the strict decoder", func() {
+		// EncodeAffinity's output has to survive DecodeAffinity, which rejects unknown fields — so
+		// this is the guard that the two stay inverses as corev1.Affinity evolves.
+		aff := reconciler.DefaultAntiAffinity("kafka-prod", "broker", "topology.kubernetes.io/zone", 20)
+		raw, err := reconciler.EncodeAffinity(aff)
+		Expect(err).NotTo(HaveOccurred())
+
+		decoded, err := reconciler.DecodeAffinity(raw)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(decoded).To(Equal(aff))
+	})
+
+	It("encodes nil as nil, which the merge reads as no opinion", func() {
+		raw, err := reconciler.EncodeAffinity(nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(raw).To(BeNil())
+	})
+})
+
+var _ = Describe("Per-role storage mount path", func() {
+	var (
+		ctx    context.Context
+		mockCR *testutil.MockCluster
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		mockCR = testutil.NewMockCluster("test-cluster", testNamespace)
+	})
+
+	storageCtx := func(roleName string) *reconciler.RoleGroupBuildContext {
+		buildCtx := defaultsBuildCtx(&v1alpha1.RoleGroupConfigSpec{
+			Resources: &v1alpha1.ResourcesSpec{
+				Storage: &v1alpha1.StorageResource{Capacity: quantityPtr("10Gi")},
+			},
+		})
+		buildCtx.RoleName = roleName
+		buildCtx.ResourceName = reconciler.RoleGroupResourceName("test-cluster", roleName, "default")
+		return buildCtx
+	}
+
+	It("gives one role a data PVC and withholds it from another", func() {
+		// DolphinScheduler's case: `worker` needs the volume, `master` must not have it. With only a
+		// handler-global StorageMountPath the migration had to choose "none", deleting the
+		// worker-data volumeClaimTemplate Gen 2 already rendered.
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("product:1", testScheme)
+		handler.SetRoleStorageMountPath("worker", "/kubedoop/data")
+
+		worker, err := handler.BuildResources(ctx, k8sClient, mockCR, storageCtx("worker"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(worker.StatefulSet.Spec.VolumeClaimTemplates).To(HaveLen(1))
+
+		master, err := handler.BuildResources(ctx, k8sClient, mockCR, storageCtx("master"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(master.StatefulSet.Spec.VolumeClaimTemplates).To(BeEmpty(),
+			"a role with no entry and no global default gets no data PVC")
+	})
+
+	It("lets a role opt OUT of a handler-global default with an empty path", func() {
+		// "" for a role is not "unset": it is the only way to say this role has no data PVC while
+		// its siblings inherit the global one.
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("product:1", testScheme)
+		handler.StorageMountPath = "/kubedoop/data"
+		handler.SetRoleStorageMountPath("master", "")
+
+		worker, err := handler.BuildResources(ctx, k8sClient, mockCR, storageCtx("worker"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(worker.StatefulSet.Spec.VolumeClaimTemplates).To(HaveLen(1), "inherits the global default")
+
+		master, err := handler.BuildResources(ctx, k8sClient, mockCR, storageCtx("master"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(master.StatefulSet.Spec.VolumeClaimTemplates).To(BeEmpty())
+	})
+
+	It("mounts the per-role path on the primary container", func() {
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("product:1", testScheme)
+		handler.StorageMountPath = "/kubedoop/data"
+		handler.SetRoleStorageMountPath("worker", "/var/lib/worker")
+
+		worker, err := handler.BuildResources(ctx, k8sClient, mockCR, storageCtx("worker"))
+		Expect(err).NotTo(HaveOccurred())
+
+		mounts := worker.StatefulSet.Spec.Template.Spec.Containers[0].VolumeMounts
+		paths := make([]string, 0, len(mounts))
+		for _, m := range mounts {
+			paths = append(paths, m.MountPath)
+		}
+		Expect(paths).To(ContainElement("/var/lib/worker"))
+		Expect(paths).NotTo(ContainElement("/kubedoop/data"))
+	})
+
+	It("keeps the handler-global path for roles with no entry", func() {
+		handler := reconciler.NewBaseRoleGroupHandler[common.ClusterInterface]("product:1", testScheme)
+		handler.StorageMountPath = "/kubedoop/data"
+
+		resources, err := handler.BuildResources(ctx, k8sClient, mockCR, storageCtx("worker"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resources.StatefulSet.Spec.VolumeClaimTemplates).To(HaveLen(1))
+		Expect(resources.StatefulSet.Spec.Template.Spec.Containers[0].VolumeMounts).To(
+			ContainElement(HaveField("MountPath", "/kubedoop/data")))
+	})
+})

--- a/pkg/reconciler/role_config_defaults_test.go
+++ b/pkg/reconciler/role_config_defaults_test.go
@@ -170,6 +170,21 @@ var _ = Describe("Role config defaults", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(reconciler.IsValidationError(err)).To(BeTrue(), "want a *ValidationError, got %T", err)
 		Expect(err.Error()).To(ContainSubstring("logging"))
+		Expect(err.Error()).To(ContainSubstring("RoleGroupBuildContext.ConfigDefaults"))
+	})
+
+	It("names the handler map when THAT is where the bad default came from", func() {
+		// The two defaults are set through different APIs in different files, so an error naming the
+		// wrong one sends the reader to code that does not contain the problem.
+		handler := newHandler()
+		handler.SetRoleConfigDefaults("worker", &v1alpha1.RoleGroupConfigSpec{
+			Logging: &v1alpha1.LoggingSpec{EnableVectorAgent: ptr.To(true)},
+		})
+
+		_, err := handler.BuildResources(ctx, k8sClient, mockCR, defaultsBuildCtx(nil))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring(`SetRoleConfigDefaults("worker")`))
+		Expect(err.Error()).NotTo(ContainSubstring("RoleGroupBuildContext.ConfigDefaults"))
 	})
 
 	It("reports a config-defaults role name the CR does not declare", func() {

--- a/pkg/reconciler/role_group_handler.go
+++ b/pkg/reconciler/role_group_handler.go
@@ -281,6 +281,25 @@ type RoleGroupBuildContext struct {
 	// StatefulSet is built, so set Image above instead.
 	MainContainerCustomizer func(*corev1.Container) error
 
+	// ConfigDefaults supplies the product's defaults for THIS role group's config block, folded
+	// beneath the CR's role and role group levels. It outranks the handler's own
+	// SetRoleConfigDefaults, and exists because some defaults cannot live on the handler at all:
+	// DefaultAntiAffinity's selector names the cluster, and the handler is shared by every cluster
+	// the operator serves (§4).
+	//
+	// Set it in BuildResources before delegating to BaseRoleGroupHandler:
+	//
+	//	aff, err := reconciler.EncodeAffinity(reconciler.DefaultAntiAffinity(
+	//	    buildCtx.ClusterName, buildCtx.RoleName, reconciler.TopologyKeyHostname, 70))
+	//	if err != nil { return nil, err }
+	//	buildCtx.ConfigDefaults = &commonsv1alpha1.RoleGroupConfigSpec{Affinity: aff}
+	//
+	// Logging must be nil here: the framework merges logging at the reconciler level, from the CR's
+	// two levels only, and has already decided Vector enablement and rendered the config file by the
+	// time this is read. A default that set it would apply to neither, so it is rejected rather than
+	// half-honoured.
+	ConfigDefaults *v1alpha1.RoleGroupConfigSpec
+
 	// VectorAggregatorAddress is the resolved Vector aggregator discovery address, populated by
 	// GenericReconciler when the Vector agent is enabled and the CR implements
 	// VectorAggregatorProvider (the reconciler reads its ConfigMap name and resolves the address


### PR DESCRIPTION
Closes #601, closes #603.

Two halves of one gap: role-level configuration the framework does not carry, so every Gen 3 migration re-implements it — three produced near-identical functions, down to the naming.

## #601 — config defaults reuse the CR's own merge

`SetRoleConfigDefaults(role, *RoleGroupConfigSpec)` declares what a role's `resources` / `affinity` / `gracefulShutdownTimeout` should be when the CR says nothing. The framework folds it through the **same `MergeRoleGroupConfig`** the CR's own two levels use — **not** a separate "fill the nil fields" pass, which is what the downstream copies do and what the issue proposed.

That difference is the design, not an implementation shortcut:

| | struct-level nil check | folding through the merge |
|---|---|---|
| product sets `cpu.min`, user sets `cpu.max` | product's `cpu.min` **discarded** | both survive (per-leaf) |
| user writes `affinity: {}` | **inherits** the product's policy | **clears** it, as documented |

The first row is exactly the silent partial loss the role/role-group merge was fixed for; the second removes the only way to say "this group has no affinity", one level further down than the case that already settled it. One rule, three layers, no new precedence for a user to learn.

**`RoleGroupBuildContext.ConfigDefaults` is the per-CR channel and outranks the handler's map.** It has to exist: `DefaultAntiAffinity`'s selector names the **cluster**, and one handler instance serves every cluster the operator reconciles — so a default containing one cannot live on the handler at all. That is the hazard #525 already established for `Image` and `ContainerPorts`.

```go
aff, err := reconciler.EncodeAffinity(reconciler.DefaultAntiAffinity(
    buildCtx.ClusterName, buildCtx.RoleName, reconciler.TopologyKeyHostname, 70))
if err != nil { return nil, err }
buildCtx.ConfigDefaults = &commonsv1alpha1.RoleGroupConfigSpec{Affinity: aff}
```

**`logging` in a default is rejected, not ignored.** The framework merges logging in the *reconciler*, from the CR's two levels, and has already decided Vector enablement and rendered the config file before a handler default is read — so one set here would apply to neither. Half-honouring it would be the worse answer.

`DefaultAntiAffinity` selects on the framework's own identity labels, which is the part worth centralising: an operator re-typing those keys as string literals (zookeeper's Gen 3 branch does) gets a selector matching nothing the moment they change, and **a preferred term that matches no pod is not an error** — the spread just silently disappears. It selects on the **role**, not the role group: three of five ZooKeeper servers on one node is an outage whether or not they share a group. `weight` and `topologyKey` stay parameters with no defaults, per the issue's own warning that the three operators disagree on the weight (20 and 70 both appear).

## #603 — per-role storage

`SetRoleStorageMountPath(role, path)`, symmetric with the five per-role setters that already existed. A role SET to `""` means **no data PVC for that role** even though the handler-global default is set — distinct from having no entry, and the case this exists for: DolphinScheduler needs the volume on `worker` and must not have it on `master`, so with only a handler-global field the migration had to choose "none", deleting the `worker-data` volumeClaimTemplate Gen 2 already rendered.

On the issue's open question — whether the value should be `[]StorageMount{Name, Path}` for the HDFS datanode case — a single path now forecloses nothing: multiple PVCs also need `config.resources.storage` to stop being a single object, which is a CRD change and the larger half. A later multi-volume feature gets its own API at that point.

Both new maps feed `ConfiguredRoleNames()`, so a typo in either setter still produces the `UnknownConfiguredRole` warning rather than a silently unconfigured role group.

## Verification

Additive and backward compatible — a handler that sets neither renders exactly what it did before. Gates green in both modules (`0 issues.`, all packages `ok`, `Generated files are up to date.`), plus seven mutations confirming the specs have teeth:

| mutation | result |
|---|---|
| config defaults never folded | ✗ |
| defaults fold ON TOP of the CR (wrong precedence) | ✗ |
| per-call `ConfigDefaults` ignored | ✗ |
| a `logging` default silently accepted | ✗ |
| per-role storage map ignored | ✗ |
| an empty per-role path falls back to the global default | ✗ |
| anti-affinity selects a non-framework label | ✗ |

Per #621, no `CHANGELOG.md` entry — the user-visible description is in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)