### PR TITLE
feat(common): let a hook say "not ready yet" without the cluster reporting a fault

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -571,6 +571,12 @@ Four things about it are load-bearing:
   a message that counts ("3/5 brokers registered") rewrites the CR every pass with nothing to back
   the ping-pong off. Put the varying detail in a log line.
 
+**A CLUSTER-level wait blocks the roles**, which is the point of #608's case — a schema migration
+that must finish before any workload starts. The pass still continues to cleanup, health and
+PostReconcile, so blocking the workloads does not also freeze the cluster's own observations. A
+ROLE-level wait does not block: it is raised mid-iteration, so the roles before it have already been
+reconciled and skipping the rest would make the outcome depend on map ordering.
+
 A waiting extension also no longer aborts its lower-priority siblings (the default
 `stopOnError: true` treated it as a precondition failure) and is logged at Info rather than Error —
 `#608`'s complaint is that a normal first install pages, and an ERROR line every pass is the other

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -533,6 +533,56 @@ Three levels of extensions for injecting custom logic, all generic over the prod
 
 There is no `Cleanup()` hook and no shutdown callback.
 
+**A hook can say "not ready YET" without the cluster going Degraded.** Returning
+`common.NewRequeueAfterError(after, reason, message)` reports that the desired state is not
+satisfiable yet — a database migration Job, a peer cluster's discovery ConfigMap, a secret an
+external controller has not issued. The framework requeues after the delay with **no `Degraded`, no
+Warning event and no workqueue backoff**, and raises its own **`Waiting`** condition
+(`reconciler.ConditionWaiting`) carrying the reason and message, while `ReconcileComplete` goes
+False with reason `Waiting`.
+
+```go
+func (e *DBInit) PreReconcile(ctx context.Context, c client.Client, cr *v1alpha1.MyCluster) error {
+    if !done { return common.NewRequeueAfterError(15*time.Second, "WaitingForDBInit", "migration Job has not completed") }
+    return nil
+}
+```
+
+Four things about it are load-bearing:
+
+- **The wait is reported at the END of the pass, not by returning where it was raised.** Cleanup,
+  health and PostReconcile all still run. `SetDegraded(false, …)` has exactly one writer —
+  `HealthManager.Check` — so an early return would leave `Degraded` **latched** at whatever the last
+  completed pass wrote: a cluster whose pods recovered while an extension waits would keep paging
+  with a message naming a pod that no longer exists, and `observedGeneration` would match, so no
+  staleness heuristic catches it. The framework already diagnosed exactly this on the
+  `reconciliationPaused` gate and fixed it the same way — observe, then return.
+- **A wait is not merged with a failure.** `common.WaitingErrors` walks the error tree and reports a
+  wait only when **every leaf** is one, taking the **shortest** delay. The framework joins per-role
+  and per-extension errors, so a tree can hold a wait next to a genuine failure — and a plain
+  `errors.As` would find the wait and launder the failure into one, or return the first delay
+  depth-first and let a ten-minute wait hide a five-second one.
+- **The delay is clamped.** controller-runtime treats `RequeueAfter` as a switch, so a non-positive
+  value never requeues at all; `deadline.Sub(time.Now())` would wedge the cluster permanently the
+  moment the deadline passed. A non-positive value becomes `common.DefaultRequeueAfter`, anything
+  under `common.MinRequeueAfter` becomes that.
+- **`Reason` and `Message` must be STABLE while the wait lasts.** The status write is guarded by a
+  whole-object `DeepEqual`, and this path returns no error so the workqueue `Forget`s the item —
+  a message that counts ("3/5 brokers registered") rewrites the CR every pass with nothing to back
+  the ping-pong off. Put the varying detail in a log line.
+
+A waiting extension also no longer aborts its lower-priority siblings (the default
+`stopOnError: true` treated it as a precondition failure) and is logged at Info rather than Error —
+`#608`'s complaint is that a normal first install pages, and an ERROR line every pass is the other
+channel that pages.
+
+**Relatedly, a role group the framework has not created yet is `Creating`, not `Degraded`.** Health
+tells "never applied" from "applied, then vanished" using `status.roleGroups`, the ledger of role
+groups a pass successfully applied. Before that, a first install reported `Degraded=True` with
+`WorkloadUnreadable` for every role group whose StatefulSet did not exist yet — for any reason,
+including a build still waiting on something external. A group **in** the ledger whose StatefulSet
+has gone is still a fault, which is the guarantee that had to survive.
+
 Hooks receive the **concrete product CR**, so an extension reads its own spec and writes its own
 status with no type assertion:
 ```go

--- a/docs/DOC_CHANGELOG.md
+++ b/docs/DOC_CHANGELOG.md
@@ -4,6 +4,20 @@ This document tracks all changes made to the SDK documentation.
 
 ---
 
+## [2026-08-10c] (a hook can wait without the cluster reporting a fault)
+
+### Package guides
+
+- Root `AGENTS.md` §5 documents `common.RequeueAfterError`, `common.WaitingErrors`, the `Waiting`
+  condition, and the four properties that are load-bearing: the wait is reported at the END of the
+  pass so health still runs (otherwise `Degraded` latches, since `SetDegraded(false, …)` has exactly
+  one writer), an aggregate is a wait only when every leaf is, the delay is clamped (a non-positive
+  `RequeueAfter` never requeues at all), and Reason/Message must be stable or the status write
+  ping-pongs with nothing to back it off.
+- Records the health change that goes with it: a role group absent from `status.roleGroups` has no
+  StatefulSet because the framework has not applied one yet — `Creating`, not `Degraded`. A group in
+  the ledger whose StatefulSet vanished is still a fault.
+
 ## [2026-08-10b] (a Job could not survive the framework's own extras channel)
 
 ### Package guides

--- a/pkg/common/errors.go
+++ b/pkg/common/errors.go
@@ -17,7 +17,9 @@ limitations under the License.
 package common
 
 import (
+	"errors"
 	"fmt"
+	"time"
 )
 
 // ConfigValidationError creates an error for configuration validation failures.
@@ -43,4 +45,115 @@ func ConfigMergeError(context string, err error) error {
 // ConfigParseError creates an error for configuration parsing failures.
 func ConfigParseError(format string, err error) error {
 	return fmt.Errorf("failed to parse %s configuration: %w", format, err)
+}
+
+// MinRequeueAfter and DefaultRequeueAfter bound the delay a RequeueAfterError can ask for.
+//
+// Both exist because controller-runtime treats the delay as a switch, not a hint: its
+// `case result.RequeueAfter > 0` falls through to a default branch that only Forgets the item, so a
+// NON-POSITIVE delay does not requeue at all. A product computing `deadline.Sub(time.Now())` therefore
+// wedges the cluster permanently the moment the deadline passes — the wait is reported, no error is
+// returned, and nothing ever wakes the controller again.
+const (
+	MinRequeueAfter     = 1 * time.Second
+	DefaultRequeueAfter = 10 * time.Second
+)
+
+// RequeueAfterError reports that the desired state is not satisfiable YET — an external condition
+// the operator does not control has not happened. It is not a failure: the framework requeues
+// without setting Degraded and without emitting a Warning event.
+//
+// It is an ERROR TYPE rather than a change to the hook signatures because the same "not yet" arises
+// in places that are not hooks — sidecar validation, ProductConfig's live lookups, a handler's
+// BuildResources — and an error is the only channel all of them already have. RateLimitError is the
+// same shape for the same reason.
+//
+// Reason and Message must be STABLE across passes while the wait lasts. The framework's status
+// write is guarded by a whole-object DeepEqual, so a message that counts ("3/5 brokers registered")
+// rewrites the CR every pass; and because this path returns no error the workqueue Forgets the item,
+// so nothing backs that ping-pong off. Put the varying detail in a log line, not in the condition.
+type RequeueAfterError struct {
+	// After is how long to wait before the next reconcile. Clamped: see NewRequeueAfterError.
+	After time.Duration
+	// Reason is a CamelCase condition reason, e.g. "WaitingForDatabase".
+	Reason string
+	// Message is a human-readable explanation surfaced on the Waiting condition.
+	Message string
+}
+
+func (e *RequeueAfterError) Error() string {
+	return fmt.Sprintf("waiting (%s): %s", e.Reason, e.Message)
+}
+
+// NewRequeueAfterError builds a wait, clamping the delay: a non-positive value becomes
+// DefaultRequeueAfter (a zero delay would never requeue at all), and anything under MinRequeueAfter
+// becomes MinRequeueAfter (a nanosecond delay is a hot loop against the API server).
+func NewRequeueAfterError(after time.Duration, reason, message string) *RequeueAfterError {
+	return &RequeueAfterError{After: ClampRequeueAfter(after), Reason: reason, Message: message}
+}
+
+// ClampRequeueAfter applies the bounds above. It is exported and applied again at the framework's
+// own branch, because RequeueAfterError is a struct literal a caller can build without the
+// constructor.
+func ClampRequeueAfter(after time.Duration) time.Duration {
+	switch {
+	case after <= 0:
+		return DefaultRequeueAfter
+	case after < MinRequeueAfter:
+		return MinRequeueAfter
+	default:
+		return after
+	}
+}
+
+// IsRequeueAfterError reports whether err is or wraps a RequeueAfterError.
+func IsRequeueAfterError(err error) bool {
+	var requeueErr *RequeueAfterError
+	return errors.As(err, &requeueErr)
+}
+
+// WaitingErrors walks an error tree and reports whether EVERY leaf is a RequeueAfterError, together
+// with the shortest delay any of them asked for.
+//
+// Both halves matter. The framework aggregates per-role and per-extension failures with
+// errors.Join, so a tree can hold a wait next to a genuine failure — and `errors.As` would find the
+// wait and suppress the failure's report. It also returns the FIRST match depth-first, so a 10-minute
+// wait on one branch would hide a 5-second wait on another and the cluster would sit idle for the
+// difference.
+//
+// A nil error is not a wait. A wrapper whose Unwrap returns nothing is opaque and counts as a
+// failure, because its cause cannot be inspected.
+func WaitingErrors(err error) (allWaiting bool, after time.Duration) {
+	if err == nil {
+		return false, 0
+	}
+	// A direct type assertion, NOT errors.As: As searches the whole tree and would report "waiting"
+	// for a wrapper around a join that also holds a genuine failure, laundering it.
+	if requeueErr, ok := err.(*RequeueAfterError); ok {
+		return true, ClampRequeueAfter(requeueErr.After)
+	}
+	if joined, ok := err.(interface{ Unwrap() []error }); ok {
+		members := joined.Unwrap()
+		if len(members) == 0 {
+			return false, 0
+		}
+		shortest := time.Duration(0)
+		for _, member := range members {
+			waiting, memberAfter := WaitingErrors(member)
+			if !waiting {
+				return false, 0
+			}
+			if shortest == 0 || memberAfter < shortest {
+				shortest = memberAfter
+			}
+		}
+		return true, shortest
+	}
+	if wrapped, ok := err.(interface{ Unwrap() error }); ok {
+		if inner := wrapped.Unwrap(); inner != nil {
+			return WaitingErrors(inner)
+		}
+	}
+	// Opaque: its cause cannot be inspected, so it counts as a failure rather than a wait.
+	return false, 0
 }

--- a/pkg/common/errors.go
+++ b/pkg/common/errors.go
@@ -112,8 +112,8 @@ func IsRequeueAfterError(err error) bool {
 	return errors.As(err, &requeueErr)
 }
 
-// WaitingErrors walks an error tree and reports whether EVERY leaf is a RequeueAfterError, together
-// with the shortest delay any of them asked for.
+// WaitingErrors walks an error tree and reports whether EVERY leaf is a RequeueAfterError,
+// returning the one with the SHORTEST delay.
 //
 // Both halves matter. The framework aggregates per-role and per-extension failures with
 // errors.Join, so a tree can hold a wait next to a genuine failure — and `errors.As` would find the
@@ -121,33 +121,37 @@ func IsRequeueAfterError(err error) bool {
 // wait on one branch would hide a 5-second wait on another and the cluster would sit idle for the
 // difference.
 //
+// Returning the winning error rather than only its duration keeps the reported Reason and Message
+// attached to the delay they belong to: with several waits joined, deriving the reason separately
+// (with errors.As, which matches depth-first) would describe one wait while waiting for another.
+//
 // A nil error is not a wait. A wrapper whose Unwrap returns nothing is opaque and counts as a
 // failure, because its cause cannot be inspected.
-func WaitingErrors(err error) (allWaiting bool, after time.Duration) {
+func WaitingErrors(err error) (*RequeueAfterError, bool) {
 	if err == nil {
-		return false, 0
+		return nil, false
 	}
 	// A direct type assertion, NOT errors.As: As searches the whole tree and would report "waiting"
 	// for a wrapper around a join that also holds a genuine failure, laundering it.
 	if requeueErr, ok := err.(*RequeueAfterError); ok {
-		return true, ClampRequeueAfter(requeueErr.After)
+		return requeueErr, true
 	}
 	if joined, ok := err.(interface{ Unwrap() []error }); ok {
 		members := joined.Unwrap()
 		if len(members) == 0 {
-			return false, 0
+			return nil, false
 		}
-		shortest := time.Duration(0)
+		var shortest *RequeueAfterError
 		for _, member := range members {
-			waiting, memberAfter := WaitingErrors(member)
+			memberErr, waiting := WaitingErrors(member)
 			if !waiting {
-				return false, 0
+				return nil, false
 			}
-			if shortest == 0 || memberAfter < shortest {
-				shortest = memberAfter
+			if shortest == nil || ClampRequeueAfter(memberErr.After) < ClampRequeueAfter(shortest.After) {
+				shortest = memberErr
 			}
 		}
-		return true, shortest
+		return shortest, true
 	}
 	if wrapped, ok := err.(interface{ Unwrap() error }); ok {
 		if inner := wrapped.Unwrap(); inner != nil {
@@ -155,5 +159,5 @@ func WaitingErrors(err error) (allWaiting bool, after time.Duration) {
 		}
 	}
 	// Opaque: its cause cannot be inspected, so it counts as a failure rather than a wait.
-	return false, 0
+	return nil, false
 }

--- a/pkg/common/extension_registry.go
+++ b/pkg/common/extension_registry.go
@@ -202,6 +202,23 @@ func executeHooks[T Extension](ctx context.Context, entries []extensionEntry[T],
 		}
 
 		extensionErr := NewExtensionError(entry.extension.Name(), err)
+
+		// A wait is not a precondition failure. Without this branch the default
+		// hookPolicy{stopOnError: true} let one extension that is merely waiting abort every
+		// lower-priority sibling — so a product following AGENTS.md §11b, which puts
+		// EnsureGeneratedSecret in this very hook, would stop generating a Secret another
+		// extension is waiting for. It is also logged at Info rather than Error: #608's complaint
+		// is that a normal first install pages, and an ERROR line every pass forever is the other
+		// channel that pages.
+		// WaitingErrors, not IsRequeueAfterError: a hook may itself return errors.Join of a wait and
+		// a genuine failure, and errors.As would find the wait and launder the failure into one.
+		if waiting, _ := WaitingErrors(err); waiting {
+			log.FromContext(ctx).Info("Extension is waiting, continuing with remaining extensions",
+				"extension", entry.extension.Name(), "reason", err.Error())
+			errs = append(errs, extensionErr)
+			continue
+		}
+
 		if entry.stopsOnError(policy.stopOnError) {
 			// Failures already collected from tolerant extensions are reported alongside the
 			// stopping one; dropping them would hide from the CR status that those extensions

--- a/pkg/common/extension_registry.go
+++ b/pkg/common/extension_registry.go
@@ -212,7 +212,7 @@ func executeHooks[T Extension](ctx context.Context, entries []extensionEntry[T],
 		// channel that pages.
 		// WaitingErrors, not IsRequeueAfterError: a hook may itself return errors.Join of a wait and
 		// a genuine failure, and errors.As would find the wait and launder the failure into one.
-		if waiting, _ := WaitingErrors(err); waiting {
+		if _, waiting := WaitingErrors(err); waiting {
 			log.FromContext(ctx).Info("Extension is waiting, continuing with remaining extensions",
 				"extension", entry.extension.Name(), "reason", err.Error())
 			errs = append(errs, extensionErr)

--- a/pkg/common/requeue_error_test.go
+++ b/pkg/common/requeue_error_test.go
@@ -52,9 +52,9 @@ var _ = Describe("WaitingErrors", func() {
 	wait := func(d time.Duration) error { return common.NewRequeueAfterError(d, "R", "m") }
 
 	It("reports a lone wait, with its delay", func() {
-		waiting, after := common.WaitingErrors(wait(30 * time.Second))
+		waitErr, waiting := common.WaitingErrors(wait(30 * time.Second))
 		Expect(waiting).To(BeTrue())
-		Expect(after).To(Equal(30 * time.Second))
+		Expect(waitErr.After).To(Equal(30 * time.Second))
 	})
 
 	It("refuses an aggregate that also holds a genuine failure", func() {
@@ -62,17 +62,24 @@ var _ = Describe("WaitingErrors", func() {
 		// hold a wait next to a real failure — and a plain errors.As would find the wait and
 		// suppress the failure's Degraded report entirely.
 		joined := errors.Join(wait(time.Minute), errors.New("unknown field \"nodeAffinty\""))
-		waiting, _ := common.WaitingErrors(joined)
+		_, waiting := common.WaitingErrors(joined)
 		Expect(waiting).To(BeFalse())
 	})
 
 	It("takes the SHORTEST delay across a join, not the first one found", func() {
 		// errors.As returns the first match depth-first, so a ten-minute wait on one branch would
 		// hide a five-second wait on another and the cluster would sit idle for the difference.
-		joined := errors.Join(wait(10*time.Minute), wait(5*time.Second), wait(time.Hour))
-		waiting, after := common.WaitingErrors(joined)
+		joined := errors.Join(
+			common.NewRequeueAfterError(10*time.Minute, "Slow", "slow"),
+			common.NewRequeueAfterError(5*time.Second, "Fast", "fast"),
+			common.NewRequeueAfterError(time.Hour, "Slowest", "slowest"),
+		)
+		waitErr, waiting := common.WaitingErrors(joined)
 		Expect(waiting).To(BeTrue())
-		Expect(after).To(Equal(5 * time.Second))
+		Expect(waitErr.After).To(Equal(5 * time.Second))
+		// The reason must belong to the SAME wait as the delay: reporting "Slow" while waiting five
+		// seconds describes a wait that is not the one about to resolve.
+		Expect(waitErr.Reason).To(Equal("Fast"))
 	})
 
 	It("walks nested joins and wrapping chains", func() {
@@ -80,18 +87,18 @@ var _ = Describe("WaitingErrors", func() {
 			fmt.Errorf("role a: %w", wait(time.Minute)),
 			errors.Join(wait(20*time.Second), wait(time.Hour)),
 		)
-		waiting, after := common.WaitingErrors(nested)
+		waitErr, waiting := common.WaitingErrors(nested)
 		Expect(waiting).To(BeTrue())
-		Expect(after).To(Equal(20 * time.Second))
+		Expect(waitErr.After).To(Equal(20 * time.Second))
 	})
 
 	It("treats nil and an opaque wrapper as not waiting", func() {
-		waiting, _ := common.WaitingErrors(nil)
+		_, waiting := common.WaitingErrors(nil)
 		Expect(waiting).To(BeFalse())
 
 		// A wrapper whose cause cannot be inspected must count as a failure: assuming it is a wait
 		// would suppress Degraded for an error nobody can see inside.
-		waiting, _ = common.WaitingErrors(errors.New("opaque"))
+		_, waiting = common.WaitingErrors(errors.New("opaque"))
 		Expect(waiting).To(BeFalse())
 	})
 })

--- a/pkg/common/requeue_error_test.go
+++ b/pkg/common/requeue_error_test.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common_test
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/zncdatadev/operator-go/pkg/common"
+)
+
+var _ = Describe("RequeueAfterError", func() {
+	It("clamps a non-positive delay, which would otherwise never requeue at all", func() {
+		// controller-runtime treats RequeueAfter as a switch: `case result.RequeueAfter > 0` falls
+		// through to a branch that only Forgets the item. A product computing
+		// deadline.Sub(time.Now()) therefore wedges the cluster the moment the deadline passes —
+		// the wait is reported, no error is returned, and nothing wakes the controller again.
+		Expect(common.NewRequeueAfterError(0, "R", "m").After).To(Equal(common.DefaultRequeueAfter))
+		Expect(common.NewRequeueAfterError(-time.Hour, "R", "m").After).To(Equal(common.DefaultRequeueAfter))
+	})
+
+	It("clamps a sub-second delay away from a hot loop", func() {
+		Expect(common.NewRequeueAfterError(time.Nanosecond, "R", "m").After).To(Equal(common.MinRequeueAfter))
+		Expect(common.NewRequeueAfterError(30*time.Second, "R", "m").After).To(Equal(30 * time.Second))
+	})
+
+	It("is found through a wrapping chain", func() {
+		wrapped := fmt.Errorf("outer: %w", common.NewRequeueAfterError(time.Minute, "R", "m"))
+		Expect(common.IsRequeueAfterError(wrapped)).To(BeTrue())
+		Expect(common.IsRequeueAfterError(errors.New("plain"))).To(BeFalse())
+	})
+})
+
+var _ = Describe("WaitingErrors", func() {
+	wait := func(d time.Duration) error { return common.NewRequeueAfterError(d, "R", "m") }
+
+	It("reports a lone wait, with its delay", func() {
+		waiting, after := common.WaitingErrors(wait(30 * time.Second))
+		Expect(waiting).To(BeTrue())
+		Expect(after).To(Equal(30 * time.Second))
+	})
+
+	It("refuses an aggregate that also holds a genuine failure", func() {
+		// The decisive rule. The framework joins per-role and per-extension errors, so a tree can
+		// hold a wait next to a real failure — and a plain errors.As would find the wait and
+		// suppress the failure's Degraded report entirely.
+		joined := errors.Join(wait(time.Minute), errors.New("unknown field \"nodeAffinty\""))
+		waiting, _ := common.WaitingErrors(joined)
+		Expect(waiting).To(BeFalse())
+	})
+
+	It("takes the SHORTEST delay across a join, not the first one found", func() {
+		// errors.As returns the first match depth-first, so a ten-minute wait on one branch would
+		// hide a five-second wait on another and the cluster would sit idle for the difference.
+		joined := errors.Join(wait(10*time.Minute), wait(5*time.Second), wait(time.Hour))
+		waiting, after := common.WaitingErrors(joined)
+		Expect(waiting).To(BeTrue())
+		Expect(after).To(Equal(5 * time.Second))
+	})
+
+	It("walks nested joins and wrapping chains", func() {
+		nested := errors.Join(
+			fmt.Errorf("role a: %w", wait(time.Minute)),
+			errors.Join(wait(20*time.Second), wait(time.Hour)),
+		)
+		waiting, after := common.WaitingErrors(nested)
+		Expect(waiting).To(BeTrue())
+		Expect(after).To(Equal(20 * time.Second))
+	})
+
+	It("treats nil and an opaque wrapper as not waiting", func() {
+		waiting, _ := common.WaitingErrors(nil)
+		Expect(waiting).To(BeFalse())
+
+		// A wrapper whose cause cannot be inspected must count as a failure: assuming it is a wait
+		// would suppress Degraded for an error nobody can see inside.
+		waiting, _ = common.WaitingErrors(errors.New("opaque"))
+		Expect(waiting).To(BeFalse())
+	})
+})

--- a/pkg/reconciler/errors.go
+++ b/pkg/reconciler/errors.go
@@ -285,19 +285,19 @@ type waitState struct {
 	Message string
 }
 
-// newWaitState renders a wait from the error that carried it. The reason and message come from the
-// FIRST RequeueAfterError found, which is the one whose delay the tree walk already reported.
-func newWaitState(after time.Duration, err error) *waitState {
-	state := &waitState{After: common.ClampRequeueAfter(after), Reason: ReasonWaiting}
-	var requeueErr *common.RequeueAfterError
-	if stderrors.As(err, &requeueErr) {
-		if requeueErr.Reason != "" {
-			state.Reason = requeueErr.Reason
-		}
-		state.Message = requeueErr.Message
+// newWaitState renders the condition from the wait that WaitingErrors selected — the one with the
+// shortest delay. Reason and Message therefore always describe the wait whose deadline is next,
+// rather than whichever one a depth-first search happened to reach first.
+func newWaitState(waitErr *common.RequeueAfterError) *waitState {
+	if waitErr == nil {
+		return nil
+	}
+	state := &waitState{After: common.ClampRequeueAfter(waitErr.After), Reason: waitErr.Reason, Message: waitErr.Message}
+	if state.Reason == "" {
+		state.Reason = ReasonWaiting
 	}
 	if state.Message == "" {
-		state.Message = err.Error()
+		state.Message = waitErr.Error()
 	}
 	return state
 }

--- a/pkg/reconciler/errors.go
+++ b/pkg/reconciler/errors.go
@@ -20,6 +20,9 @@ import (
 	stderrors "errors"
 	"fmt"
 	"time"
+
+	"github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
+	"github.com/zncdatadev/operator-go/pkg/common"
 )
 
 // ConfigError represents a configuration-related error.
@@ -251,4 +254,66 @@ func NewRateLimitError(retryAfter time.Duration, cause error) *RateLimitError {
 func IsRateLimitError(err error) bool {
 	var rateLimitErr *RateLimitError
 	return stderrors.As(err, &rateLimitErr)
+}
+
+// ConditionWaiting reports that the framework is waiting on something outside its control before
+// the desired state can be reached — a database migration Job, a peer cluster's discovery
+// ConfigMap, a secret an external controller has not issued yet.
+//
+// It is a condition of its own rather than an overload of Progressing for two reasons. Progressing
+// has exactly one owner, HealthManager.Check, which writes it on every non-paused pass; a second
+// writer in the same pass flips it and re-stamps LastTransitionTime, so the CR would be rewritten
+// forever. And a wait that spans reconciles needs its OWN LastTransitionTime to be alertable at all
+// — "waiting for more than 30 minutes" is the alert an operator actually wants, and it cannot be
+// expressed on a field another writer resets. ConditionOrphanCleanupPending exists for the same
+// reason and follows the same "only clear what this framework raised" rule.
+const ConditionWaiting v1alpha1.ConditionType = "Waiting"
+
+const (
+	// ReasonWaiting is the ReconcileComplete=False reason while something is waiting.
+	ReasonWaiting = "Waiting"
+	// ReasonWaitSatisfied means nothing is waiting any more.
+	ReasonWaitSatisfied = "WaitSatisfied"
+)
+
+// waitState is the wait a pass has accumulated. Several sites can raise one — the cluster
+// PreReconcile hook, dependency validation, the role aggregate — and the pass reports a single
+// condition, so they are merged rather than the last one winning.
+type waitState struct {
+	After   time.Duration
+	Reason  string
+	Message string
+}
+
+// newWaitState renders a wait from the error that carried it. The reason and message come from the
+// FIRST RequeueAfterError found, which is the one whose delay the tree walk already reported.
+func newWaitState(after time.Duration, err error) *waitState {
+	state := &waitState{After: common.ClampRequeueAfter(after), Reason: ReasonWaiting}
+	var requeueErr *common.RequeueAfterError
+	if stderrors.As(err, &requeueErr) {
+		if requeueErr.Reason != "" {
+			state.Reason = requeueErr.Reason
+		}
+		state.Message = requeueErr.Message
+	}
+	if state.Message == "" {
+		state.Message = err.Error()
+	}
+	return state
+}
+
+// mergeWait keeps the SHORTEST delay of the waits a pass raised, so a ten-minute wait at one site
+// cannot make the cluster sit idle through a five-second wait at another. The reason and message of
+// the earliest-deadline wait are the ones reported, since that is the one that will resolve first.
+func mergeWait(existing, next *waitState) *waitState {
+	switch {
+	case existing == nil:
+		return next
+	case next == nil:
+		return existing
+	case next.After < existing.After:
+		return next
+	default:
+		return existing
+	}
 }

--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -43,6 +43,7 @@ import (
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -567,14 +568,26 @@ func (r *GenericReconciler[CR]) reconcile(ctx context.Context, cr CR, stored cli
 		return ctrl.Result{}, NewReconcileError("WorkloadRBAC", "failed to ensure workload RBAC", err)
 	}
 
-	// 1. Execute PreReconcile extensions
+	// 1. Execute PreReconcile extensions.
+	//
+	// A wait does NOT return here. The pass continues so cleanup and health still run, which is what
+	// keeps Degraded and Available current; the wait itself is reported at step 8.
+	var waitFor *waitState
 	if err := r.extensionRegistry.ExecuteClusterPreReconcile(ctx, r.client, cr); err != nil {
-		return ctrl.Result{}, NewReconcileError("PreReconcile", "extension hook failed", err)
+		waiting, after := common.WaitingErrors(err)
+		if !waiting {
+			return ctrl.Result{}, NewReconcileError("PreReconcile", "extension hook failed", err)
+		}
+		waitFor = mergeWait(waitFor, newWaitState(after, err))
 	}
 
 	// 2. Validate dependencies declared by the product (no-op when the hook is unset)
 	if err := r.validateDependencies(ctx, cr); err != nil {
-		return ctrl.Result{}, NewReconcileError("DependencyValidation", "dependency validation failed", err)
+		waiting, after := common.WaitingErrors(err)
+		if !waiting {
+			return ctrl.Result{}, NewReconcileError("DependencyValidation", "dependency validation failed", err)
+		}
+		waitFor = mergeWait(waitFor, newWaitState(after, err))
 	}
 
 	// 3. Process each role, BEST EFFORT: a role that fails does not stop the others, and does not
@@ -640,11 +653,50 @@ func (r *GenericReconciler[CR]) reconcile(ctx context.Context, cr CR, stored cli
 	// caller sets Degraded and writes the status once, and the workqueue backs off. The status
 	// write is left to that path so a failing cycle does not write twice.
 	if len(roleErrs) > 0 {
-		return ctrl.Result{}, stderrors.Join(roleErrs...)
+		joined := stderrors.Join(roleErrs...)
+		// A genuine failure anywhere outranks a wait: Degraded has to be set and the workqueue has
+		// to back off, and the joined message carries the waiting role's own text alongside the
+		// failure so nothing is hidden. Only an aggregate that is waits ALL THE WAY DOWN is a wait.
+		waiting, after := common.WaitingErrors(joined)
+		if !waiting {
+			return ctrl.Result{}, joined
+		}
+		waitFor = mergeWait(waitFor, newWaitState(after, joined))
 	}
 
-	// 8. Final status update
-	status.SetReconcileComplete(true, v1alpha1.ReasonReconcileComplete, "Reconciliation completed successfully")
+	// 8. Final status update.
+	//
+	// A wait is reported HERE, after cleanup, health and PostReconcile have all run, rather than by
+	// returning early where it was raised. That position is the whole design: SetDegraded(false) has
+	// exactly one writer, HealthManager.Check, so an early return leaves Degraded LATCHED at whatever
+	// the last completed pass wrote — a cluster whose pods recovered while an extension waits would
+	// keep paging with a message naming a pod that no longer exists, and observedGeneration would
+	// match, so no staleness heuristic catches it. The framework already diagnosed exactly this on
+	// the reconciliationPaused gate and fixed it the same way: observe, then return.
+	if waitFor != nil {
+		status.SetCondition(metav1.Condition{
+			Type:    string(ConditionWaiting),
+			Status:  metav1.ConditionTrue,
+			Reason:  waitFor.Reason,
+			Message: waitFor.Message,
+		})
+		// ReconcileComplete is falsified because it is the documented generation gate: leaving it
+		// True next to the bumped observedGeneration reports a user's edit as applied while the
+		// framework is still waiting to apply it.
+		status.SetReconcileComplete(false, ReasonWaiting, waitFor.Message)
+	} else {
+		// Cleared only when this framework raised it, so a product that never waits gets no noise —
+		// the rule ConditionOrphanCleanupPending already follows.
+		if status.GetCondition(ConditionWaiting) != nil {
+			status.SetCondition(metav1.Condition{
+				Type:    string(ConditionWaiting),
+				Status:  metav1.ConditionFalse,
+				Reason:  ReasonWaitSatisfied,
+				Message: "Nothing is waiting",
+			})
+		}
+		status.SetReconcileComplete(true, v1alpha1.ReasonReconcileComplete, "Reconciliation completed successfully")
+	}
 
 	if err := r.updateStatus(ctx, cr, stored); err != nil {
 		return ctrl.Result{}, err
@@ -655,6 +707,11 @@ func (r *GenericReconciler[CR]) reconcile(ctx context.Context, cr CR, stored cli
 	// gray-delete grace period running out — needs a timed requeue. Both sources collapse into
 	// a single RequeueAfter (the earliest one); zero means "no periodic wakeup".
 	requeueAfter := earliestRequeue(r.healthCheckInterval, cleanupRequeue)
+	if waitFor != nil {
+		requeueAfter = earliestRequeue(requeueAfter, waitFor.After)
+		logger.Info("Reconciliation is waiting", "reason", waitFor.Reason, "requeueAfter", waitFor.After)
+		return ctrl.Result{RequeueAfter: requeueAfter}, nil
+	}
 
 	logger.Info("Reconciliation completed successfully")
 	return ctrl.Result{RequeueAfter: requeueAfter}, nil

--- a/pkg/reconciler/generic_reconciler.go
+++ b/pkg/reconciler/generic_reconciler.go
@@ -574,20 +574,20 @@ func (r *GenericReconciler[CR]) reconcile(ctx context.Context, cr CR, stored cli
 	// keeps Degraded and Available current; the wait itself is reported at step 8.
 	var waitFor *waitState
 	if err := r.extensionRegistry.ExecuteClusterPreReconcile(ctx, r.client, cr); err != nil {
-		waiting, after := common.WaitingErrors(err)
+		waitErr, waiting := common.WaitingErrors(err)
 		if !waiting {
 			return ctrl.Result{}, NewReconcileError("PreReconcile", "extension hook failed", err)
 		}
-		waitFor = mergeWait(waitFor, newWaitState(after, err))
+		waitFor = mergeWait(waitFor, newWaitState(waitErr))
 	}
 
 	// 2. Validate dependencies declared by the product (no-op when the hook is unset)
 	if err := r.validateDependencies(ctx, cr); err != nil {
-		waiting, after := common.WaitingErrors(err)
+		waitErr, waiting := common.WaitingErrors(err)
 		if !waiting {
 			return ctrl.Result{}, NewReconcileError("DependencyValidation", "dependency validation failed", err)
 		}
-		waitFor = mergeWait(waitFor, newWaitState(after, err))
+		waitFor = mergeWait(waitFor, newWaitState(waitErr))
 	}
 
 	// 3. Process each role, BEST EFFORT: a role that fails does not stop the others, and does not
@@ -609,7 +609,18 @@ func (r *GenericReconciler[CR]) reconcile(ctx context.Context, cr CR, stored cli
 	// updateStatus and make the controller reschedule itself forever.
 	r.warnOnUnknownConfiguredRoles(ctx, cr, spec)
 	var roleErrs []error
+	// A CLUSTER-level wait blocks the roles. That is the whole point of #608's case — a schema
+	// migration Job that must finish before any workload starts — and applying the StatefulSets
+	// anyway would start the product against a database that is not initialised. The pass still
+	// continues below: cleanup, health and PostReconcile run, so the wait does not freeze the
+	// cluster's own observations the way an early return would.
+	//
+	// A ROLE-level wait does not do this. It is raised while iterating, so the roles before it have
+	// already been reconciled, and skipping the rest would make the outcome depend on map ordering.
 	for _, roleName := range slices.Sorted(maps.Keys(spec.Roles)) {
+		if waitFor != nil {
+			break
+		}
 		roleSpec := spec.Roles[roleName]
 		if err := r.reconcileRole(ctx, cr, roleName, &roleSpec); err != nil {
 			// Throttling is the one failure that must stop the pass: the API server is rejecting
@@ -657,11 +668,11 @@ func (r *GenericReconciler[CR]) reconcile(ctx context.Context, cr CR, stored cli
 		// A genuine failure anywhere outranks a wait: Degraded has to be set and the workqueue has
 		// to back off, and the joined message carries the waiting role's own text alongside the
 		// failure so nothing is hidden. Only an aggregate that is waits ALL THE WAY DOWN is a wait.
-		waiting, after := common.WaitingErrors(joined)
+		waitErr, waiting := common.WaitingErrors(joined)
 		if !waiting {
 			return ctrl.Result{}, joined
 		}
-		waitFor = mergeWait(waitFor, newWaitState(after, joined))
+		waitFor = mergeWait(waitFor, newWaitState(waitErr))
 	}
 
 	// 8. Final status update.

--- a/pkg/reconciler/health.go
+++ b/pkg/reconciler/health.go
@@ -102,7 +102,7 @@ func (h *HealthManager) Check(ctx context.Context, namespace, clusterName string
 	// StatefulSet to read at all.
 	progressing := false
 	evaluated := 0
-	var shortOfReplicas, unreadable []string
+	var shortOfReplicas, unreadable, creating []string
 
 	for roleName, roleSpec := range spec.Roles {
 		for groupName, groupSpec := range roleSpec.RoleGroups {
@@ -110,8 +110,19 @@ func (h *HealthManager) Check(ctx context.Context, namespace, clusterName string
 			resourceName := RoleGroupResourceName(clusterName, roleName, groupName)
 			available, isProgressing, err := h.checkRoleGroupHealth(ctx, namespace, resourceName, groupSpec.GetReplicas())
 			if err != nil {
-				// A role group whose StatefulSet cannot even be read is both not available and a
-				// genuine fault: the object the operator applied is gone or unreachable.
+				// "Never applied yet" and "applied, then vanished" are different facts, and the
+				// status already distinguishes them: status.roleGroups is the ledger of role groups
+				// this framework successfully applied. A role group absent from the ledger has no
+				// StatefulSet because the framework has not got that far — a first install, a build
+				// still waiting on something external — which is Creating, not a fault. Reporting it
+				// as Degraded is what made a normal first install page.
+				if !inLedger(status, roleName, groupName) {
+					logger.V(1).Info("Role group has no StatefulSet yet", "role", roleName, "group", groupName)
+					creating = append(creating, roleName+"/"+groupName)
+					continue
+				}
+				// Applied before and unreadable now: the object the operator applied is gone or
+				// unreachable, which is a genuine fault.
 				logger.Error(err, "Failed to check role group health", "role", roleName, "group", groupName)
 				unreadable = append(unreadable, roleName+"/"+groupName)
 				continue
@@ -128,13 +139,14 @@ func (h *HealthManager) Check(ctx context.Context, namespace, clusterName string
 
 	sort.Strings(shortOfReplicas)
 	sort.Strings(unreadable)
+	sort.Strings(creating)
 
 	switch {
 	case evaluated == 0:
 		// No role group was evaluated, so nothing runs. Reporting "all replicas are available"
 		// for a cluster with zero workloads would make Available useless as a readiness gate.
 		status.SetUnavailable(v1alpha1.ReasonCreating, "Cluster declares no role groups")
-	case len(shortOfReplicas) == 0 && len(unreadable) == 0:
+	case len(shortOfReplicas) == 0 && len(unreadable) == 0 && len(creating) == 0:
 		status.SetAvailable(v1alpha1.ReasonAvailable, "All replicas are available")
 	default:
 		// Name the offenders, and say which kind of problem each one is: with several roles the
@@ -147,10 +159,13 @@ func (h *HealthManager) Check(ctx context.Context, namespace, clusterName string
 		if len(unreadable) > 0 {
 			parts = append(parts, "StatefulSet could not be read: "+strings.Join(unreadable, ", "))
 		}
-		reason := v1alpha1.ReasonPodsNotReady
-		if len(shortOfReplicas) == 0 {
-			reason = v1alpha1.ReasonWorkloadUnreadable
+		if len(creating) > 0 {
+			parts = append(parts, "not created yet: "+strings.Join(creating, ", "))
 		}
+		// The reason names the WORST kind present, so a cluster that is merely still being built
+		// never reports a fault reason. Ordering: a failing workload outranks a missing one, and a
+		// missing one outranks a not-yet-created one.
+		reason := unavailableReason(shortOfReplicas, unreadable)
 		status.SetUnavailable(reason, "Role groups — "+strings.Join(parts, "; "))
 	}
 
@@ -231,6 +246,32 @@ func (h *HealthManager) Check(ctx context.Context, namespace, clusterName string
 	status.SetDegraded(degraded, degradedReason, degradedMessage)
 
 	return nil
+}
+
+// unavailableReason names the WORST kind of unavailability present, so a cluster that is merely
+// still being built never reports a fault reason. A failing workload outranks a missing one, and a
+// missing one outranks a not-yet-created one.
+func unavailableReason(shortOfReplicas, unreadable []string) string {
+	switch {
+	case len(shortOfReplicas) > 0:
+		return v1alpha1.ReasonPodsNotReady
+	case len(unreadable) > 0:
+		return v1alpha1.ReasonWorkloadUnreadable
+	default:
+		return v1alpha1.ReasonCreating
+	}
+}
+
+// inLedger reports whether status.roleGroups records this role group as one the framework has
+// already applied. It is the only evidence available for telling "not created yet" apart from
+// "created, then lost", and it is written by the apply path after a successful pass.
+func inLedger(status *v1alpha1.GenericClusterStatus, roleName, groupName string) bool {
+	for _, recorded := range status.GetRoleGroups()[roleName] {
+		if recorded == groupName {
+			return true
+		}
+	}
+	return false
 }
 
 // checkRoleGroupHealth reports whether a role group has at least as many ready replicas as the spec

--- a/pkg/reconciler/health_test.go
+++ b/pkg/reconciler/health_test.go
@@ -472,16 +472,44 @@ var _ = Describe("HealthManager role group aggregation", func() {
 		hm := reconciler.NewHealthManager(k8sClient)
 		Expect(hm.Check(ctx, namespace, "health-missing-sts", spec, status)).To(Succeed())
 
-		// A StatefulSet that does not exist yet has no available replicas: claiming
-		// Available=True next to Degraded=True would misreport the cluster as usable.
+		// A StatefulSet that does not exist has no available replicas either way: claiming
+		// Available=True would misreport the cluster as usable.
 		available := status.GetCondition(v1alpha1.ConditionAvailable)
 		Expect(available).NotTo(BeNil())
 		Expect(available.Status).To(Equal(metav1.ConditionFalse))
+		// The message names the offender instead of a generic "some replicas are unhealthy".
+		Expect(available.Message).To(ContainSubstring("missing-role/default"))
+
+		// NOT Degraded: status.roleGroups does not record this group, so the framework has not
+		// applied its StatefulSet yet — a first install, or a build still waiting on something
+		// external. Reporting that as a fault is what made a normal first install page.
+		degraded := status.GetCondition(v1alpha1.ConditionDegraded)
+		Expect(degraded).NotTo(BeNil())
+		Expect(degraded.Status).To(Equal(metav1.ConditionFalse))
+		Expect(available.Reason).To(Equal(v1alpha1.ReasonCreating))
+	})
+
+	It("reports Degraded when a role group it ALREADY APPLIED has lost its StatefulSet", func() {
+		// The other side of the same distinction, and the guarantee that must survive: an object
+		// the framework put there and that has since gone is a real fault no pod state reveals.
+		spec := &v1alpha1.GenericClusterSpec{
+			Roles: map[string]v1alpha1.RoleSpec{
+				"missing-role": {
+					RoleGroups: map[string]v1alpha1.RoleGroupSpec{
+						"default": {Replicas: ptr.To(int32(3))},
+					},
+				},
+			},
+		}
+		status.SetRoleGroup("missing-role", "default")
+
+		hm := reconciler.NewHealthManager(k8sClient)
+		Expect(hm.Check(ctx, namespace, "health-missing-sts", spec, status)).To(Succeed())
 
 		degraded := status.GetCondition(v1alpha1.ConditionDegraded)
 		Expect(degraded).NotTo(BeNil())
 		Expect(degraded.Status).To(Equal(metav1.ConditionTrue))
-		// The message names the offender instead of a generic "some replicas are unhealthy".
+		Expect(degraded.Reason).To(Equal(v1alpha1.ReasonWorkloadUnreadable))
 		Expect(degraded.Message).To(ContainSubstring("missing-role/default"))
 	})
 
@@ -611,9 +639,13 @@ var _ = Describe("Degraded is a fault signal, not a progress signal", func() {
 		return status
 	}
 
-	// check runs a single pass over a fresh status.
+	// check runs a single pass over a fresh status that already RECORDS the role group as applied.
+	// That is what these specs mean by an unreadable StatefulSet — one the framework put there and
+	// that has since gone — as distinct from one it has not created yet, which is Creating.
 	check := func(cluster string, specReplicas int32, op *v1alpha1.ClusterOperationSpec) *v1alpha1.GenericClusterStatus {
-		return checkInto(&v1alpha1.GenericClusterStatus{}, cluster, specReplicas, op)
+		status := &v1alpha1.GenericClusterStatus{}
+		status.SetRoleGroup("worker", "default")
+		return checkInto(status, cluster, specReplicas, op)
 	}
 
 	newCluster := func() string {
@@ -828,8 +860,9 @@ var _ = Describe("Degraded is a fault signal, not a progress signal", func() {
 	})
 
 	It("still reports Degraded when a role group's StatefulSet is missing entirely", func() {
-		// Nothing to read means the object the operator applied is gone: a real fault, and one that
-		// no pod state would reveal.
+		// Nothing to read for a role group the framework RECORDED as applied means the object it
+		// applied is gone: a real fault, and one that no pod state would reveal. The ledger is what
+		// distinguishes it from a role group that was never created (see the sibling spec below).
 		status := check(newCluster(), 1, nil)
 		Expect(status.IsDegraded()).To(BeTrue())
 		Expect(status.GetCondition(v1alpha1.ConditionDegraded).Reason).
@@ -854,6 +887,11 @@ var _ = Describe("Available names the right kind of problem", func() {
 
 	check := func(cluster string, groups map[string]v1alpha1.RoleGroupSpec) *v1alpha1.GenericClusterStatus {
 		status := &v1alpha1.GenericClusterStatus{}
+		// Recorded as applied: these specs are about a StatefulSet that vanished, not one that was
+		// never created (see "a role group the framework has not created yet").
+		for groupName := range groups {
+			status.SetRoleGroup("worker", groupName)
+		}
 		Expect(reconciler.NewHealthManager(k8sClient).Check(ctx, ns, cluster,
 			&v1alpha1.GenericClusterSpec{Roles: map[string]v1alpha1.RoleSpec{
 				"worker": {RoleGroups: groups},

--- a/pkg/reconciler/waiting_test.go
+++ b/pkg/reconciler/waiting_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/zncdatadev/operator-go/pkg/common"
 	"github.com/zncdatadev/operator-go/pkg/reconciler"
 	"github.com/zncdatadev/operator-go/pkg/testutil"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -65,10 +67,14 @@ var _ = Describe("An extension that is waiting", func() {
 		Expect(k8sClient.Create(ctx, cr)).To(Succeed())
 		DeferCleanup(func() {
 			_ = k8sClient.Delete(ctx, cr)
+			// envtest runs no garbage collector, so owner references reclaim nothing: every object
+			// a spec creates has to be deleted by name or it leaks into the next one.
 			base := reconciler.RoleGroupResourceName(name, "worker", "default")
 			for _, n := range []string{base, base + "-headless"} {
-				_ = k8sClient.Delete(ctx, &metav1.PartialObjectMetadata{})
-				_ = n
+				meta := metav1.ObjectMeta{Name: n, Namespace: testNamespace}
+				_ = k8sClient.Delete(ctx, &corev1.ConfigMap{ObjectMeta: meta})
+				_ = k8sClient.Delete(ctx, &corev1.Service{ObjectMeta: meta})
+				_ = k8sClient.Delete(ctx, &appsv1.StatefulSet{ObjectMeta: meta})
 			}
 		})
 		return cr
@@ -159,6 +165,32 @@ var _ = Describe("An extension that is waiting", func() {
 		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: cr.Name}, fetched)).To(Succeed())
 		Expect(fetched.Status.IsDegraded()).To(BeFalse(),
 			"health ran on the waiting pass, so the healed fault was cleared instead of latching")
+	})
+
+	It("blocks the roles while a cluster-level hook waits, but still observes", func() {
+		// #608's case is a schema migration that must finish BEFORE any workload starts; applying
+		// the StatefulSets anyway would run the product against an uninitialised database.
+		crName := uniqueCRName("waiting-blocks")
+		cr := newCR(crName)
+		resourceName := reconciler.RoleGroupResourceName(cr.Name, "worker", "default")
+
+		_, err := reconcileWith(cr.Name, &waitingExtension{
+			name: "db-init",
+			pre: func() error {
+				return common.NewRequeueAfterError(20*time.Second, "WaitingForDBInit", "migration Job has not completed")
+			},
+		}, record.NewFakeRecorder(100))
+		Expect(err).NotTo(HaveOccurred())
+
+		sts := &appsv1.StatefulSet{}
+		getErr := k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: resourceName}, sts)
+		Expect(getErr).To(HaveOccurred(), "no workload may be applied while a cluster-level hook is waiting")
+
+		// But the pass still ran to the end: health observed the cluster rather than freezing it.
+		fetched := &testutil.MockCluster{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: cr.Name}, fetched)).To(Succeed())
+		Expect(fetched.Status.GetCondition(v1alpha1.ConditionAvailable)).NotTo(BeNil(),
+			"health still ran, so Available reflects this pass rather than a stale one")
 	})
 
 	It("clears the Waiting condition once nothing is waiting", func() {

--- a/pkg/reconciler/waiting_test.go
+++ b/pkg/reconciler/waiting_test.go
@@ -1,0 +1,222 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler_test
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/zncdatadev/operator-go/pkg/apis/commons/v1alpha1"
+	"github.com/zncdatadev/operator-go/pkg/common"
+	"github.com/zncdatadev/operator-go/pkg/reconciler"
+	"github.com/zncdatadev/operator-go/pkg/testutil"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// waitingExtension returns whatever its hook func returns; nil means "nothing to wait for".
+type waitingExtension struct {
+	name string
+	pre  func() error
+}
+
+func (e *waitingExtension) Name() string { return e.name }
+func (e *waitingExtension) PreReconcile(context.Context, client.Client, *testutil.MockCluster) error {
+	if e.pre == nil {
+		return nil
+	}
+	return e.pre()
+}
+func (e *waitingExtension) PostReconcile(context.Context, client.Client, *testutil.MockCluster) error {
+	return nil
+}
+func (e *waitingExtension) OnReconcileError(context.Context, client.Client, *testutil.MockCluster, error) error {
+	return nil
+}
+
+var _ = Describe("An extension that is waiting", func() {
+	var ctx context.Context
+
+	BeforeEach(func() { ctx = context.Background() })
+
+	newCR := func(name string) *testutil.MockCluster {
+		cr := testutil.NewMockCluster(name, testNamespace).
+			WithRoles(map[string]v1alpha1.RoleSpec{"worker": defaultGroupRole()})
+		Expect(k8sClient.Create(ctx, cr)).To(Succeed())
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(ctx, cr)
+			base := reconciler.RoleGroupResourceName(name, "worker", "default")
+			for _, n := range []string{base, base + "-headless"} {
+				_ = k8sClient.Delete(ctx, &metav1.PartialObjectMetadata{})
+				_ = n
+			}
+		})
+		return cr
+	}
+
+	reconcileWith := func(crName string, ext *waitingExtension, rec record.EventRecorder) (ctrl.Result, error) {
+		registry := common.NewExtensionRegistry[*testutil.MockCluster]()
+		registry.RegisterClusterExtension(ext)
+		r, err := reconciler.NewGenericReconciler(&reconciler.GenericReconcilerConfig[*testutil.MockCluster]{
+			Client:            k8sClient,
+			Scheme:            testScheme,
+			Recorder:          rec,
+			RoleGroupHandler:  testutil.NewMockRoleGroupHandler(),
+			ExtensionRegistry: registry,
+			Prototype:         testutil.NewMockCluster("proto", testNamespace),
+		})
+		Expect(err).NotTo(HaveOccurred())
+		return r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Namespace: testNamespace, Name: crName}})
+	}
+
+	It("is not a failure: no Degraded, no Warning event, and it requeues on its own delay", func() {
+		// The whole complaint in #608: a cluster that is merely waiting for a database migration
+		// pages, because the only channel a hook had was an error.
+		crName := uniqueCRName("waiting-basic")
+		cr := newCR(crName)
+		fakeRecorder := record.NewFakeRecorder(100)
+
+		result, err := reconcileWith(cr.Name, &waitingExtension{
+			name: "db-init",
+			pre: func() error {
+				return common.NewRequeueAfterError(15*time.Second, "WaitingForDBInit", "database migration Job has not completed")
+			},
+		}, fakeRecorder)
+
+		Expect(err).NotTo(HaveOccurred(), "a wait must not be returned as an error")
+		Expect(result.RequeueAfter).To(Equal(15 * time.Second))
+
+		fetched := &testutil.MockCluster{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: cr.Name}, fetched)).To(Succeed())
+		Expect(fetched.Status.IsDegraded()).To(BeFalse())
+
+		waiting := fetched.Status.GetCondition(reconciler.ConditionWaiting)
+		Expect(waiting).NotTo(BeNil(), "the wait has to be visible somewhere")
+		Expect(waiting.Status).To(Equal(metav1.ConditionTrue))
+		Expect(waiting.Reason).To(Equal("WaitingForDBInit"))
+		Expect(waiting.Message).To(ContainSubstring("database migration Job"))
+
+		// The documented generation gate must not report a spec edit as applied while the
+		// framework is still waiting to apply it.
+		complete := fetched.Status.GetCondition(v1alpha1.ConditionReconcileComplete)
+		Expect(complete).NotTo(BeNil())
+		Expect(complete.Status).To(Equal(metav1.ConditionFalse))
+		Expect(complete.Reason).To(Equal(reconciler.ReasonWaiting))
+
+		Expect(drainRecorder(fakeRecorder)).NotTo(ContainElement(ContainSubstring("ReconcileError")))
+	})
+
+	It("still runs health, so Degraded cannot latch at a fault that has healed", func() {
+		// The reason the wait is reported at the END of the pass rather than by returning where it
+		// was raised. SetDegraded(false, ...) has exactly one writer — HealthManager.Check — so an
+		// early return leaves Degraded frozen at whatever the last completed pass wrote. A cluster
+		// whose pods recovered while an extension waits would keep paging with a message naming a
+		// pod that no longer exists, and observedGeneration would match, so no staleness heuristic
+		// catches it.
+		crName := uniqueCRName("waiting-latch")
+		cr := newCR(crName)
+
+		// Pass 1: a real failure sets Degraded.
+		_, err := reconcileWith(cr.Name, &waitingExtension{
+			name: "boom",
+			pre:  func() error { return errors.New("catalog backend is unreachable") },
+		}, record.NewFakeRecorder(100))
+		Expect(err).To(HaveOccurred())
+
+		fetched := &testutil.MockCluster{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: cr.Name}, fetched)).To(Succeed())
+		Expect(fetched.Status.IsDegraded()).To(BeTrue(), "precondition: the cluster is degraded")
+
+		// Pass 2: the failure is gone and the extension is merely waiting.
+		_, err = reconcileWith(cr.Name, &waitingExtension{
+			name: "boom",
+			pre: func() error {
+				return common.NewRequeueAfterError(30*time.Second, "WaitingForCatalog", "catalog is initialising")
+			},
+		}, record.NewFakeRecorder(100))
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: cr.Name}, fetched)).To(Succeed())
+		Expect(fetched.Status.IsDegraded()).To(BeFalse(),
+			"health ran on the waiting pass, so the healed fault was cleared instead of latching")
+	})
+
+	It("clears the Waiting condition once nothing is waiting", func() {
+		crName := uniqueCRName("waiting-cleared")
+		cr := newCR(crName)
+
+		_, err := reconcileWith(cr.Name, &waitingExtension{
+			name: "gate",
+			pre: func() error {
+				return common.NewRequeueAfterError(time.Minute, "WaitingForPeer", "peer cluster is not ready")
+			},
+		}, record.NewFakeRecorder(100))
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = reconcileWith(cr.Name, &waitingExtension{name: "gate"}, record.NewFakeRecorder(100))
+		Expect(err).NotTo(HaveOccurred())
+
+		fetched := &testutil.MockCluster{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: cr.Name}, fetched)).To(Succeed())
+		waiting := fetched.Status.GetCondition(reconciler.ConditionWaiting)
+		Expect(waiting).NotTo(BeNil())
+		Expect(waiting.Status).To(Equal(metav1.ConditionFalse))
+		Expect(fetched.Status.GetCondition(v1alpha1.ConditionReconcileComplete).Status).
+			To(Equal(metav1.ConditionTrue))
+	})
+
+	It("never raises the condition for a product that does not wait", func() {
+		// The same rule ConditionOrphanCleanupPending follows: only clear what was raised, so a
+		// product that never waits carries no extra condition at all.
+		crName := uniqueCRName("waiting-none")
+		cr := newCR(crName)
+
+		_, err := reconcileWith(cr.Name, &waitingExtension{name: "quiet"}, record.NewFakeRecorder(100))
+		Expect(err).NotTo(HaveOccurred())
+
+		fetched := &testutil.MockCluster{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: cr.Name}, fetched)).To(Succeed())
+		Expect(fetched.Status.GetCondition(reconciler.ConditionWaiting)).To(BeNil())
+	})
+
+	It("still fails the cluster when a genuine error accompanies the wait", func() {
+		// A wait must never launder a real failure. The hook returns both, joined.
+		crName := uniqueCRName("waiting-mixed")
+		cr := newCR(crName)
+
+		_, err := reconcileWith(cr.Name, &waitingExtension{
+			name: "mixed",
+			pre: func() error {
+				return errors.Join(
+					common.NewRequeueAfterError(time.Minute, "WaitingForPeer", "peer is not ready"),
+					errors.New("catalog config is invalid"),
+				)
+			},
+		}, record.NewFakeRecorder(100))
+		Expect(err).To(HaveOccurred(), "a real failure in the aggregate outranks the wait")
+
+		fetched := &testutil.MockCluster{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: cr.Name}, fetched)).To(Succeed())
+		Expect(fetched.Status.IsDegraded()).To(BeTrue())
+	})
+})


### PR DESCRIPTION
Closes #608.

A `ClusterExtension` blocking on something outside the operator's control could only return an error, which `Reconcile` turned into `Degraded=True` + `ReconcileComplete=False` + a Warning event + backoff to a 1000s cap. Operators alert on `Degraded`, so **a normal first install pages**.

```go
return common.NewRequeueAfterError(15*time.Second, "WaitingForDBInit", "migration Job has not completed")
```

No `Degraded`, no Warning event, no backoff; a `Waiting` condition carries the reason and message, and `ReconcileComplete` goes False with reason `Waiting`.

## The issue's proposal had a hole, and three more turned up under measurement

It asked for the branch to sit "next to the `RateLimitError` branch, plus `SetProgressing(...)` so the wait is visible". That branch **returns before `updateStatus`** (`generic_reconciler.go:459` vs `:473`) — so the `SetProgressing` would never have been persisted and the promise would be inert. The other three came out of an adversarial pass that ran the real reconciler against envtest:

| decision | what measurement showed |
|---|---|
| report the wait **at the end of the pass**, not where it was raised | `SetDegraded(false, …)` has exactly **one** writer, `HealthManager.Check`. An early return leaves `Degraded` **latched**: measured, a cluster whose pod recovered kept `Degraded=True reason=PodFailure` naming a deleted pod across every waiting pass, with `observedGeneration` matching so nothing looks stale. The framework already diagnosed this on the `reconciliationPaused` gate and fixed it the same way — observe, then return. |
| its **own** condition, not `Progressing` | `Progressing` is owned by health and written every pass; a second writer flips it intra-pass and re-stamps `lastTransitionTime`, so the CR is rewritten forever (measured rv 221→222→223→224). A dedicated condition also makes `lastTransitionTime` mean "waiting since", so "waiting > 30m" is alertable. `ConditionOrphanCleanupPending` is the same shape. |
| `ReconcileComplete=False` | leaving it True next to the bumped `observedGeneration` makes the SDK's own documented generation gate report a user's edit as **applied** while it is still waiting to apply it. |
| the type goes in **`pkg/common`** | the first intermediate a hook's error passes is `pkg/common`'s `executeHooks`, which logged it at **ERROR** every pass (the other channel that pages) and, under the default `stopOnError`, **aborted every lower-priority sibling** — precondition-failure semantics for a non-failure. Teaching it the type from `pkg/reconciler` is an import cycle. |

## A wait is never merged with a failure

`common.WaitingErrors` walks the error tree and reports a wait only when **every leaf** is one, taking the **shortest** delay. The framework joins per-role and per-extension errors, so a tree can hold a wait beside a genuine failure — `errors.As` would find the wait and launder the failure into one, and would return the first delay depth-first, letting a 10-minute wait hide a 5-second one.

My own first implementation had exactly that bug (an `errors.As` fast path). The spec caught it.

The delay is also **clamped**: controller-runtime treats `RequeueAfter` as a switch, so a non-positive value never requeues at all — `deadline.Sub(time.Now())` would wedge the cluster permanently once the deadline passed.

## The other reason a first install pages

Independent of any of the above: health reported a role group whose StatefulSet has **never existed** as `WorkloadUnreadable` → `Degraded=True`. "Never applied" and "applied, then vanished" are different facts, and `status.roleGroups` already distinguishes them. An absent group is now `Available=False`/`Creating`; a group **in** the ledger whose StatefulSet has gone is still a fault.

That guarantee is what the existing specs meant — their fixtures never recorded the group as applied, so they now say so explicitly, and one spec that demanded `Degraded=True` for a StatefulSet that "does not exist **yet**" is split into the two cases it was conflating.

## Verification

Gates green in both modules, plus five mutations:

| mutation | result |
|---|---|
| `WaitingErrors` uses `errors.As` (launders a mixed aggregate) | ✗ |
| take the first delay in a join, not the shortest | ✗ |
| no clamping (a zero delay never requeues) | ✗ |
| return the wait early, before health (restores the Degraded latch) | ✗ |
| a never-created role group is Degraded again | ✗ |

Per #621, no `CHANGELOG.md` entry — the user-visible description is in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)