### PR TITLE
feat(authentication): make "exactly one provider" enforceable, and readable the same way everywhere

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1276,9 +1276,14 @@ All AI agents and developers working on this project **must** follow these rules
 - If adding new public interfaces, update AGENTS.md accordingly
 
 ### CHANGELOG.md
-**Do NOT edit `CHANGELOG.md` in a pull request.** The entries under a version heading are generated
-**at release time from the commit history**, not written by hand per PR. The unreleased section
-therefore stays empty between releases, and the release process fills it in.
+**Do NOT edit `CHANGELOG.md` in a pull request.** The entries under a version heading are written
+**at release time from the commit history**, not per PR. The unreleased section therefore stays
+empty between releases, and the release fills it in.
+
+There is no generator: a maintainer reads the commits since the last tag and writes the section by
+hand. That is worth saying plainly, because the wording this replaced ("generated at release time")
+described a tool that does not exist and pointed at a release procedure that was never written —
+`.github/workflows/` holds only lint and test, and `hack/` holds only the boilerplate header.
 
 What this means in practice:
 - A PR carries its user-visible description in its **commit message**, which is the input the
@@ -1288,8 +1293,8 @@ What this means in practice:
 - Behavioral and API documentation belongs in `AGENTS.md` (what exists today) and
   `docs/architecture.md` (design intent) — those **are** part of the PR. Hand-maintaining the same
   prose in three places is what made the changelog drift.
-- Only the release itself touches `CHANGELOG.md`: see the release procedure for tagging and version
-  bumps.
+- Only the release itself touches `CHANGELOG.md`. Tagging and the version bump are not documented
+  anywhere yet — see #399.
 
 ### Code Style & Conventions
 - **Formatting**: Must pass `go fmt`

--- a/pkg/apis/authentication/v1alpha1/authentication_types.go
+++ b/pkg/apis/authentication/v1alpha1/authentication_types.go
@@ -28,6 +28,23 @@ type AuthenticationClassSpec struct {
 	AuthenticationProvider *AuthenticationProvider `json:"provider"`
 }
 
