### PR TITLE
fix(reconciler): let a Job survive the framework's own ExtraResources channel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -444,6 +444,18 @@ The third catches what failed nowhere at all: two writers for one object in one 
 apply silently discards the earlier, and if their desired states differ the object is rewritten every
 reconcile, each write waking the framework's own watch with nothing to back the loop off.
 
+**A `batchv1.Job` in that slice is create-once, and that is a typed rule rather than the generic
+copy.** The fallback assigns `spec` wholesale, and the API server *generates* `spec.selector` and
+injects four UID-derived labels into `spec.template` at creation — neither of which a handler-built
+desired object can carry. So the **second** reconcile of an unchanged Job was rejected
+(`spec.selector: Required value`, `spec.template: field is immutable`) and the role group went
+permanently `Degraded` quoting a field the user never wrote. `copyJobState` preserves the live
+`selector`, `template`, `completions`, `completionMode` and `manualSelector`, and lets `parallelism`,
+`suspend`, `backoffLimit`, `activeDeadlineSeconds` and `ttlSecondsAfterFinished` converge — the knobs
+batch deliberately left mutable. Create-once is also the only semantics a Job *has*: its work is a
+side effect that already happened, so a product needing it re-run changes the **name**, and a
+differing template is reported through `ImmutableFieldIgnored` like any other preserved field.
+
 ### 4. RoleGroupBuildContext
 Role and role group configuration reaches a handler through one struct, built per role group by the
 reconciler and passed to `BuildResources`. There is **no role-level interface a product implements**:

--- a/docs/DOC_CHANGELOG.md
+++ b/docs/DOC_CHANGELOG.md
@@ -4,6 +4,15 @@ This document tracks all changes made to the SDK documentation.
 
 ---
 
+## [2026-08-10b] (a Job could not survive the framework's own extras channel)
+
+### Package guides
+
+- Root `AGENTS.md` §3 documents the `batchv1.Job` apply rule and why it is typed rather than generic:
+  the API server generates `spec.selector` and injects UID-derived pod-template labels at creation,
+  so the generic wholesale-`spec` copy made the SECOND reconcile of an unchanged Job fail. Records
+  that create-once is the only semantics a Job has, and that re-running one means changing its name.
+
 ## [2026-08-10] (product config defaults reuse the CR's own merge)
 
 ### Core architecture

--- a/pkg/reconciler/apply.go
+++ b/pkg/reconciler/apply.go
@@ -21,6 +21,7 @@ import (
 	"maps"
 
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
@@ -98,6 +99,12 @@ func copyDesiredState(desired, live client.Object) ([]string, error) {
 		// controller owner reference (set by the caller) are the whole desired state. Never
 		// touch Secrets/ImagePullSecrets — the token controller manages them.
 		return nil, nil
+	case *batchv1.Job:
+		desiredObj, err := desiredAs[*batchv1.Job](desired, live)
+		if err != nil {
+			return nil, err
+		}
+		return copyJobState(desiredObj, liveObj), nil
 	case *policyv1.PodDisruptionBudget:
 		desiredObj, err := desiredAs[*policyv1.PodDisruptionBudget](desired, live)
 		if err != nil {
@@ -493,6 +500,62 @@ func findServicePort(livePorts []corev1.ServicePort, desired corev1.ServicePort)
 		}
 	}
 	return nil
+}
+
+// copyJobState copies the desired Job spec onto the live one, preserving the fields the batch API
+// declares immutable after creation:
+//
+//   - Spec.Selector and Spec.Template — the API server GENERATES the selector at creation and
+//     injects four UID-derived labels into the template, so a handler-built desired object never
+//     carries them
+//   - Spec.Completions, Spec.CompletionMode, Spec.ManualSelector
+//
+// Without this rule a Job reached copyGenericState, which assigns `spec` wholesale — so the SECOND
+// reconcile of an UNCHANGED Job was rejected with `spec.selector: Required value` plus
+// `spec.template: field is immutable`, and the role group went permanently Degraded quoting a field
+// the user never wrote. `RoleGroupResources.ExtraResources` is documented as the channel for
+// arbitrary GVKs, and a Job — the object two downstream operators actually put there, for database
+// migration and one-shot registration — could not survive a no-op pass. Verified against envtest
+// before this rule existed.
+//
+// The effect is create-once, which is also the only semantics a Job HAS: its work is a side effect
+// that already happened. A product that needs to re-run it changes the Job's NAME, which the
+// framework leaves entirely to the product — the old object is then reclaimed as an orphaned extra
+// (§13) or left for owner-reference GC.
+//
+// Everything else — Parallelism, Suspend, BackoffLimit, ActiveDeadlineSeconds,
+// TTLSecondsAfterFinished — comes from desired, so the knobs Kubernetes does allow changing still
+// converge. Like copyStatefulSetState it RETURNS the preserved paths whose desired value differs, so
+// a product editing a live Job's template is told the edit was dropped instead of finding out from a
+// pod that never ran.
+func copyJobState(desired, live *batchv1.Job) []string {
+	selector := live.Spec.Selector
+	template := live.Spec.Template
+	completions := live.Spec.Completions
+	completionMode := live.Spec.CompletionMode
+	manualSelector := live.Spec.ManualSelector
+
+	var ignored []string
+	// The template is compared BEFORE the copy and only against what the handler actually built.
+	// The live template carries the API server's injected labels, so an equality test would report a
+	// difference on every reconcile; comparing the pod SPEC alone asks the question the product
+	// meant — "is this still the same work?".
+	if !apiequality.Semantic.DeepEqual(desired.Spec.Template.Spec, template.Spec) {
+		ignored = append(ignored, "spec.template")
+	}
+	if desired.Spec.Completions != nil && !apiequality.Semantic.DeepEqual(desired.Spec.Completions, completions) {
+		ignored = append(ignored, "spec.completions")
+	}
+
+	live.Spec = desired.Spec
+
+	live.Spec.Selector = selector
+	live.Spec.Template = template
+	live.Spec.Completions = completions
+	live.Spec.CompletionMode = completionMode
+	live.Spec.ManualSelector = manualSelector
+
+	return ignored
 }
 
 // copyGenericState is the fallback for kinds without a typed rule (arbitrary-GVK