+// AuthenticationProvider names EXACTLY ONE authentication method. A deployment offering several
+// methods declares several AuthenticationClasses; it does not put several providers in one.
+//
+// The rule is enforced at admission by CEL (ExactlyOneOf desugars to x-kubernetes-validations)
+// because nothing else can enforce it: AuthenticationClass has no controller in any repo, so this
+// object is only ever read at build time by whichever product operator references it. Before the
+// rule, the CRD accepted both zero providers and several, and the five operators that read it had
+// five different readings — first-match with the remaining providers silently unhandled, or, in one
+// case, BOTH an OIDC and an LDAP block concatenated into the same generated config file where the
+// second assignment silently won. An empty provider was worse than ambiguous: it failed OPEN, with
+// the product's authenticator skipped and its UI served unauthenticated, logged at V(5).
+//
+// The marker only stops NEW bad objects, and only once the regenerated CRD is applied. Use
+// ResolveProvider to read one: it gives every operator the same answer on every cluster, including
+// for objects stored before the rule existed.
+//
+// +kubebuilder:validation:ExactlyOneOf=oidc;tls;static;ldap;kerberos
 type AuthenticationProvider struct {
 	// +kubebuilder:validation:Optional
 	OIDC *OIDCProvider `json:"oidc,omitempty"`

--- a/pkg/apis/authentication/v1alpha1/provider.go
+++ b/pkg/apis/authentication/v1alpha1/provider.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ProviderKind names which authentication method an AuthenticationProvider selected.
+type ProviderKind string
+
+const (
+	ProviderKindOIDC     ProviderKind = "oidc"
+	ProviderKindTLS      ProviderKind = "tls"
+	ProviderKindStatic   ProviderKind = "static"
+	ProviderKindLDAP     ProviderKind = "ldap"
+	ProviderKindKerberos ProviderKind = "kerberos"
+)
+
+// ResolveProvider reports which single authentication method a provider selected, and fails when
+// the answer is not exactly one.
+//
+// It exists because the CEL rule on AuthenticationProvider cannot reach objects that already exist:
+// it rejects new writes, but an AuthenticationClass stored before the rule shipped — or on a cluster
+// whose CRD has not been upgraded — is read exactly as it was. This function gives every operator
+// the same answer everywhere, which is the half that actually fixes the defect.
+//
+// The defect being fixed is divergence, not a missing feature. Five operators read this one object
+// five different ways: first-match `if/else` chains whose remaining providers fall through
+// silently, and one that concatenated an OIDC block and an LDAP block into the same generated
+// config file, where both assigned the same key and the second silently won. Reading it through one
+// function makes an ambiguous object an ERROR at the point of use rather than a coin toss.
+//
+// Zero providers is an error for the same reason and a sharper one: it used to fail OPEN. A product
+// that treated "no provider" as "no authenticator" served its UI unauthenticated, and the only
+// trace was a log line at V(5). "The user asked for authentication and named no method" is a
+// mistake, not a request for none.
+func ResolveProvider(provider *AuthenticationProvider) (ProviderKind, error) {
+	if provider == nil {
+		return "", fmt.Errorf("authentication provider is not set: exactly one of %s is required",
+			strings.Join(providerFieldNames(), ", "))
+	}
+
+	var found []ProviderKind
+	if provider.OIDC != nil {
+		found = append(found, ProviderKindOIDC)
+	}
+	if provider.TLS != nil {
+		found = append(found, ProviderKindTLS)
+	}
+	if provider.Static != nil {
+		found = append(found, ProviderKindStatic)
+	}
+	if provider.LDAP != nil {
+		found = append(found, ProviderKindLDAP)
+	}
+	if provider.Kerberos != nil {
+		found = append(found, ProviderKindKerberos)
+	}
+
+	switch len(found) {
+	case 1:
+		return found[0], nil
+	case 0:
+		return "", fmt.Errorf("authentication provider names no method: set exactly one of %s",
+			strings.Join(providerFieldNames(), ", "))
+	default:
+		// Naming all of them matters: the object is usually shared, so whoever has to fix it is
+		// rarely whoever wrote it, and the fix is to split it into one AuthenticationClass per
+		// method rather than to pick a winner here.
+		names := make([]string, 0, len(found))
+		for _, kind := range found {
+			names = append(names, string(kind))
+		}
+		return "", fmt.Errorf("authentication provider names %d methods (%s): exactly one is "+
+			"allowed — declare one AuthenticationClass per method instead",
+			len(found), strings.Join(names, ", "))
+	}
+}
+
+// providerFieldNames lists the provider fields in declaration order, for error messages.
+func providerFieldNames() []string {
+	return []string{
+		string(ProviderKindOIDC),
+		string(ProviderKindTLS),
+		string(ProviderKindStatic),
+		string(ProviderKindLDAP),
+		string(ProviderKindKerberos),
+	}
+}

--- a/pkg/apis/authentication/v1alpha1/provider_test.go
+++ b/pkg/apis/authentication/v1alpha1/provider_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/zncdatadev/operator-go/pkg/apis/authentication/v1alpha1"
+)
+
+var _ = Describe("ResolveProvider", func() {
+	It("names the single method that is set", func() {
+		kind, err := v1alpha1.ResolveProvider(&v1alpha1.AuthenticationProvider{
+			OIDC: &v1alpha1.OIDCProvider{},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kind).To(Equal(v1alpha1.ProviderKindOIDC))
+
+		kind, err = v1alpha1.ResolveProvider(&v1alpha1.AuthenticationProvider{
+			Kerberos: &v1alpha1.KerberosProvider{},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(kind).To(Equal(v1alpha1.ProviderKindKerberos))
+	})
+
+	It("refuses an empty provider rather than failing open", func() {
+		// The sharp case. `provider: {}` passes the CRD's Required check on the field itself, and a
+		// product treating "no provider" as "no authenticator" served its UI unauthenticated with
+		// nothing but a V(5) log line to say so.
+		_, err := v1alpha1.ResolveProvider(&v1alpha1.AuthenticationProvider{})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("names no method"))
+		// The message lists what to set, because the reader is usually not the author.
+		Expect(err.Error()).To(ContainSubstring("oidc"))
+		Expect(err.Error()).To(ContainSubstring("kerberos"))
+	})
+
+	It("refuses two methods instead of picking one", func() {
+		// Five operators picked differently — first-match by declaration order, or, in one case,
+		// emitting BOTH config blocks so the later assignment silently won. An error at the point of
+		// use is the only answer that is the same everywhere.
+		_, err := v1alpha1.ResolveProvider(&v1alpha1.AuthenticationProvider{
+			OIDC: &v1alpha1.OIDCProvider{},
+			LDAP: &v1alpha1.LDAPProvider{},
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("names 2 methods"))
+		Expect(err.Error()).To(ContainSubstring("oidc"))
+		Expect(err.Error()).To(ContainSubstring("ldap"))
+		// The fix is to split the object, not to choose a winner.
+		Expect(err.Error()).To(ContainSubstring("one AuthenticationClass per method"))
+	})
+
+	It("treats a nil provider as unset rather than panicking", func() {
+		// AuthenticationClassSpec.AuthenticationProvider is a pointer, so a CR stored before the
+		// field was Required — or one built in Go — reaches this as nil.
+		_, err := v1alpha1.ResolveProvider(nil)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("not set"))
+	})
+})

--- a/pkg/apis/authentication/v1alpha1/suite_test.go
+++ b/pkg/apis/authentication/v1alpha1/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2024 ZNCDataDev.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1alpha1_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAuthenticationAPI(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Authentication API Suite")
+}


### PR DESCRIPTION
Triage of the three issues that had been open longest (#139 from 2024-09, #340 from 2025-04, #399 from 2025-11). Closes #340; #139 and #399 get code plus a precise account of what remains.

**#139 was filed as an API-ergonomics request and is actually a fail-open.**

`AuthenticationProvider` declares five optional pointers and constrains nothing. The shipped CRD accepts `provider: {}` **and** accepts two providers at once (verified against the real CRD in envtest), and `AuthenticationClass` has **no controller in any repo** — so the object is only read at build time by whichever product operator references it, and nothing ever tells a user their object is ambiguous.

| operator | how it reads the same object |
|---|---|
| trino | first-match `if/else` (OIDC > Static > LDAP); TLS and Kerberos fall through to `return "", nil` |
| superset | appends **both** the OIDC and the LDAP block into `superset_config.py`; both assign `AUTH_TYPE`, Python last-wins, LDAP silently selected while the `OAUTH_PROVIDERS` block stays in the file |
| doris / hbase / hdfs | each reads exactly one field, ignores the rest |

And `provider: {}` fails **open**: trino returns a nil authenticator, hbase/hdfs skip the oauth2-proxy container entirely, so the UI serves unauthenticated — logged at `V(5)`.

## Two halves, because neither is sufficient alone

**`+kubebuilder:validation:ExactlyOneOf`** stops new bad objects at admission. Verified to generate with this repo's controller-gen v0.19.0 (the version commons-operator pins) and to be enforced by a k8s 1.35 API server: zero, two and five providers rejected; each singleton accepted. #139 asked for a *webhook* because kubebuilder cannot emit `oneOf` — still true (controller-tools#461 is open), but it no longer implies a webhook: CEL says it declaratively, and the org has **no webhook infrastructure at all** (no operator registers a validator, no chart deploys one, every kustomize webhook block is commented scaffolding).

**`ResolveProvider`** is the half that fixes objects that already exist. The marker cannot reach them — it rejects writes, but a class stored before the rule, or on a cluster whose CRD was never upgraded, is read exactly as before. One shared implementation returning an error for zero or 2+ providers is what actually ends the five-way divergence, on every cluster, regardless of CRD version.

## The marker is not free, and this PR is not the whole rollout

On clusters **below k8s 1.30** there is no `CRDValidationRatcheting`, so once the regenerated CRD is applied every stored violating object becomes **write-locked** — even `kubectl label` is rejected (proven on envtest 1.26.1 against the real shipped CRD) — and a GitOps pipeline managing one goes permanently failed-sync.

Even on 1.35 ratcheting is nearly vacuous here: `AuthenticationClassSpec` has exactly one field, so any real edit (rotating an IdP hostname, changing an LDAP bind secretClass) touches `spec.provider` and is refused.

**The org contradicts itself about the floor** — `docs/architecture.md:1365` says "K8s Version: 1.31+", while commons-operator and ten other repos default their e2e kind cluster to **1.26.15**. That has to be settled before commons-operator regenerates the CRD. The marker here is inert until then; details on #139.

## #340 — closed, with the premise corrected

Self-answered question whose stated technical principle is wrong, and was wrong when written: controller-gen has **zero** references to `OpenAPISchemaType`/`OpenAPIV3OneOfTypes` in v0.19.0 *or* v0.17.1 (the version the repo ran in April 2025). `Quantity`'s `anyOf` comes from a hardcoded import-path table in controller-tools — which is why the emitted `[integer, string]` does not match the method's `["string","number"]`. Full answer posted on the issue; no doc section added, because five of the six candidate topics describe markers with **zero occurrences** in this repo and `AGENTS.md`'s own scope rule forbids documenting what does not exist.

## #399 — partially satisfied, one dangling promise fixed here

Bullet (b) (modules + design principles) was delivered four months *after* the issue by `docs/architecture.md` + 8 `AGENTS.md` files. Bullets (a), (c), (e) remain open.

(e) got worse two days ago: #621 added "see the release procedure for tagging and version bumps" to `AGENTS.md` and asserted the changelog is "generated at release time from the commit history" — **no such document and no such generator exist** (`.github/workflows/` holds only lint and test; `hack/` holds only the boilerplate header). That is an aspirational statement in an `AGENTS.md`, which its own scope rule forbids. Corrected here to say what actually happens, pointing at #399 for the rest.

**Separate finding, deliberately not fixed here:** the md-lint CI job globs `README.*.md`, which matches **no file** — so documentation changes are linted by nothing. Widening it surfaces **759** pre-existing violations (412 in `docs/architecture.md` alone), so whether to relax `.markdownlint.yml` or fix them is a house-style call, not something to smuggle into a triage PR. Reported on #399.

## Verification

Gates green in both modules. The CEL marker was proven end-to-end (generated with commons-operator's own controller-gen invocation, installed in envtest, all eight cases exercised); `ResolveProvider` has specs for the single, zero, two and nil cases.

Per #621, no `CHANGELOG.md` entry — the user-visible description is in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)