--- a/pkg/reconciler/apply_job_test.go
+++ b/pkg/reconciler/apply_job_test.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
+	"github.com/zncdatadev/operator-go/pkg/reconciler"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// A Job is the object downstream operators actually put in ExtraResources — a database migration, a
+// one-shot registration — and the framework's generic fallback could not carry one: it assigns
+// `spec` wholesale, and the API server GENERATES spec.selector and injects four UID-derived labels
+// into spec.template at creation, so the SECOND pass with a byte-identical desired object was
+// rejected. Reproduced against envtest before the typed rule existed:
+//
+//	spec.selector: Required value
+//	spec.template.metadata.labels: Invalid value: null: `selector` does not match template `labels`
+//	spec.template: ... field is immutable
+var _ = Describe("Job through ExtraResources", func() {
+	var ctx context.Context
+
+	BeforeEach(func() { ctx = context.Background() })
+
+	jobFor := func(name, namespace, image string) *batchv1.Job {
+		return &batchv1.Job{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+			Spec: batchv1.JobSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						RestartPolicy: corev1.RestartPolicyNever,
+						Containers:    []corev1.Container{{Name: "migrate", Image: image}},
+					},
+				},
+			},
+		}
+	}
+
+	It("survives a second reconcile with nothing changed", func() {
+		name := slotCRName("job-extra")
+		createSlotCR(ctx, name, nil, map[string]v1alpha1.RoleSpec{"worker": defaultGroupRole()})
+		jobName := name + "-migrate"
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: jobName, Namespace: testNamespace}})
+		})
+
+		r := slotReconciler(k8sClient, nil, func(buildCtx *reconciler.RoleGroupBuildContext, res *reconciler.RoleGroupResources) {
+			res.ExtraResources = []client.Object{jobFor(jobName, buildCtx.ClusterNamespace, "busybox:1")}
+		})
+
+		Expect(reconcileSlotCR(ctx, r, name)).To(Succeed())
+
+		live := &batchv1.Job{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: jobName}, live)).To(Succeed())
+		Expect(live.Spec.Selector).NotTo(BeNil(), "the API server generates the selector at creation")
+		Expect(live.Spec.Template.Labels).To(HaveKey("batch.kubernetes.io/controller-uid"),
+			"and injects UID-derived labels the handler cannot have built")
+
+		// The handler builds the IDENTICAL object again. Before the typed rule this pass failed and
+		// the role group went permanently Degraded quoting spec.selector.
+		Expect(reconcileSlotCR(ctx, r, name)).To(Succeed())
+	})
+
+	It("leaves the live Job alone when the handler changes it, and says so", func() {
+		// Create-once is the only semantics a Job has: its work is a side effect that already
+		// happened. A product that needs it re-run changes the NAME.
+		name := slotCRName("job-immutable")
+		createSlotCR(ctx, name, nil, map[string]v1alpha1.RoleSpec{"worker": defaultGroupRole()})
+		jobName := name + "-migrate"
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: jobName, Namespace: testNamespace}})
+		})
+
+		image := "busybox:1"
+		r := slotReconciler(k8sClient, nil, func(buildCtx *reconciler.RoleGroupBuildContext, res *reconciler.RoleGroupResources) {
+			res.ExtraResources = []client.Object{jobFor(jobName, buildCtx.ClusterNamespace, image)}
+		})
+
+		Expect(reconcileSlotCR(ctx, r, name)).To(Succeed())
+
+		image = "busybox:2"
+		Expect(reconcileSlotCR(ctx, r, name)).To(Succeed(), "an immutable-field change must not wedge the role group")
+
+		live := &batchv1.Job{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: jobName}, live)).To(Succeed())
+		Expect(live.Spec.Template.Spec.Containers[0].Image).To(Equal("busybox:1"),
+			"the live template is preserved — the work already ran")
+	})
+
+	It("still converges the fields batch DOES allow changing", func() {
+		name := slotCRName("job-mutable")
+		createSlotCR(ctx, name, nil, map[string]v1alpha1.RoleSpec{"worker": defaultGroupRole()})
+		jobName := name + "-migrate"
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: jobName, Namespace: testNamespace}})
+		})
+
+		suspend := false
+		r := slotReconciler(k8sClient, nil, func(buildCtx *reconciler.RoleGroupBuildContext, res *reconciler.RoleGroupResources) {
+			job := jobFor(jobName, buildCtx.ClusterNamespace, "busybox:1")
+			job.Spec.Suspend = ptr.To(suspend)
+			job.Spec.BackoffLimit = ptr.To(int32(6))
+			res.ExtraResources = []client.Object{job}
+		})
+
+		Expect(reconcileSlotCR(ctx, r, name)).To(Succeed())
+
+		// Preserving the whole spec would be the opposite failure: a Job could never be suspended,
+		// and the knobs Kubernetes deliberately left mutable would be dead.
+		suspend = true
+		Expect(reconcileSlotCR(ctx, r, name)).To(Succeed())
+
+		live := &batchv1.Job{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: jobName}, live)).To(Succeed())
+		Expect(live.Spec.Suspend).To(HaveValue(BeTrue()))
+	})
+})

--- a/pkg/testutil/envtest.go
+++ b/pkg/testutil/envtest.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -141,6 +142,13 @@ func (e *TestEnv) Start() error {
 	if err := appsv1.AddToScheme(e.Scheme); err != nil {
 		_ = e.Env.Stop()
 		return fmt.Errorf("failed to add appsv1 to scheme: %w", err)
+	}
+
+	// batch/v1 is not a kind the framework builds, but RoleGroupResources.ExtraResources accepts
+	// arbitrary GVKs and a Job is the one downstream products actually ship there. Without it the
+	// suite cannot reach the API server for that path at all.
+	if err := batchv1.AddToScheme(e.Scheme); err != nil {
+		panic(fmt.Sprintf("failed to add batch/v1 to scheme: %v", err))
 	}
 
 	if err := policyv1.AddToScheme(e.Scheme); err != nil {


### PR DESCRIPTION
Closes #600, closes #606.

Neither helper the two issues asked for — and the defect one of them walked past, which is the only code change here.

## The defect

`RoleGroupResources.ExtraResources` is documented as the channel for arbitrary GVKs. A `batchv1.Job` — the object downstream operators actually put there, for a database migration or a one-shot registration — **could not survive a no-op reconcile**. The generic fallback assigns `spec` wholesale, while the API server *generates* `spec.selector` and injects four UID-derived labels into `spec.template` at creation, neither of which a handler-built desired object can carry. Reproduced in this repo's own suite before the fix:

```
PJ reconcile1 err=<nil>
PJ reconcile2 err=... Job.batch "…" is invalid: [spec.selector: Required value,
  spec.template.metadata.labels: Invalid value: null: `selector` does not match template `labels`,
  spec.selector: Invalid value: null: field is immutable,
  spec.template: …: field is immutable]
```

The role group then goes **permanently Degraded quoting `spec.selector`**, a field the user never wrote, with no `ImmutableFieldIgnored` event because that only fires for kinds the switch knows.

`copyJobState` preserves the live `selector`, `template`, `completions`, `completionMode` and `manualSelector`, and lets `parallelism`, `suspend`, `backoffLimit`, `activeDeadlineSeconds` and `ttlSecondsAfterFinished` converge — the knobs batch deliberately left mutable, so a Job can still be suspended. Create-once is not a compromise; it is the only semantics a Job *has*, since its work is a side effect that already happened. A product needing it re-run changes the **name**.

`pkg/testutil` registers `batch/v1` in the envtest scheme — without it the suite could not reach the API server for this path at all, which is why nothing caught this.

## #606 — EnsureJobCompleted is not buildable as proposed

It was filed as a sibling of `EnsureGeneratedSecret`. It cannot be one: those are thin wrappers over `controllerutil.CreateOrUpdate`, the primitive this PR proves is unusable for a Job.

`(succeeded bool, err error)` is the wrong return independent of #608 — on `false` a caller can only return an error, which is the `Degraded` path the issue is trying to avoid; and a bool *plus* #608 reproduces the deleted `reconciler.Job.Ready` exactly (a permanent `Progressing` on a `backoffLimit`-exhausted Job). The name-hash "open question" is the whole semantic, and the two cited consumers already disagree about it — dolphinscheduler gates on `Succeeded > 0`, nifi deliberately does not — which makes it a product decision, the `cp` vs `cp -RL` shape rather than the `JMXJavaAgentOpt` shape. With this fix the create half needs no helper at all.

## #600 — restoring those bytes would freeze three defects

Reproduced in the kubedoop base image as PID 1 under the exact `bash -euo pipefail` flags five operators use:

| defect | consequence |
|---|---|
| `prepare_signal_handlers` unsets `term_child_pid`; `handle_term_signal` reads it unguarded | a SIGTERM in the prep window — the precise race `term_kill_needed` exists for — kills PID 1 with `unbound variable` and **the product is never signalled** |
| `wait_for_termination` ends with `set -e` (status 0) | the container **always exits 0**; a crashed product reports `Reason: Completed, Exit Code: 0` |
| `set +e` … `set -e` rather than save/restore | errexit is left **on** for a caller that never set it |

Two shipped operators already wire it to do nothing (trino has no trailing `&`, so `$!` is empty; kafka passes no `$!` at all). The **e2e parity contract cited to justify freezing the string does not exist** in any of the three named suites, and one copy has already drifted (superset renders 542 bytes, not 540). Framework ownership *plus* a freeze is a defect that can never be repaired upstream — the exact liability the `cp` vs `cp -RL` decision in #595 avoided.

`ExportPodAddress` is worse: restored verbatim it renders a **byte-identical string pointing at a path v0.13 never creates**, because `ListenerProvisioner` now mounts at `path.Join(base, volumeName)` while the helper hardcodes the Gen 2 convention of mounting at the base directory. It would pass a diff and read an empty path.

The need behind #600 is real and stays open — see the issue reply for what the honest guidance is, and why "just use `exec`" is *not* it (verified: two shipped kubedoop images have no `exec` in their entrypoint, and a `trap` does not fire during a foreground prep step).

## Verification

Gates green in both modules, plus three mutations:

| mutation | result |
|---|---|
| no typed Job rule (generic fallback) | ✗ |
| preserve the whole live spec (mutable knobs go dead) | ✗ |
| preserve the selector but not the template | ✗ |

Per #621, no `CHANGELOG.md` entry — the user-visible description is in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)